### PR TITLE
feat(ar2): .iset/.fset write support + gen_image_layer rename

### DIFF
--- a/crates/core/src/ar2/feature_map.rs
+++ b/crates/core/src/ar2/feature_map.rs
@@ -276,10 +276,10 @@ fn gen_feature_map_for_level(
             let p = |di: isize, dj: isize| -> f32 {
                 image[((j as isize + dj) as usize) * w + ((i as isize + di) as usize)] as f32
             };
-            let dx = (p(1, -1) - p(-1, -1) + p(1, 0) - p(-1, 0) + p(1, 1) - p(-1, 1))
-                / (3.0 * 256.0);
-            let dy = (p(1, 1) - p(1, -1) + p(0, 1) - p(0, -1) + p(-1, 1) - p(-1, -1))
-                / (3.0 * 256.0);
+            let dx =
+                (p(1, -1) - p(-1, -1) + p(1, 0) - p(-1, 0) + p(1, 1) - p(-1, 1)) / (3.0 * 256.0);
+            let dy =
+                (p(1, 1) - p(1, -1) + p(0, 1) - p(0, -1) + p(-1, 1) - p(-1, -1)) / (3.0 * 256.0);
             grad[idx] = ((dx * dx + dy * dy) / 2.0).sqrt();
         }
     }
@@ -291,11 +291,7 @@ fn gen_feature_map_for_level(
         for i in 1..(w - 1) {
             let idx = j * w + i;
             let g = grad[idx];
-            if g > grad[idx - 1]
-                && g > grad[idx + 1]
-                && g > grad[idx - w]
-                && g > grad[idx + w]
-            {
+            if g > grad[idx - 1] && g > grad[idx + 1] && g > grad[idx - w] && g > grad[idx + w] {
                 let k = ((g * 1000.0) as usize).min(999);
                 hist[k] += 1;
                 sum += 1;
@@ -325,10 +321,7 @@ fn gen_feature_map_for_level(
             let g = grad[idx];
 
             // NMS check
-            if g <= grad[idx - 1]
-                || g <= grad[idx + 1]
-                || g <= grad[idx - w]
-                || g <= grad[idx + w]
+            if g <= grad[idx - 1] || g <= grad[idx + 1] || g <= grad[idx - w] || g <= grad[idx + w]
             {
                 continue;
             }
@@ -340,12 +333,11 @@ fn gen_feature_map_for_level(
             let ci = i as i32;
             let cj = j as i32;
 
-            let vlen = match make_template(
-                image, xsize, ysize, ci, cj, ts1, ts2, sd_thresh, &mut tmpl,
-            ) {
-                Some(v) => v,
-                None => continue,
-            };
+            let vlen =
+                match make_template(image, xsize, ysize, ci, cj, ts1, ts2, sd_thresh, &mut tmpl) {
+                    Some(v) => v,
+                    None => continue,
+                };
 
             let mut max = -1.0f32;
             let mut early_exit = false;
@@ -452,9 +444,9 @@ fn select_features(
                 if i == 0 && j == 0 {
                     continue;
                 }
-                if let Some(sim) = get_similarity(
-                    image, xsize, ysize, &tmpl, vlen, ts1, ts2, cx + i, cy + j,
-                ) {
+                if let Some(sim) =
+                    get_similarity(image, xsize, ysize, &tmpl, vlen, ts1, ts2, cx + i, cy + j)
+                {
                     if sim < local_min {
                         local_min = sim;
                         if local_min < min_sim_thresh && local_min < min_sim {
@@ -535,7 +527,9 @@ pub fn ar2_gen_feature_map(
 ) -> Result<AR2FeatureSetT, Ar2Error> {
     // Validate inputs
     if image.is_empty() || xsize <= 0 || ysize <= 0 {
-        return Err(Ar2Error::InvalidInput("image is empty or has zero dimensions"));
+        return Err(Ar2Error::InvalidInput(
+            "image is empty or has zero dimensions",
+        ));
     }
     if image.len() != (xsize as usize) * (ysize as usize) {
         return Err(Ar2Error::InvalidInput(
@@ -615,8 +609,7 @@ mod tests {
     #[test]
     #[ignore] // Heavy computation — run explicitly with `cargo test -- --ignored`
     fn test_feature_map_produces_points() {
-        let img = image::open("examples/Data/pinball.jpg")
-            .expect("failed to open test image");
+        let img = image::open("examples/Data/pinball.jpg").expect("failed to open test image");
         let gray = img.to_luma8();
         let w = gray.width() as i32;
         let h = gray.height() as i32;
@@ -647,7 +640,11 @@ mod tests {
         let mut data = vec![0u8; (w * h) as usize];
         for y in 0..h {
             for x in 0..w {
-                data[(y * w + x) as usize] = if ((x / 4) + (y / 4)) % 2 == 0 { 200 } else { 50 };
+                data[(y * w + x) as usize] = if ((x / 4) + (y / 4)) % 2 == 0 {
+                    200
+                } else {
+                    50
+                };
             }
         }
 
@@ -670,11 +667,17 @@ mod tests {
         let levels = build_pyramid(&data, w as i32, h as i32, 200.0);
         // 200 → 100 → 50 → 25 (at 25 DPI: 128*25/200 = 16 ≥ 8)
         // → 12.5 (128*12.5/200 = 8 ≥ 8) → 6.25 (128*6.25/200 = 4 < 8, stop)
-        assert!(levels.len() >= 3, "should have at least 3 levels, got {}", levels.len());
+        assert!(
+            levels.len() >= 3,
+            "should have at least 3 levels, got {}",
+            levels.len()
+        );
         assert_eq!(levels[0].width, w as i32);
         assert_eq!(levels[0].height, h as i32);
         for i in 1..levels.len() {
-            assert!(levels[i].width < levels[i - 1].width || levels[i].height < levels[i - 1].height);
+            assert!(
+                levels[i].width < levels[i - 1].width || levels[i].height < levels[i - 1].height
+            );
         }
     }
 
@@ -682,7 +685,7 @@ mod tests {
     fn test_make_template_out_of_bounds() {
         let data = vec![100u8; 10 * 10];
         let mut tmpl = vec![0.0f32; 529]; // (11+11+1)^2 = 529
-        // Centre at (0,0) with ts1=11 → out of bounds
+                                          // Centre at (0,0) with ts1=11 → out of bounds
         assert!(make_template(&data, 10, 10, 0, 0, 11, 11, 0.0, &mut tmpl).is_none());
     }
 }

--- a/crates/core/src/ar2/feature_map.rs
+++ b/crates/core/src/ar2/feature_map.rs
@@ -41,7 +41,7 @@
 //! [`AR2FeatureSetT`].
 
 use super::feature_set::{AR2FeatureCoordT, AR2FeaturePointsT, AR2FeatureSetT};
-use super::image_set::gen_image_layer;
+use super::image_set::gen_image_layer2;
 
 // ---------------------------------------------------------------------------
 // Constants (from AR2/config.h)
@@ -121,7 +121,7 @@ fn build_pyramid(image: &[u8], xsize: i32, ysize: i32, dpi: f32) -> Vec<PyramidL
         if next_w < MIN_PYRAMID_DIM || next_h < MIN_PYRAMID_DIM {
             break;
         }
-        let layer = gen_image_layer(image, xsize, ysize, dpi, next_dpi);
+        let layer = gen_image_layer2(image, xsize, ysize, dpi, next_dpi);
         levels.push(PyramidLevel {
             data: layer.img_bw,
             width: layer.xsize,

--- a/crates/core/src/ar2/feature_set.rs
+++ b/crates/core/src/ar2/feature_set.rs
@@ -59,8 +59,8 @@
 //!     [f32]  maxSim    — maximum similarity score
 //! ```
 
-use byteorder::{LittleEndian, ReadBytesExt};
-use std::io::{self, Cursor, Read};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use std::io::{self, BufWriter, Cursor, Read, Write};
 use std::path::Path;
 
 /// A single feature coordinate.
@@ -121,6 +121,81 @@ impl AR2FeatureSetT {
     pub fn from_bytes(data: &[u8]) -> io::Result<Self> {
         let mut cursor = Cursor::new(data);
         Self::read_from(&mut cursor)
+    }
+
+    /// Save the feature set to an `.fset` file on disk.
+    ///
+    /// Writes the same little-endian binary layout that [`load()`](Self::load)
+    /// and the C function `ar2LoadFeatureSet()` expect, so the resulting file
+    /// is compatible with both the Rust and C/C++ readers.
+    ///
+    /// ## Binary layout (little-endian)
+    ///
+    /// ```text
+    /// [i32]  num_scales
+    /// For each scale:
+    ///   [i32]  scale       — scale index
+    ///   [f32]  maxdpi      — maximum DPI for this scale
+    ///   [f32]  mindpi      — minimum DPI for this scale
+    ///   [i32]  num_coords  — number of feature coordinates
+    ///   For each coord:
+    ///     [i32]  x         — pixel x position
+    ///     [i32]  y         — pixel y position
+    ///     [f32]  mx        — marker x coordinate (millimetres)
+    ///     [f32]  my        — marker y coordinate (millimetres)
+    ///     [f32]  maxSim    — maximum similarity score
+    /// ```
+    pub fn save<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        let file = std::fs::File::create(path)?;
+        let mut w = BufWriter::new(file);
+        self.write_to(&mut w)?;
+        w.flush()
+    }
+
+    /// Serialize the feature set into an in-memory byte vector.
+    ///
+    /// Uses the same binary format as [`save()`](Self::save).
+    pub fn to_bytes(&self) -> io::Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        self.write_to(&mut buf)?;
+        Ok(buf)
+    }
+
+    /// Write the feature set to any [`Write`] implementor.
+    ///
+    /// This is the shared serialization core used by both [`save()`](Self::save)
+    /// and [`to_bytes()`](Self::to_bytes). The field ordering mirrors
+    /// [`read_from()`] exactly so that `write_to` → `read_from` is a
+    /// lossless roundtrip.
+    fn write_to<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        if self.list.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "feature set has no scales to write",
+            ));
+        }
+
+        // Number of scales.
+        writer.write_i32::<LittleEndian>(self.list.len() as i32)?;
+
+        for pts in &self.list {
+            // Scale header.
+            writer.write_i32::<LittleEndian>(pts.scale)?;
+            writer.write_f32::<LittleEndian>(pts.maxdpi)?;
+            writer.write_f32::<LittleEndian>(pts.mindpi)?;
+            writer.write_i32::<LittleEndian>(pts.coord.len() as i32)?;
+
+            // Feature coordinates.
+            for c in &pts.coord {
+                writer.write_i32::<LittleEndian>(c.x)?;
+                writer.write_i32::<LittleEndian>(c.y)?;
+                writer.write_f32::<LittleEndian>(c.mx)?;
+                writer.write_f32::<LittleEndian>(c.my)?;
+                writer.write_f32::<LittleEndian>(c.max_sim)?;
+            }
+        }
+
+        Ok(())
     }
 
     fn read_from<R: Read>(reader: &mut R) -> io::Result<Self> {
@@ -216,5 +291,78 @@ mod tests {
         assert_eq!(fset.list[0].coord[0].x, 10);
         assert_eq!(fset.list[0].coord[0].y, 20);
         assert_eq!(fset.list[0].coord[1].max_sim, 0.80);
+    }
+
+    /// Roundtrip test: build → save() → load() → compare.
+    ///
+    /// Verifies that the save/load cycle is lossless for a feature set
+    /// with 2 scales and 3 feature coordinates each.
+    #[test]
+    fn test_feature_set_save_load_roundtrip() {
+        let original = AR2FeatureSetT {
+            list: vec![
+                AR2FeaturePointsT {
+                    coord: vec![
+                        AR2FeatureCoordT { x: 10, y: 20, mx: 3.528, my: 16.933, max_sim: 0.42 },
+                        AR2FeatureCoordT { x: 55, y: 80, mx: 19.403, my: 10.795, max_sim: 0.37 },
+                        AR2FeatureCoordT { x: 100, y: 5, mx: 35.278, my: 19.261, max_sim: 0.51 },
+                    ],
+                    scale: 0,
+                    maxdpi: 200.0,
+                    mindpi: 100.0,
+                },
+                AR2FeaturePointsT {
+                    coord: vec![
+                        AR2FeatureCoordT { x: 5, y: 10, mx: 1.764, my: 8.467, max_sim: 0.55 },
+                        AR2FeatureCoordT { x: 25, y: 40, mx: 8.819, my: 5.397, max_sim: 0.48 },
+                        AR2FeatureCoordT { x: 50, y: 2, mx: 17.639, my: 9.631, max_sim: 0.60 },
+                    ],
+                    scale: 1,
+                    maxdpi: 100.0,
+                    mindpi: 50.0,
+                },
+            ],
+        };
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        original.save(tmp.path()).unwrap();
+        let loaded = AR2FeatureSetT::load(tmp.path()).unwrap();
+
+        assert_eq!(loaded.num(), original.num());
+        for (orig_pts, load_pts) in original.list.iter().zip(loaded.list.iter()) {
+            assert_eq!(load_pts.scale, orig_pts.scale);
+            assert_eq!(load_pts.maxdpi, orig_pts.maxdpi);
+            assert_eq!(load_pts.mindpi, orig_pts.mindpi);
+            assert_eq!(load_pts.num(), orig_pts.num());
+            for (oc, lc) in orig_pts.coord.iter().zip(load_pts.coord.iter()) {
+                assert_eq!(lc.x, oc.x);
+                assert_eq!(lc.y, oc.y);
+                assert!((lc.mx - oc.mx).abs() < 1e-4, "mx mismatch");
+                assert!((lc.my - oc.my).abs() < 1e-4, "my mismatch");
+                assert!((lc.max_sim - oc.max_sim).abs() < 1e-4, "max_sim mismatch");
+            }
+        }
+    }
+
+    /// Verify that to_bytes() output is loadable by from_bytes().
+    #[test]
+    fn test_feature_set_to_bytes_from_bytes_roundtrip() {
+        let original = AR2FeatureSetT {
+            list: vec![AR2FeaturePointsT {
+                coord: vec![AR2FeatureCoordT {
+                    x: 42, y: 99, mx: 7.5, my: 12.3, max_sim: 0.65,
+                }],
+                scale: 0,
+                maxdpi: 150.0,
+                mindpi: 75.0,
+            }],
+        };
+
+        let bytes = original.to_bytes().unwrap();
+        let loaded = AR2FeatureSetT::from_bytes(&bytes).unwrap();
+
+        assert_eq!(loaded.num(), 1);
+        assert_eq!(loaded.list[0].coord[0].x, 42);
+        assert_eq!(loaded.list[0].coord[0].y, 99);
     }
 }

--- a/crates/core/src/ar2/feature_set.rs
+++ b/crates/core/src/ar2/feature_set.rs
@@ -303,9 +303,27 @@ mod tests {
             list: vec![
                 AR2FeaturePointsT {
                     coord: vec![
-                        AR2FeatureCoordT { x: 10, y: 20, mx: 3.528, my: 16.933, max_sim: 0.42 },
-                        AR2FeatureCoordT { x: 55, y: 80, mx: 19.403, my: 10.795, max_sim: 0.37 },
-                        AR2FeatureCoordT { x: 100, y: 5, mx: 35.278, my: 19.261, max_sim: 0.51 },
+                        AR2FeatureCoordT {
+                            x: 10,
+                            y: 20,
+                            mx: 3.528,
+                            my: 16.933,
+                            max_sim: 0.42,
+                        },
+                        AR2FeatureCoordT {
+                            x: 55,
+                            y: 80,
+                            mx: 19.403,
+                            my: 10.795,
+                            max_sim: 0.37,
+                        },
+                        AR2FeatureCoordT {
+                            x: 100,
+                            y: 5,
+                            mx: 35.278,
+                            my: 19.261,
+                            max_sim: 0.51,
+                        },
                     ],
                     scale: 0,
                     maxdpi: 200.0,
@@ -313,9 +331,27 @@ mod tests {
                 },
                 AR2FeaturePointsT {
                     coord: vec![
-                        AR2FeatureCoordT { x: 5, y: 10, mx: 1.764, my: 8.467, max_sim: 0.55 },
-                        AR2FeatureCoordT { x: 25, y: 40, mx: 8.819, my: 5.397, max_sim: 0.48 },
-                        AR2FeatureCoordT { x: 50, y: 2, mx: 17.639, my: 9.631, max_sim: 0.60 },
+                        AR2FeatureCoordT {
+                            x: 5,
+                            y: 10,
+                            mx: 1.764,
+                            my: 8.467,
+                            max_sim: 0.55,
+                        },
+                        AR2FeatureCoordT {
+                            x: 25,
+                            y: 40,
+                            mx: 8.819,
+                            my: 5.397,
+                            max_sim: 0.48,
+                        },
+                        AR2FeatureCoordT {
+                            x: 50,
+                            y: 2,
+                            mx: 17.639,
+                            my: 9.631,
+                            max_sim: 0.60,
+                        },
                     ],
                     scale: 1,
                     maxdpi: 100.0,
@@ -350,7 +386,11 @@ mod tests {
         let original = AR2FeatureSetT {
             list: vec![AR2FeaturePointsT {
                 coord: vec![AR2FeatureCoordT {
-                    x: 42, y: 99, mx: 7.5, my: 12.3, max_sim: 0.65,
+                    x: 42,
+                    y: 99,
+                    mx: 7.5,
+                    my: 12.3,
+                    max_sim: 0.65,
                 }],
                 scale: 0,
                 maxdpi: 150.0,

--- a/crates/core/src/ar2/image_set.rs
+++ b/crates/core/src/ar2/image_set.rs
@@ -407,7 +407,11 @@ pub(crate) fn gen_image_layer1(
             // Divide by count * nc to average across both pixels and channels,
             // producing a single grayscale value.
             let divisor = count * (nc as u32);
-            dst[(dy * dst_xsize + dx) as usize] = if divisor > 0 { (sum / divisor) as u8 } else { 0 };
+            dst[(dy * dst_xsize + dx) as usize] = if divisor > 0 {
+                (sum / divisor) as u8
+            } else {
+                0
+            };
         }
     }
 
@@ -592,8 +596,18 @@ mod tests {
 
         let original = AR2ImageSetT {
             scale: vec![
-                AR2ImageT { img_bw: pixels_0, xsize: 8, ysize: 8, dpi: 200.0 },
-                AR2ImageT { img_bw: pixels_1, xsize: 4, ysize: 4, dpi: 100.0 },
+                AR2ImageT {
+                    img_bw: pixels_0,
+                    xsize: 8,
+                    ysize: 8,
+                    dpi: 200.0,
+                },
+                AR2ImageT {
+                    img_bw: pixels_1,
+                    xsize: 4,
+                    ysize: 4,
+                    dpi: 100.0,
+                },
             ],
         };
 

--- a/crates/core/src/ar2/image_set.rs
+++ b/crates/core/src/ar2/image_set.rs
@@ -63,8 +63,8 @@
 //!   [u8 × xsize*ysize]  raw grayscale pixels
 //! ```
 
-use byteorder::{LittleEndian, ReadBytesExt};
-use std::io::{self, Cursor, Read};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use std::io::{self, BufWriter, Cursor, Read, Write};
 use std::path::Path;
 
 /// A single image scale in the pyramid.
@@ -198,7 +198,7 @@ impl AR2ImageSetT {
 
         // Generate downscaled layers via area-averaging.
         for &target_dpi in &dpi_values[1..num] {
-            let layer = gen_image_layer(
+            let layer = gen_image_layer2(
                 &scales[0].img_bw,
                 base_xsize,
                 base_ysize,
@@ -242,6 +242,68 @@ impl AR2ImageSetT {
 
         Ok(AR2ImageSetT { scale: scales })
     }
+
+    /// Save the image set to an `.iset` file on disk.
+    ///
+    /// Writes the **legacy (ARToolKit v4.x) raw pixel format** so that the
+    /// resulting file is readable by both the Rust [`load()`](Self::load)
+    /// and the C/C++ `ar2LoadImageSet()` functions.
+    ///
+    /// ## Binary layout (little-endian)
+    ///
+    /// ```text
+    /// [i32 LE]  num_scales          — number of pyramid levels
+    /// For each scale:
+    ///   [i32 LE]  xsize             — width in pixels
+    ///   [i32 LE]  ysize             — height in pixels
+    ///   [f32 LE]  dpi               — resolution in dots-per-inch
+    ///   [u8 × xsize*ysize]          — raw grayscale pixels (row-major)
+    /// ```
+    pub fn save<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        let file = std::fs::File::create(path)?;
+        let mut w = BufWriter::new(file);
+        self.write_to(&mut w)?;
+        w.flush()
+    }
+
+    /// Serialize the image set into an in-memory byte vector.
+    ///
+    /// Uses the same legacy binary format as [`save()`](Self::save).
+    pub fn to_bytes(&self) -> io::Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        self.write_to(&mut buf)?;
+        Ok(buf)
+    }
+
+    /// Write the image set to any [`Write`] implementor.
+    ///
+    /// This is the shared serialization core used by both [`save()`](Self::save)
+    /// and [`to_bytes()`](Self::to_bytes). The field ordering mirrors
+    /// [`read_legacy_format()`] so that `write_to` → `read_legacy_format` is a
+    /// lossless roundtrip.
+    fn write_to<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        if self.scale.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "image set has no scales to write",
+            ));
+        }
+
+        // Number of scales.
+        writer.write_i32::<LittleEndian>(self.scale.len() as i32)?;
+
+        for img in &self.scale {
+            // Per-scale header.
+            writer.write_i32::<LittleEndian>(img.xsize)?;
+            writer.write_i32::<LittleEndian>(img.ysize)?;
+            writer.write_f32::<LittleEndian>(img.dpi)?;
+
+            // Raw grayscale pixel data.
+            writer.write_all(&img.img_bw)?;
+        }
+
+        Ok(())
+    }
 }
 
 /// Parse JFIF APP0 marker to extract DPI.
@@ -276,10 +338,102 @@ fn parse_jfif_dpi(jpeg_data: &[u8]) -> Option<f32> {
     }
 }
 
-/// Generate a downscaled image layer via area-averaging.
+/// Generate a downscaled image layer from a colour or grayscale source.
 ///
-/// Ported from `ar2GenImageLayer2` in the C source.
-pub(crate) fn gen_image_layer(
+/// Ported from `ar2GenImageLayer1` in the C source. This is the entry-point
+/// variant that handles colour-to-grayscale conversion during downscale.
+///
+/// # Arguments
+///
+/// * `src` — Raw pixel data. Length must be `src_xsize * src_ysize * nc`.
+/// * `src_xsize` — Source image width in pixels.
+/// * `src_ysize` — Source image height in pixels.
+/// * `nc` — Number of colour channels: `1` for grayscale, `3` for RGB.
+/// * `src_dpi` — Source resolution in dots-per-inch.
+/// * `target_dpi` — Desired output resolution in dots-per-inch.
+///
+/// For `nc == 3` the RGB channels are averaged to produce a single grayscale
+/// value per pixel. For `nc == 1` the behaviour is identical to
+/// [`gen_image_layer2()`].
+pub(crate) fn gen_image_layer1(
+    src: &[u8],
+    src_xsize: i32,
+    src_ysize: i32,
+    nc: i32,
+    src_dpi: f32,
+    target_dpi: f32,
+) -> AR2ImageT {
+    let scale = target_dpi / src_dpi;
+    let dst_xsize = ((src_xsize as f32) * scale + 0.5) as i32;
+    let dst_ysize = ((src_ysize as f32) * scale + 0.5) as i32;
+
+    if dst_xsize <= 0 || dst_ysize <= 0 {
+        return AR2ImageT {
+            img_bw: Vec::new(),
+            xsize: 0,
+            ysize: 0,
+            dpi: target_dpi,
+        };
+    }
+
+    let mut dst = vec![0u8; (dst_xsize * dst_ysize) as usize];
+    let inv_scale = src_dpi / target_dpi;
+    let nc_u = nc as usize;
+
+    for dy in 0..dst_ysize {
+        for dx in 0..dst_xsize {
+            let sx_start = (dx as f32 * inv_scale) as i32;
+            let sy_start = (dy as f32 * inv_scale) as i32;
+            let sx_end = (((dx + 1) as f32) * inv_scale).ceil() as i32;
+            let sy_end = (((dy + 1) as f32) * inv_scale).ceil() as i32;
+
+            let sx_end = sx_end.min(src_xsize);
+            let sy_end = sy_end.min(src_ysize);
+
+            let mut sum = 0u32;
+            let mut count = 0u32;
+            for sy in sy_start..sy_end {
+                for sx in sx_start..sx_end {
+                    let base = ((sy * src_xsize + sx) as usize) * nc_u;
+                    // Sum all channels (for nc=1 this is just the grayscale
+                    // value; for nc=3 we sum R+G+B).
+                    for ch in 0..nc_u {
+                        sum += src[base + ch] as u32;
+                    }
+                    count += 1;
+                }
+            }
+
+            // Divide by count * nc to average across both pixels and channels,
+            // producing a single grayscale value.
+            let divisor = count * (nc as u32);
+            dst[(dy * dst_xsize + dx) as usize] = if divisor > 0 { (sum / divisor) as u8 } else { 0 };
+        }
+    }
+
+    AR2ImageT {
+        img_bw: dst,
+        xsize: dst_xsize,
+        ysize: dst_ysize,
+        dpi: target_dpi,
+    }
+}
+
+/// Generate a downscaled image layer from an already-grayscale source via
+/// area-averaging.
+///
+/// Ported from `ar2GenImageLayer2` in the C source. Unlike
+/// [`gen_image_layer1()`] this function assumes the input is already
+/// single-channel grayscale and does not perform colour conversion.
+///
+/// # Arguments
+///
+/// * `src` — Grayscale pixel data. Length must be `src_xsize * src_ysize`.
+/// * `src_xsize` — Source image width in pixels.
+/// * `src_ysize` — Source image height in pixels.
+/// * `src_dpi` — Source resolution in dots-per-inch.
+/// * `target_dpi` — Desired output resolution in dots-per-inch.
+pub(crate) fn gen_image_layer2(
     src: &[u8],
     src_xsize: i32,
     src_ysize: i32,
@@ -358,15 +512,43 @@ mod tests {
     }
 
     #[test]
-    fn test_gen_image_layer_halves() {
+    fn test_gen_image_layer2_halves() {
         // 4x4 white image at 200 DPI → 2x2 at 100 DPI.
         let src = vec![255u8; 16];
-        let layer = gen_image_layer(&src, 4, 4, 200.0, 100.0);
+        let layer = gen_image_layer2(&src, 4, 4, 200.0, 100.0);
         assert_eq!(layer.xsize, 2);
         assert_eq!(layer.ysize, 2);
         assert_eq!(layer.dpi, 100.0);
         assert_eq!(layer.img_bw.len(), 4);
         assert!(layer.img_bw.iter().all(|&v| v == 255));
+    }
+
+    /// Test gen_image_layer1 with RGB input: average R+G+B per pixel.
+    #[test]
+    fn test_gen_image_layer1_rgb() {
+        // 4×4 RGB image (12 bytes per row, 48 bytes total).
+        // Each pixel: R=60, G=120, B=180 → grayscale avg = (60+120+180)/3 = 120.
+        let mut src = Vec::new();
+        for _ in 0..(4 * 4) {
+            src.extend_from_slice(&[60u8, 120, 180]);
+        }
+        let layer = gen_image_layer1(&src, 4, 4, 3, 200.0, 100.0);
+        assert_eq!(layer.xsize, 2);
+        assert_eq!(layer.ysize, 2);
+        assert_eq!(layer.dpi, 100.0);
+        assert_eq!(layer.img_bw.len(), 4);
+        // Each output pixel averages 4 source pixels that are each 120 gray.
+        assert!(layer.img_bw.iter().all(|&v| v == 120));
+    }
+
+    /// Test gen_image_layer1 with grayscale (nc=1) behaves like layer2.
+    #[test]
+    fn test_gen_image_layer1_grayscale() {
+        let src = vec![200u8; 16];
+        let layer = gen_image_layer1(&src, 4, 4, 1, 200.0, 100.0);
+        assert_eq!(layer.xsize, 2);
+        assert_eq!(layer.ysize, 2);
+        assert!(layer.img_bw.iter().all(|&v| v == 200));
     }
 
     #[test]
@@ -386,5 +568,45 @@ mod tests {
         assert_eq!(set.scale[0].ysize, 2);
         assert_eq!(set.scale[0].dpi, 100.0);
         assert_eq!(set.scale[0].img_bw, vec![10, 20, 30, 40]);
+    }
+
+    /// Roundtrip test: build → save() → load() → compare.
+    ///
+    /// Verifies that the save/load cycle is lossless for a 2-level image
+    /// pyramid written in legacy raw format.
+    #[test]
+    fn test_image_set_save_load_roundtrip() {
+        // Level 0: 8×8 at 200 DPI — checkerboard pattern.
+        let mut pixels_0 = vec![0u8; 64];
+        for y in 0..8i32 {
+            for x in 0..8i32 {
+                pixels_0[(y * 8 + x) as usize] = if (x + y) % 2 == 0 { 200 } else { 50 };
+            }
+        }
+
+        // Level 1: 4×4 at 100 DPI — gradient.
+        let mut pixels_1 = vec![0u8; 16];
+        for i in 0..16 {
+            pixels_1[i] = (i as u8) * 16;
+        }
+
+        let original = AR2ImageSetT {
+            scale: vec![
+                AR2ImageT { img_bw: pixels_0, xsize: 8, ysize: 8, dpi: 200.0 },
+                AR2ImageT { img_bw: pixels_1, xsize: 4, ysize: 4, dpi: 100.0 },
+            ],
+        };
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        original.save(tmp.path()).unwrap();
+        let loaded = AR2ImageSetT::load(tmp.path()).unwrap();
+
+        assert_eq!(loaded.num(), original.num());
+        for (orig, load) in original.scale.iter().zip(loaded.scale.iter()) {
+            assert_eq!(load.xsize, orig.xsize);
+            assert_eq!(load.ysize, orig.ysize);
+            assert_eq!(load.dpi, orig.dpi);
+            assert_eq!(load.img_bw, orig.img_bw);
+        }
     }
 }

--- a/crates/core/tests/nft_pipeline.rs
+++ b/crates/core/tests/nft_pipeline.rs
@@ -1,0 +1,109 @@
+/*
+ *  tests/nft_pipeline.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! End-to-end NFT marker creation pipeline test.
+//!
+//! This is the first complete Rust-only NFT marker creation test:
+//! load image → generate features → save .fset → reload → verify roundtrip.
+
+use webarkitlib_rs::ar2::feature_map::ar2_gen_feature_map;
+use webarkitlib_rs::ar2::feature_set::AR2FeatureSetT;
+
+/// Full NFT marker creation pipeline: image → feature map → save → load.
+///
+/// Loads `pinball.jpg`, generates features via `ar2_gen_feature_map`,
+/// saves the resulting `.fset` to a temporary file, reloads it, and
+/// verifies that the roundtrip is lossless.
+///
+/// This test is `#[ignore]` because `ar2_gen_feature_map` is
+/// compute-intensive. Run it explicitly with:
+///
+/// ```bash
+/// cargo test -p webarkitlib-rs --test nft_pipeline -- --ignored --release
+/// ```
+#[test]
+#[ignore]
+fn test_full_nft_marker_creation_pipeline() {
+    // Load pinball.jpg and convert to grayscale.
+    let img = image::open("examples/Data/pinball.jpg").expect("failed to open pinball.jpg");
+    let gray = img.to_luma8();
+    let w = gray.width() as i32;
+    let h = gray.height() as i32;
+    let data = gray.into_raw();
+
+    // Generate features.
+    let feature_set =
+        ar2_gen_feature_map(&data, w, h, 72.0, 16, 64).expect("ar2_gen_feature_map failed");
+    assert!(
+        !feature_set.list.is_empty(),
+        "feature set should have at least one scale"
+    );
+    let total_features: usize = feature_set.list.iter().map(|p| p.coord.len()).sum();
+    assert!(total_features > 0, "should produce at least one feature");
+
+    // Save to a temporary .fset file.
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    feature_set.save(tmp.path()).unwrap();
+
+    // Reload and verify roundtrip.
+    let reloaded = AR2FeatureSetT::load(tmp.path()).unwrap();
+    assert_eq!(
+        reloaded.num(),
+        feature_set.num(),
+        "scale count must match after roundtrip"
+    );
+
+    // Verify each scale's metadata and first coordinate.
+    for (orig_pts, load_pts) in feature_set.list.iter().zip(reloaded.list.iter()) {
+        assert_eq!(load_pts.scale, orig_pts.scale);
+        assert_eq!(load_pts.num(), orig_pts.num());
+        assert!((load_pts.maxdpi - orig_pts.maxdpi).abs() < 1e-4);
+        assert!((load_pts.mindpi - orig_pts.mindpi).abs() < 1e-4);
+
+        if !orig_pts.coord.is_empty() {
+            let oc = &orig_pts.coord[0];
+            let lc = &load_pts.coord[0];
+            assert_eq!(lc.x, oc.x);
+            assert_eq!(lc.y, oc.y);
+            assert!(
+                (lc.mx - oc.mx).abs() < 1e-4,
+                "first coord mx mismatch: {} vs {}",
+                lc.mx,
+                oc.mx
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Completes M5-2 by adding write support for AR2 image sets and feature sets, and aligning the `gen_image_layer` naming with the C source.

Closes #38, closes #39. Builds on the `ar2_gen_feature_map` port from #40 (already merged into `dev` as 22521d0) by enabling full in-Rust NFT marker creation: image → features → `.fset`/`.iset` on disk.

## Changes

- **`AR2FeatureSetT::save()` / `to_bytes()`** in `feature_set.rs` — serialize to the little-endian `.fset` binary layout expected by both the Rust loader and C's `ar2LoadFeatureSet()`. Shared `write_to()` core mirrors `read_from()` field-for-field.
- **`AR2ImageSetT::save()` / `to_bytes()`** in `image_set.rs` — writes the legacy raw `.iset` format (`[num_scales][xsize][ysize][dpi][pixels…]`). No JPEG encoder dependency needed.
- **`gen_image_layer` → `gen_image_layer2`** — renamed to match C's `ar2GenImageLayer2` (grayscale→grayscale downscale). Call site in `feature_map.rs::build_pyramid()` updated.
- **New `gen_image_layer1()`** — ports C's `ar2GenImageLayer1`. Accepts RGB (`nc=3`) or grayscale (`nc=1`) source and produces a grayscale `AR2ImageT` via area-averaging with per-pixel channel summing.
- **New integration test** `crates/core/tests/nft_pipeline.rs` (`#[ignore]`) — loads `examples/Data/pinball.jpg`, runs `ar2_gen_feature_map`, saves the `.fset` to a temp file, reloads, and asserts a lossless roundtrip.
- Thorough doc comments on all new/modified public APIs cross-referencing the C source.

## Test plan

- [x] `cargo test -p webarkitlib-rs -- ar2::image_set ar2::feature_set` — new roundtrip tests pass (`test_feature_set_save_load_roundtrip`, `test_feature_set_to_bytes_from_bytes_roundtrip`, `test_image_set_save_load_roundtrip`, `test_gen_image_layer1_rgb`, `test_gen_image_layer1_grayscale`, `test_gen_image_layer2_halves`)
- [x] `cargo test -p webarkitlib-rs` — full suite green
- [x] `cargo test -p webarkitlib-rs --test nft_pipeline -- --ignored` — end-to-end pinball pipeline (compute-intensive; run explicitly)
- [x] `cargo clippy -p webarkitlib-rs` — clean (one pre-existing `unused_variable: search_size` warning in `feature_map.rs`, unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)