### PR TITLE
feat(kpm): KpmHandle struct and crate documentation (#25)

### DIFF
--- a/crates/kpm/src/backend.rs
+++ b/crates/kpm/src/backend.rs
@@ -34,19 +34,44 @@
  *
  */
 
+//! Feature-matching backend trait and associated types.
+//!
+//! This module defines [`FreakMatcherBackend`], the pluggable interface
+//! that decouples the KPM pipeline from any specific implementation.
+//! The crate ships one concrete backend —
+//! [`CppFreakMatcher`](crate::CppFreakMatcher) — which delegates to
+//! the compiled C++ FreakMatcher library via FFI. A future pure-Rust
+//! backend can be dropped in by implementing the same trait.
+
 use std::fmt;
 
-// --- Backend-specific types ---
+// ---------------------------------------------------------------------------
+// Backend-specific data types
+// ---------------------------------------------------------------------------
 
+/// A 2D feature point detected in an image.
+///
+/// Holds the pixel position together with the keypoint's orientation
+/// and scale, as computed by the detector (e.g. DoG + orientation
+/// assignment).
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct FeaturePoint {
+    /// Horizontal position in pixels.
     pub x: f32,
+    /// Vertical position in pixels.
     pub y: f32,
+    /// Dominant orientation in radians.
     pub angle: f32,
+    /// Scale (pyramid octave level) at which the keypoint was detected.
     pub scale: f32,
+    /// Whether this keypoint is a scale-space maximum.
     pub maxima: bool,
 }
 
+/// A 3D point in world coordinates (millimetres).
+///
+/// Computed from 2D pixel positions and the reference image's DPI. The
+/// Z coordinate is always `0.0` for planar targets.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Point3d {
     pub x: f32,
@@ -54,26 +79,51 @@ pub struct Point3d {
     pub z: f32,
 }
 
+/// An index pair representing a single feature match.
+///
+/// Links a feature in the query (input) image to a feature in the
+/// reference database.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Match {
+    /// Index into the query feature-point list.
     pub ins: usize,
+    /// Index into the reference feature-point list.
     pub ref_: usize,
 }
 
+/// Lightweight result returned by [`FreakMatcherBackend::query`].
+///
+/// Contains only the matched page ID and inlier count. For the full
+/// pose matrix, see [`KpmResult`](crate::types::KpmResult).
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct QueryResult {
+    /// Page number of the best-matching reference image, or `-1` if no
+    /// match was found.
     pub matched_id: i32,
+    /// Number of RANSAC inliers supporting the match.
     pub inlier_count: usize,
 }
 
-// --- Error type ---
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
 
+/// Errors that can occur during KPM operations.
 #[derive(Debug)]
 pub enum KpmError {
+    /// The internal C++ handle pointer is null (freed or never created).
     NullHandle,
+    /// The caller supplied invalid arguments (e.g. wrong buffer size).
     InvalidInput(String),
+    /// An unrecoverable error inside the backend.
     InternalError(String),
-    NotEnoughPoints { got: usize, need: usize },
+    /// Too few feature points were detected for reliable matching.
+    NotEnoughPoints {
+        /// Number of points actually detected.
+        got: usize,
+        /// Minimum number required by the algorithm.
+        need: usize,
+    },
 }
 
 impl fmt::Display for KpmError {
@@ -91,14 +141,35 @@ impl fmt::Display for KpmError {
 
 impl std::error::Error for KpmError {}
 
-// --- Backend trait ---
+// ---------------------------------------------------------------------------
+// Backend trait
+// ---------------------------------------------------------------------------
 
-/// Abstraction over the feature-matching backend.
+/// Pluggable feature-matching backend for the KPM pipeline.
 ///
-/// This trait mirrors the `VisualDatabaseFacade` C++ API and allows
-/// swapping the C++ FFI backend for a pure-Rust implementation without
-/// changing any calling code.
+/// This trait mirrors the public API of the C++ `VisualDatabaseFacade`
+/// and allows swapping the C++ FFI backend for a pure-Rust
+/// implementation without changing any calling code.
+///
+/// All implementations must be [`Send`] so that a [`KpmHandle`](crate::KpmHandle)
+/// can be moved between threads.
+///
+/// # Implementors
+///
+/// * [`CppFreakMatcher`](crate::CppFreakMatcher) — FFI backend (default,
+///   feature-gated behind `ffi-backend`).
 pub trait FreakMatcherBackend: Send {
+    /// Adds a grayscale reference image to the database.
+    ///
+    /// The backend extracts FREAK features internally, computes 3D world
+    /// coordinates, and stores them under the given `image_id`.
+    ///
+    /// # Arguments
+    ///
+    /// * `image`    — grayscale pixel data (one byte per pixel, row-major).
+    /// * `width`    — image width in pixels.
+    /// * `height`   — image height in pixels.
+    /// * `image_id` — unique identifier for this reference image.
     fn add_image(
         &mut self,
         image: &[u8],
@@ -107,6 +178,20 @@ pub trait FreakMatcherBackend: Send {
         image_id: usize,
     ) -> Result<(), KpmError>;
 
+    /// Adds pre-extracted FREAK features and descriptors to the database.
+    ///
+    /// Use this when features have already been computed externally
+    /// (e.g. loaded from a serialised file). The C++ FFI backend does
+    /// **not** support this path and returns `Ok(())` as a no-op.
+    ///
+    /// # Arguments
+    ///
+    /// * `points`      — 2D feature-point positions.
+    /// * `descriptors` — packed binary FREAK descriptors (96 bytes each).
+    /// * `points_3d`   — corresponding 3D world coordinates.
+    /// * `width`       — reference image width.
+    /// * `height`      — reference image height.
+    /// * `db_id`       — database slot identifier.
     fn add_freak_features(
         &mut self,
         points: &[FeaturePoint],
@@ -117,15 +202,37 @@ pub trait FreakMatcherBackend: Send {
         db_id: usize,
     ) -> Result<(), KpmError>;
 
+    /// Runs a query against the database using a grayscale camera frame.
+    ///
+    /// Returns a [`QueryResult`] with the best-matching page ID and
+    /// inlier count. A `matched_id` of `-1` indicates no match.
+    ///
+    /// # Arguments
+    ///
+    /// * `image`  — grayscale pixel data of the camera frame.
+    /// * `width`  — frame width in pixels.
+    /// * `height` — frame height in pixels.
     fn query(&mut self, image: &[u8], width: usize, height: usize)
         -> Result<QueryResult, KpmError>;
 
+    /// Returns the inlier matches from the most recent query.
+    ///
+    /// Each [`Match`] links a query feature index to a reference feature
+    /// index. Returns an empty slice if the backend does not expose
+    /// inlier data (e.g. the C++ FFI backend).
     fn inliers(&self) -> &[Match];
 
+    /// Returns the page ID of the last successful match, or `-1`.
     fn matched_id(&self) -> i32;
 
+    /// Returns the 2D feature points detected in the most recent query frame.
+    ///
+    /// Returns an empty slice if not available.
     fn query_feature_points(&self) -> &[FeaturePoint];
 
+    /// Returns the 3D feature points for the given reference image.
+    ///
+    /// Returns an empty slice if not available.
     fn get_3d_feature_points(&self, image_id: usize) -> &[Point3d];
 }
 

--- a/crates/kpm/src/cpp_backend.rs
+++ b/crates/kpm/src/cpp_backend.rs
@@ -34,12 +34,47 @@
  *
  */
 
+//! C++ FFI backend for the KPM pipeline.
+//!
+//! [`CppFreakMatcher`] implements [`FreakMatcherBackend`] by delegating
+//! to the compiled FreakMatcher C++ static library through the thin
+//! `extern "C"` wrapper defined in `kpm_c_api.h` / `kpm_c_api.cpp`.
+//!
+//! This module is only compiled when the **`ffi-backend`** feature is
+//! enabled (the default).
+//!
+//! # Safety
+//!
+//! All FFI calls are guarded by a null-pointer check on the internal
+//! [`KpmOpaqueHandle`](crate::kpm_ffi::KpmOpaqueHandle) pointer, and
+//! every `unsafe` block carries a `// SAFETY:` comment explaining why
+//! the call is sound.
+
 use crate::backend::{FeaturePoint, FreakMatcherBackend, KpmError, Match, Point3d, QueryResult};
 use crate::kpm_ffi;
 
-/// C++ FFI backend implementing `FreakMatcherBackend` by delegating to the
-/// compiled FreakMatcher static library through `kpm_c_api.h` bindings.
+/// C++ FFI backend implementing [`FreakMatcherBackend`].
+///
+/// Wraps an opaque `KpmOpaqueHandle` pointer allocated on the C++ side.
+/// The handle is freed automatically when the struct is dropped.
+///
+/// # Thread safety
+///
+/// The struct implements [`Send`] because the C++ handle is not shared;
+/// ownership is transferred with the Rust struct. All trait methods take
+/// `&mut self`, preventing concurrent access.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use webarkitlib_kpm::CppFreakMatcher;
+///
+/// let matcher = CppFreakMatcher::new(640, 480).expect("failed to create backend");
+/// // Use `matcher` through the `FreakMatcherBackend` trait…
+/// // Automatically freed on drop.
+/// ```
 pub struct CppFreakMatcher {
+    /// Raw pointer to the C++ `KpmOpaqueHandle`.
     ptr: *mut kpm_ffi::KpmOpaqueHandle,
 }
 
@@ -62,6 +97,16 @@ impl Drop for CppFreakMatcher {
 unsafe impl Send for CppFreakMatcher {}
 
 impl CppFreakMatcher {
+    /// Creates a new C++ FreakMatcher backend for the given frame size.
+    ///
+    /// # Arguments
+    ///
+    /// * `xsize` — expected camera frame width in pixels.
+    /// * `ysize` — expected camera frame height in pixels.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KpmError::NullHandle`] if the C++ allocation fails.
     pub fn new(xsize: i32, ysize: i32) -> Result<Self, KpmError> {
         // SAFETY: `kpm_create` allocates a new handle on the C++ side.
         // It returns null only on allocation failure.
@@ -123,6 +168,11 @@ impl FreakMatcherBackend for CppFreakMatcher {
         }
     }
 
+    /// No-op for the C++ backend.
+    ///
+    /// The C API wrapper handles feature extraction internally inside
+    /// `kpm_add_ref_image`, so pre-extracted features cannot be injected
+    /// through the FFI.
     fn add_freak_features(
         &mut self,
         _points: &[FeaturePoint],
@@ -133,9 +183,6 @@ impl FreakMatcherBackend for CppFreakMatcher {
         _db_id: usize,
     ) -> Result<(), KpmError> {
         self.check_ptr()?;
-        // The C API wrapper handles feature extraction internally inside
-        // kpm_add_ref_image, so pre-extracted features cannot be injected
-        // through the FFI. This is a no-op for the C++ backend.
         Ok(())
     }
 
@@ -186,24 +233,25 @@ impl FreakMatcherBackend for CppFreakMatcher {
         }
     }
 
+    /// Returns an empty slice — the C API does not expose inlier data.
     fn inliers(&self) -> &[Match] {
-        // The C API does not expose inlier data; return empty slice.
         &[]
     }
 
+    /// Returns `-1` — the thin C wrapper does not cache the last matched ID.
+    ///
+    /// Callers should use the [`QueryResult`] returned by [`query`](FreakMatcherBackend::query) instead.
     fn matched_id(&self) -> i32 {
-        // Without cached state the last matched ID is not available through
-        // the thin C wrapper. Callers should use the QueryResult instead.
         -1
     }
 
+    /// Returns an empty slice — the C API does not expose query feature points.
     fn query_feature_points(&self) -> &[FeaturePoint] {
-        // The C API does not expose query feature points.
         &[]
     }
 
+    /// Returns an empty slice — the C API does not expose per-image 3D feature points.
     fn get_3d_feature_points(&self, _image_id: usize) -> &[Point3d] {
-        // The C API does not expose per-image 3D feature points.
         &[]
     }
 }

--- a/crates/kpm/src/handle.rs
+++ b/crates/kpm/src/handle.rs
@@ -34,32 +34,333 @@
  *
  */
 
-use crate::backend::{FreakMatcherBackend, KpmError, QueryResult};
+//! Central KPM handle and configuration enums.
+//!
+//! This module contains [`KpmHandle`], the main entry point for all KPM
+//! tracking operations. It owns a boxed [`FreakMatcherBackend`] and
+//! coordinates reference-image management, query execution, and result
+//! retrieval.
 
-/// Central handle for KPM operations, generic over the backend implementation.
-pub struct KpmHandle<B: FreakMatcherBackend> {
-    backend: B,
+use crate::backend::{FreakMatcherBackend, KpmError};
+use crate::types::{KpmInputDataSet, KpmRefDataSet, KpmResult, DB_IMAGE_MAX};
+use std::sync::Arc;
+use webarkitlib_rs::types::ARParamLT;
+
+/// Processing resolution mode for KPM detection.
+///
+/// Controls how much the input camera frame is down-scaled before feature
+/// extraction. Smaller sizes are faster but may miss fine details.
+///
+/// The [`scale_factor`](KpmProcMode::scale_factor) method returns the
+/// divisor applied to each image dimension.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum KpmProcMode {
+    /// Process at the original camera resolution (scale = 1.0).
+    FullSize,
+    /// Process at 2/3 of the original resolution (scale = 1.5).
+    TwoThirdSize,
+    /// Process at half the original resolution (scale = 2.0).
+    HalfSize,
+    /// Process at 1/3 of the original resolution (scale = 3.0).
+    OneThirdSize,
+    /// Process at 1/4 of the original resolution (scale = 4.0).
+    QuarterSize,
 }
 
-impl<B: FreakMatcherBackend> KpmHandle<B> {
-    pub fn with_backend(backend: B) -> Self {
-        Self { backend }
+impl KpmProcMode {
+    /// Returns the scale divisor applied to each image dimension.
+    ///
+    /// For example, [`HalfSize`](KpmProcMode::HalfSize) returns `2.0`,
+    /// meaning a 640x480 frame becomes 320x240 internally.
+    pub fn scale_factor(&self) -> f32 {
+        match self {
+            KpmProcMode::FullSize => 1.0,
+            KpmProcMode::TwoThirdSize => 1.5,
+            KpmProcMode::HalfSize => 2.0,
+            KpmProcMode::OneThirdSize => 3.0,
+            KpmProcMode::QuarterSize => 4.0,
+        }
+    }
+}
+
+/// Pose estimation mode for KPM matching.
+///
+/// Determines whether the tracker computes a full 6-DOF camera pose
+/// (requiring calibrated camera parameters) or a planar homography.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum KpmPoseMode {
+    /// Full six-degrees-of-freedom pose estimation.
+    /// Requires valid camera parameters ([`ARParamLT`]).
+    Pose6DOF,
+    /// Planar homography estimation (3x3 matrix).
+    /// Does not require camera calibration.
+    Homography,
+}
+
+/// Central handle for KPM (Key-Point Matching) operations.
+///
+/// This is the Rust equivalent of the C++ `KpmHandle` from `kpmHandle.cpp`.
+/// It owns a [`Box<dyn FreakMatcherBackend>`] and coordinates all tracking
+/// operations: adding reference images, running queries against camera
+/// frames, and collecting pose results.
+///
+/// # Architecture
+///
+/// The handle uses **dynamic dispatch** (`dyn FreakMatcherBackend`) so that
+/// the C++ FFI backend ([`CppFreakMatcher`](crate::CppFreakMatcher)) can
+/// be transparently swapped for a future pure-Rust implementation without
+/// changing any calling code.
+///
+/// # Camera parameters
+///
+/// The optional `cparam_lt` field holds camera intrinsics wrapped in
+/// [`Arc`](std::sync::Arc). `Arc` (Atomically Reference Counted) is a
+/// thread-safe smart pointer that enables multiple owners of the same
+/// data. The internal reference count is incremented and decremented
+/// atomically, so it is safe to share across threads (unlike `Rc`).
+/// Camera parameters are typically created once and shared read-only
+/// across the tracking pipeline, making `Arc` an ideal fit — no need to
+/// duplicate the data for each handle. When the last `Arc` pointing to
+/// the data is dropped, the memory is freed automatically.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use webarkitlib_kpm::{CppFreakMatcher, KpmHandle, KpmProcMode};
+///
+/// let backend = CppFreakMatcher::new(640, 480).unwrap();
+/// let mut handle = KpmHandle::new(640, 480, None, Box::new(backend));
+///
+/// // Optionally change the processing resolution.
+/// handle.set_proc_mode(KpmProcMode::HalfSize).unwrap();
+/// ```
+pub struct KpmHandle {
+    /// The feature-matching backend (C++ FFI or pure-Rust).
+    pub matcher: Box<dyn FreakMatcherBackend>,
+    /// Reference data set containing FREAK descriptors and 3D coordinates.
+    pub ref_data_set: KpmRefDataSet,
+    /// Input data set holding 2D coordinates extracted from the current frame.
+    pub in_data_set: KpmInputDataSet,
+    /// Per-page matching results from the most recent query.
+    pub result: Vec<KpmResult>,
+    /// Shared camera intrinsics and lens-distortion look-up table.
+    ///
+    /// Wrapped in [`Arc`](std::sync::Arc) (Atomically Reference Counted)
+    /// so that multiple handles or pipeline stages can share the same
+    /// calibration data without copying. `Arc` is thread-safe: its
+    /// reference count is updated atomically, and the inner data is freed
+    /// when the last `Arc` clone is dropped.
+    pub cparam_lt: Option<Arc<ARParamLT>>,
+    /// Current processing resolution mode.
+    pub proc_mode: KpmProcMode,
+    /// Current pose estimation mode (6-DOF or homography).
+    pub pose_mode: KpmPoseMode,
+    /// Camera frame width in pixels.
+    pub xsize: i32,
+    /// Camera frame height in pixels.
+    pub ysize: i32,
+    /// Maximum number of features to detect per frame (`-1` = unlimited).
+    pub detected_max_feature: i32,
+    /// Per-page identifier array, indexed by internal page slot.
+    pub page_ids: [i32; DB_IMAGE_MAX],
+}
+
+impl KpmHandle {
+    /// Creates a new [`KpmHandle`].
+    ///
+    /// # Arguments
+    ///
+    /// * `xsize`     — camera frame width in pixels.
+    /// * `ysize`     — camera frame height in pixels.
+    /// * `cparam_lt` — optional shared camera parameters. Pass `None` when
+    ///   using [`KpmPoseMode::Homography`].
+    /// * `backend`   — a boxed [`FreakMatcherBackend`] implementation
+    ///   (e.g. [`CppFreakMatcher`](crate::CppFreakMatcher)).
+    ///
+    /// # Defaults
+    ///
+    /// * `proc_mode` = [`KpmProcMode::FullSize`]
+    /// * `pose_mode` = [`KpmPoseMode::Pose6DOF`]
+    /// * `detected_max_feature` = `-1` (unlimited)
+    pub fn new(
+        xsize: i32,
+        ysize: i32,
+        cparam_lt: Option<Arc<ARParamLT>>,
+        backend: Box<dyn FreakMatcherBackend>,
+    ) -> Self {
+        Self {
+            matcher: backend,
+            ref_data_set: KpmRefDataSet::default(),
+            in_data_set: KpmInputDataSet::default(),
+            result: Vec::new(),
+            cparam_lt,
+            proc_mode: KpmProcMode::FullSize,
+            pose_mode: KpmPoseMode::Pose6DOF,
+            xsize,
+            ysize,
+            detected_max_feature: -1,
+            page_ids: [0i32; DB_IMAGE_MAX],
+        }
     }
 
-    pub fn query(
-        &mut self,
-        image: &[u8],
-        width: usize,
-        height: usize,
-    ) -> Result<QueryResult, KpmError> {
-        self.backend.query(image, width, height)
+    /// Returns the camera frame width in pixels.
+    pub fn get_xsize(&self) -> i32 {
+        self.xsize
     }
 
-    pub fn backend(&self) -> &B {
-        &self.backend
+    /// Returns the camera frame height in pixels.
+    pub fn get_ysize(&self) -> i32 {
+        self.ysize
     }
 
-    pub fn backend_mut(&mut self) -> &mut B {
-        &mut self.backend
+    /// Sets the processing resolution mode.
+    ///
+    /// This controls how much the input frame is down-scaled before
+    /// feature detection. See [`KpmProcMode`] for available options.
+    pub fn set_proc_mode(&mut self, mode: KpmProcMode) -> Result<(), KpmError> {
+        self.proc_mode = mode;
+        Ok(())
+    }
+
+    /// Sets the maximum number of features to detect per frame.
+    ///
+    /// Pass `-1` for unlimited (the default).
+    pub fn set_detected_feature_max(&mut self, n: i32) {
+        self.detected_max_feature = n;
+    }
+
+    /// Marks the given page numbers as "skip" during matching.
+    ///
+    /// For each entry in `skip_pages`, any [`KpmResult`] whose `page_no`
+    /// matches will have its `skip_f` field set to `1`, causing the
+    /// matcher to ignore that page on the next query.
+    pub fn set_matching_skip_page(&mut self, skip_pages: &[i32]) -> Result<(), KpmError> {
+        for result in &mut self.result {
+            if skip_pages.contains(&result.page_no) {
+                result.skip_f = 1;
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns all per-page matching results from the most recent query.
+    pub fn get_result(&self) -> &[KpmResult] {
+        &self.result
+    }
+
+    /// Returns the first valid pose from the results.
+    ///
+    /// A result is considered valid when its `cam_pose_f` field equals `0`.
+    ///
+    /// # Returns
+    ///
+    /// `Some((cam_pose, page_no, error))` for the first valid result, or
+    /// `None` if every result has a non-zero `cam_pose_f` (i.e. no valid
+    /// pose was estimated).
+    pub fn get_pose(&self) -> Option<(&[[f32; 4]; 3], i32, f32)> {
+        self.result
+            .iter()
+            .find(|r| r.cam_pose_f == 0)
+            .map(|r| (&r.cam_pose, r.page_no, r.error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::{FeaturePoint, Match, Point3d, QueryResult};
+
+    // --- Mock backend for testing ---
+
+    struct MockBackend;
+
+    impl FreakMatcherBackend for MockBackend {
+        fn add_image(
+            &mut self,
+            _image: &[u8],
+            _width: usize,
+            _height: usize,
+            _image_id: usize,
+        ) -> Result<(), KpmError> {
+            todo!()
+        }
+
+        fn add_freak_features(
+            &mut self,
+            _points: &[FeaturePoint],
+            _descriptors: &[u8],
+            _points_3d: &[Point3d],
+            _width: usize,
+            _height: usize,
+            _db_id: usize,
+        ) -> Result<(), KpmError> {
+            todo!()
+        }
+
+        fn query(
+            &mut self,
+            _image: &[u8],
+            _width: usize,
+            _height: usize,
+        ) -> Result<QueryResult, KpmError> {
+            todo!()
+        }
+
+        fn inliers(&self) -> &[Match] {
+            todo!()
+        }
+
+        fn matched_id(&self) -> i32 {
+            todo!()
+        }
+
+        fn query_feature_points(&self) -> &[FeaturePoint] {
+            todo!()
+        }
+
+        fn get_3d_feature_points(&self, _image_id: usize) -> &[Point3d] {
+            todo!()
+        }
+    }
+
+    #[test]
+    fn test_kpm_handle_new() {
+        let handle = KpmHandle::new(640, 480, None, Box::new(MockBackend));
+
+        assert_eq!(handle.get_xsize(), 640);
+        assert_eq!(handle.get_ysize(), 480);
+        assert_eq!(handle.proc_mode, KpmProcMode::FullSize);
+        assert_eq!(handle.pose_mode, KpmPoseMode::Pose6DOF);
+        assert_eq!(handle.detected_max_feature, -1);
+        assert!(handle.result.is_empty());
+        assert!(handle.cparam_lt.is_none());
+    }
+
+    #[test]
+    fn test_kpm_proc_mode_scale_factor() {
+        assert_eq!(KpmProcMode::FullSize.scale_factor(), 1.0);
+        assert_eq!(KpmProcMode::TwoThirdSize.scale_factor(), 1.5);
+        assert_eq!(KpmProcMode::HalfSize.scale_factor(), 2.0);
+        assert_eq!(KpmProcMode::OneThirdSize.scale_factor(), 3.0);
+        assert_eq!(KpmProcMode::QuarterSize.scale_factor(), 4.0);
+    }
+
+    #[test]
+    fn test_kpm_get_pose_none_when_no_valid_result() {
+        let mut handle = KpmHandle::new(640, 480, None, Box::new(MockBackend));
+
+        // Add results with cam_pose_f = -1 (invalid).
+        handle.result.push(KpmResult {
+            cam_pose_f: -1,
+            page_no: 0,
+            ..KpmResult::default()
+        });
+        handle.result.push(KpmResult {
+            cam_pose_f: -1,
+            page_no: 1,
+            ..KpmResult::default()
+        });
+
+        assert!(handle.get_pose().is_none());
     }
 }

--- a/crates/kpm/src/kpm_ffi.rs
+++ b/crates/kpm/src/kpm_ffi.rs
@@ -34,6 +34,18 @@
  *
  */
 
+//! Raw bindgen-generated FFI bindings for `kpm_c_api.h`.
+//!
+//! This module is only compiled when the **`ffi-backend`** feature is
+//! enabled. It re-exports all symbols produced by `bindgen` in
+//! `build.rs`, including the opaque [`KpmOpaqueHandle`] type and the
+//! four `extern "C"` functions: [`kpm_create`], [`kpm_destroy`],
+//! [`kpm_add_ref_image`], and [`kpm_query`].
+//!
+//! **Do not call these functions directly** — use
+//! [`CppFreakMatcher`](crate::CppFreakMatcher) instead, which wraps
+//! them with safe Rust types and null-pointer guards.
+
 #[cfg(feature = "ffi-backend")]
 mod bindings {
     #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]

--- a/crates/kpm/src/lib.rs
+++ b/crates/kpm/src/lib.rs
@@ -34,6 +34,44 @@
  *
  */
 
+//! # webarkitlib-kpm
+//!
+//! KPM (Key-Point Matching) / NFT (Natural Feature Tracking) layer for
+//! WebARKitLib-rs, ported from the C++ FreakMatcher library.
+//!
+//! This crate provides a Rust interface to the FREAK-descriptor-based
+//! feature matching pipeline used for planar image tracking. It supports
+//! two operation modes:
+//!
+//! - **`ffi-backend`** (default) — delegates to the compiled C++ FreakMatcher
+//!   static library through a thin `extern "C"` wrapper (`kpm_c_api.h`).
+//! - *(future)* **pure-Rust** — a native Rust re-implementation of the same
+//!   pipeline, swappable via the [`FreakMatcherBackend`] trait.
+//!
+//! ## Quick start
+//!
+//! ```rust,no_run
+//! use webarkitlib_kpm::{CppFreakMatcher, KpmHandle};
+//!
+//! // Create a C++ backend for a 640x480 camera frame.
+//! let backend = CppFreakMatcher::new(640, 480).unwrap();
+//!
+//! // Wrap it in a KpmHandle (the central coordinator).
+//! let mut handle = KpmHandle::new(640, 480, None, Box::new(backend));
+//! ```
+//!
+//! ## Crate layout
+//!
+//! | Module           | Purpose |
+//! |------------------|---------|
+//! | [`backend`]      | `FreakMatcherBackend` trait and associated error / data types |
+//! | [`handle`]       | [`KpmHandle`] struct — central coordinator for KPM operations |
+//! | [`types`]        | Ported C structs (`KpmRefDataSet`, `KpmResult`, etc.) |
+//! | [`cpp_backend`]  | [`CppFreakMatcher`] — FFI backend (feature-gated) |
+//! | [`kpm_ffi`]      | Raw bindgen bindings (feature-gated) |
+//! | [`matching`]     | [`MatchResult`](matching::MatchResult) wrapper |
+//! | [`ref_data_set`] | [`RefDataSet`](ref_data_set::RefDataSet) collection |
+
 pub mod backend;
 pub mod handle;
 pub mod kpm_ffi;
@@ -47,11 +85,8 @@ pub mod cpp_backend;
 // Re-export key types for convenience.
 pub use backend::QueryResult;
 pub use backend::{FeaturePoint, FreakMatcherBackend, KpmError, Match, Point3d};
-pub use handle::KpmHandle;
+pub use handle::{KpmHandle, KpmPoseMode, KpmProcMode};
 pub use types::{Homography3x3, RefImage};
 
 #[cfg(feature = "ffi-backend")]
 pub use cpp_backend::CppFreakMatcher;
-
-#[cfg(feature = "ffi-backend")]
-pub type DefaultKpmHandle = KpmHandle<CppFreakMatcher>;

--- a/crates/kpm/src/matching.rs
+++ b/crates/kpm/src/matching.rs
@@ -34,32 +34,56 @@
  *
  */
 
+//! High-level matching result wrapper.
+//!
+//! [`MatchResult`] provides a convenient `Option`-like API around a
+//! [`QueryResult`](crate::types::QueryResult), making it easy to check
+//! whether a match was found and to extract the result.
+
 use crate::types::QueryResult;
 
-/// Result of a matching operation.
+/// Outcome of a single matching operation.
+///
+/// Wraps an `Option<QueryResult>` and exposes helper methods to inspect
+/// the match without pattern matching.
+///
+/// # Examples
+///
+/// ```rust
+/// use webarkitlib_kpm::matching::MatchResult;
+///
+/// let miss = MatchResult::not_found();
+/// assert!(!miss.is_match());
+/// assert!(miss.result().is_none());
+/// ```
 pub struct MatchResult {
     inner: Option<QueryResult>,
 }
 
 impl MatchResult {
+    /// Creates a successful match result.
     pub fn found(result: QueryResult) -> Self {
         Self {
             inner: Some(result),
         }
     }
 
+    /// Creates a "no match" result.
     pub fn not_found() -> Self {
         Self { inner: None }
     }
 
+    /// Returns `true` if a match was found.
     pub fn is_match(&self) -> bool {
         self.inner.is_some()
     }
 
+    /// Returns a reference to the inner [`QueryResult`], if any.
     pub fn result(&self) -> Option<&QueryResult> {
         self.inner.as_ref()
     }
 
+    /// Consumes `self` and returns the inner [`QueryResult`], if any.
     pub fn into_result(self) -> Option<QueryResult> {
         self.inner
     }

--- a/crates/kpm/src/ref_data_set.rs
+++ b/crates/kpm/src/ref_data_set.rs
@@ -34,30 +34,44 @@
  *
  */
 
+//! Reference-image collection for the KPM database.
+//!
+//! [`RefDataSet`] is a simple growable collection of [`RefImage`]
+//! entries. It is used to stage reference images before they are
+//! submitted to the backend for feature extraction.
+
 use crate::types::RefImage;
 
-/// Collection of reference images for the KPM database.
+/// A collection of reference images to be registered in the KPM database.
+///
+/// Images are added one at a time via [`add`](RefDataSet::add) and can
+/// be iterated over with [`iter`](RefDataSet::iter).
 pub struct RefDataSet {
     images: Vec<RefImage>,
 }
 
 impl RefDataSet {
+    /// Creates an empty reference data set.
     pub fn new() -> Self {
         Self { images: Vec::new() }
     }
 
+    /// Appends a reference image to the set.
     pub fn add(&mut self, image: RefImage) {
         self.images.push(image);
     }
 
+    /// Returns the number of images in the set.
     pub fn len(&self) -> usize {
         self.images.len()
     }
 
+    /// Returns `true` if the set contains no images.
     pub fn is_empty(&self) -> bool {
         self.images.is_empty()
     }
 
+    /// Returns an iterator over the reference images.
     pub fn iter(&self) -> impl Iterator<Item = &RefImage> {
         self.images.iter()
     }

--- a/crates/kpm/src/types.rs
+++ b/crates/kpm/src/types.rs
@@ -34,39 +34,81 @@
  *
  */
 
-// Constants ported from kpmType.h and kpm.h
+//! KPM data types ported from the C headers `kpmType.h` and `kpm.h`.
+//!
+//! These are pure Rust types (no `#[repr(C)]`) used throughout the crate
+//! to represent reference data, query results, and geometric primitives.
+//! FFI communication goes through the opaque C API (`kpm_c_api.h`)
+//! instead.
 
+// ---------------------------------------------------------------------------
+// Constants ported from kpmType.h and kpm.h
+// ---------------------------------------------------------------------------
+
+/// Size (in bytes) of a single FREAK descriptor.
+///
+/// Each descriptor is a 96-byte binary string used for fast
+/// Hamming-distance matching.
 pub const FREAK_SUB_DIMENSION: usize = 96;
+
+/// Maximum number of reference images the database can hold.
 pub const DB_IMAGE_MAX: usize = 1024;
+
+/// Maximum number of corner points detected in a single frame.
 pub const MAX_CORNER_POINTS: usize = 2000;
 
-// --- Types ported from kpmType.h ---
+// ---------------------------------------------------------------------------
+// Types ported from kpmType.h
+// ---------------------------------------------------------------------------
 
+/// 2D coordinate used for feature-point positions and projections.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct KpmCoord2D {
+    /// Horizontal position (pixels).
     pub x: f32,
+    /// Vertical position (pixels).
     pub y: f32,
 }
 
+/// Metadata for a single image within a reference page.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct KpmImageInfo {
+    /// Unique image number within the page.
     pub image_no: i32,
+    /// Image width in pixels.
     pub width: i32,
+    /// Image height in pixels.
     pub height: i32,
 }
 
+/// Metadata for a reference page (a tracked planar target).
+///
+/// A page can contain multiple images at different resolutions to
+/// improve tracking robustness across scales.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct KpmPageInfo {
+    /// Unique page number.
     pub page_no: i32,
+    /// Number of images associated with this page.
     pub image_num: i32,
+    /// Per-image metadata.
     pub image_info: Vec<KpmImageInfo>,
 }
 
+/// A single FREAK (Fast Retina Keypoint) feature descriptor.
+///
+/// The descriptor is a 96-byte binary string ([`FREAK_SUB_DIMENSION`])
+/// designed for fast Hamming-distance comparison, together with the
+/// keypoint's orientation, scale, and maxima flag.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FreakFeature {
+    /// 96-byte binary descriptor vector.
     pub v: [u8; FREAK_SUB_DIMENSION],
+    /// Keypoint orientation in radians.
     pub angle: f32,
+    /// Keypoint scale (pyramid level).
     pub scale: f32,
+    /// Whether this keypoint is a local maximum (`1`) or not (`0`).
     pub maxima: i32,
 }
 
@@ -81,64 +123,112 @@ impl Default for FreakFeature {
     }
 }
 
+/// A reference data point linking a 2D image position, a 3D world
+/// position, and a FREAK descriptor.
+///
+/// These are stored in [`KpmRefDataSet`] and used during matching to
+/// establish 2D-3D correspondences for pose estimation.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct KpmRefData {
+    /// 2D position of the feature in the reference image (pixels).
     pub coord2d: KpmCoord2D,
+    /// 3D world coordinate computed from the 2D position and DPI
+    /// (millimetres, centred on the image).
     pub coord3d: KpmCoord2D,
+    /// FREAK descriptor for this feature.
     pub feature_vec: FreakFeature,
+    /// Page number this feature belongs to.
     pub page_no: i32,
+    /// Reference-image number within the page.
     pub ref_image_no: i32,
 }
 
 impl KpmRefData {
+    /// Returns the raw descriptor bytes for this feature point.
     pub fn feature_vec_as_bytes(&self) -> &[u8] {
         &self.feature_vec.v
     }
 }
 
+/// Complete set of reference data for all registered pages.
+///
+/// Populated by [`KpmHandle`](crate::KpmHandle) when reference images
+/// are added, and consumed by the matcher during queries.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct KpmRefDataSet {
+    /// All reference feature points across every page.
     pub ref_point: Vec<KpmRefData>,
+    /// Total number of reference points (kept in sync with `ref_point.len()`).
     pub num: i32,
+    /// Per-page metadata.
     pub page_info: Vec<KpmPageInfo>,
+    /// Total number of pages (kept in sync with `page_info.len()`).
     pub page_num: i32,
 }
 
+/// Set of 2D input coordinates extracted from the current camera frame.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct KpmInputDataSet {
+    /// Detected feature coordinates.
     pub coord: Vec<KpmCoord2D>,
+    /// Number of detected features (kept in sync with `coord.len()`).
     pub num: i32,
 }
 
-// --- Types ported from kpm.h ---
+// ---------------------------------------------------------------------------
+// Types ported from kpm.h
+// ---------------------------------------------------------------------------
 
+/// Per-page result of a KPM matching + pose-estimation query.
+///
+/// After a call to `kpm_query`, one of these is produced for every
+/// registered page. Inspect `cam_pose_f` to decide whether the pose
+/// is valid (`0`) or not (`-1`).
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct KpmResult {
+    /// 3x4 camera pose matrix (row-major).
+    ///
+    /// Layout: `[[r00 r01 r02 tx], [r10 r11 r12 ty], [r20 r21 r22 tz]]`.
     pub cam_pose: [[f32; 4]; 3],
+    /// Pose validity flag: `0` = valid, `-1` = not estimated.
     pub cam_pose_f: i32,
+    /// Page number this result refers to.
     pub page_no: i32,
+    /// Number of RANSAC inliers that support this pose.
     pub inlier_num: i32,
+    /// Reprojection error of the estimated pose.
     pub error: f32,
+    /// Skip flag: `1` = this page was excluded from matching.
     pub skip_f: i32,
 }
 
-// --- Corner point types ---
+// ---------------------------------------------------------------------------
+// Corner-point types
+// ---------------------------------------------------------------------------
 
+/// 2D point with `f32` coordinates.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Point2f {
     pub x: f32,
     pub y: f32,
 }
 
+/// 2D point with integer coordinates, used for corner detection.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Point2i {
     pub x: i32,
     pub y: i32,
 }
 
+/// Fixed-capacity buffer of detected corner points.
+///
+/// Uses a statically-sized array of [`MAX_CORNER_POINTS`] entries to
+/// avoid heap allocation on the hot detection path.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CornerPoints {
+    /// Number of valid entries in `pt`.
     pub num: i32,
+    /// Corner positions (only the first `num` entries are meaningful).
     pub pt: [Point2i; MAX_CORNER_POINTS],
 }
 
@@ -151,9 +241,14 @@ impl Default for CornerPoints {
     }
 }
 
-// --- FFI bridge types (used by cpp_backend) ---
+// ---------------------------------------------------------------------------
+// FFI bridge types (used by cpp_backend)
+// ---------------------------------------------------------------------------
 
 /// A 3x3 homography matrix stored in row-major order.
+///
+/// Used to represent the planar transformation between a reference
+/// image and the current camera frame.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Homography3x3(pub [f32; 9]);
 
@@ -163,22 +258,38 @@ impl Default for Homography3x3 {
     }
 }
 
-/// Result from a query operation.
+/// Result from a query operation (FFI bridge level).
+///
+/// This type is used internally by [`CppFreakMatcher`](crate::CppFreakMatcher)
+/// to shuttle data across the FFI boundary. Higher-level code should
+/// prefer [`backend::QueryResult`](crate::backend::QueryResult).
 #[derive(Debug, Clone, PartialEq)]
 pub struct QueryResult {
+    /// Page number of the matched reference image, or `-1` if no match.
     pub page_no: i32,
+    /// 3x3 homography from the reference image to the camera frame.
     pub homography: Homography3x3,
+    /// Reprojection error (`0.0` on success, `-1.0` on failure).
     pub error: f32,
 }
 
-/// A reference image to be added to the database.
+/// A reference image to be added to the KPM database.
+///
+/// Contains the raw grayscale pixel data together with metadata needed
+/// to compute 3D world coordinates from pixel positions.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RefImage {
+    /// Grayscale pixel data (one byte per pixel, row-major).
     pub data: Vec<u8>,
+    /// Image width in pixels.
     pub width: i32,
+    /// Image height in pixels.
     pub height: i32,
+    /// Dots per inch — used to convert pixel positions to millimetres.
     pub dpi: f32,
+    /// Page number this image belongs to.
     pub page_no: i32,
+    /// Image number within the page.
     pub image_no: i32,
 }
 


### PR DESCRIPTION
## Summary
- Implement `KpmHandle` struct with `KpmProcMode`/`KpmPoseMode` enums and accessors (`new`, `get_xsize`, `get_ysize`, `set_proc_mode`, `set_detected_feature_max`, `set_matching_skip_page`, `get_result`, `get_pose`)
- Add comprehensive Rust doc comments (`///` and `//!`) across all 8 kpm crate source modules, including crate-level docs with quick-start example, struct/field/method documentation, and working doc-tests
- Replace generic `KpmHandle<B>` with trait-object-based `KpmHandle` using `Box<dyn FreakMatcherBackend>`, removing the `DefaultKpmHandle` type alias

Closes #25

## Test plan
- [x] `cargo test -p webarkitlib-kpm` — 11 unit tests + 4 doc-tests pass
- [x] `cargo build -p webarkitlib-kpm --features ffi-backend` — builds clean
- [x] `cargo fmt -p webarkitlib-kpm -- --check` — no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)