### PR TITLE
fix(kpm): fix generate() producing 0 FREAK features in .fset3

### DIFF
--- a/crates/core/src/kpm/backend.rs
+++ b/crates/core/src/kpm/backend.rs
@@ -234,6 +234,28 @@ pub trait FreakMatcherBackend: Send {
     ///
     /// Returns an empty slice if not available.
     fn get_3d_feature_points(&self, image_id: usize) -> &[Point3d];
+
+    /// Extract FREAK features and descriptors from a grayscale image
+    /// **without** storing them in the database.
+    ///
+    /// Returns `(points, descriptors)` where `descriptors.len() == points.len() * 96`.
+    /// Returns `Ok((vec![], vec![]))` if no features were detected.
+    ///
+    /// Use this to obtain the full feature data (2D coords, angle, scale,
+    /// maxima, 96-byte descriptor) needed to build a complete
+    /// [`KpmRefDataSet`](crate::kpm::types::KpmRefDataSet).
+    ///
+    /// # Arguments
+    ///
+    /// * `image`  — grayscale pixel data (one byte per pixel, row-major).
+    /// * `width`  — image width in pixels.
+    /// * `height` — image height in pixels.
+    fn extract_features(
+        &mut self,
+        image: &[u8],
+        width: usize,
+        height: usize,
+    ) -> Result<(Vec<FeaturePoint>, Vec<u8>), KpmError>;
 }
 
 #[cfg(test)]

--- a/crates/core/src/kpm/cpp_backend.rs
+++ b/crates/core/src/kpm/cpp_backend.rs
@@ -371,6 +371,91 @@ impl FreakMatcherBackend for CppFreakMatcher {
         &self.cached_query_points
     }
 
+    fn extract_features(
+        &mut self,
+        image: &[u8],
+        width: usize,
+        height: usize,
+    ) -> Result<(Vec<FeaturePoint>, Vec<u8>), KpmError> {
+        self.check_ptr()?;
+
+        let expected = width * height;
+        if image.len() < expected {
+            return Err(KpmError::InvalidInput(format!(
+                "buffer too small: got {} bytes, need {expected}",
+                image.len()
+            )));
+        }
+
+        // Step 1: count-only call (NULL output arrays).
+        // SAFETY: `self.ptr` is valid. Passing null output pointers is the
+        // documented "count only" mode defined in kpm_c_api.h.
+        let count = unsafe {
+            kpm_ffi::kpm_extract_features(
+                self.ptr,
+                image.as_ptr(),
+                width as i32,
+                height as i32,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+
+        if count < 0 {
+            return Err(KpmError::InternalError(
+                "kpm_extract_features failed".to_string(),
+            ));
+        }
+        if count == 0 {
+            return Ok((vec![], vec![]));
+        }
+
+        let n = count as usize;
+        let mut xs = vec![0.0f32; n];
+        let mut ys = vec![0.0f32; n];
+        let mut angles = vec![0.0f32; n];
+        let mut scales = vec![0.0f32; n];
+        let mut maxima = vec![0i32; n];
+        let mut descs = vec![0u8; n * 96];
+
+        // Step 2: fill all output arrays.
+        // SAFETY: `self.ptr` is valid. All output buffers have exactly `n`
+        // elements / n*96 bytes. FREAK extraction is deterministic on the
+        // same image, so the count cannot increase between the two calls.
+        unsafe {
+            kpm_ffi::kpm_extract_features(
+                self.ptr,
+                image.as_ptr(),
+                width as i32,
+                height as i32,
+                xs.as_mut_ptr(),
+                ys.as_mut_ptr(),
+                angles.as_mut_ptr(),
+                scales.as_mut_ptr(),
+                maxima.as_mut_ptr(),
+                descs.as_mut_ptr(),
+                n as i32,
+            );
+        }
+
+        let points = (0..n)
+            .map(|i| FeaturePoint {
+                x: xs[i],
+                y: ys[i],
+                angle: angles[i],
+                scale: scales[i],
+                maxima: maxima[i] != 0,
+            })
+            .collect();
+
+        Ok((points, descs))
+    }
+
     fn get_3d_feature_points(&self, image_id: usize) -> &[Point3d] {
         // SAFETY: No other thread can access `self` concurrently — the struct
         // is `Send` but not `Sync`, and all `&mut self` methods are exclusive.

--- a/crates/core/src/kpm/handle.rs
+++ b/crates/core/src/kpm/handle.rs
@@ -390,6 +390,15 @@ mod tests {
         fn get_3d_feature_points(&self, _image_id: usize) -> &[Point3d] {
             todo!()
         }
+
+        fn extract_features(
+            &mut self,
+            _image: &[u8],
+            _width: usize,
+            _height: usize,
+        ) -> Result<(Vec<FeaturePoint>, Vec<u8>), KpmError> {
+            todo!()
+        }
     }
 
     #[test]

--- a/crates/core/src/kpm/kpm_c_api.cpp
+++ b/crates/core/src/kpm/kpm_c_api.cpp
@@ -240,4 +240,45 @@ int kpm_matched_id(KpmOpaqueHandle* handle) {
     return handle->db->matchedId();
 }
 
+int kpm_extract_features(KpmOpaqueHandle* handle,
+                         const unsigned char* image, int w, int h,
+                         float* x_out, float* y_out,
+                         float* angle_out, float* scale_out,
+                         int* maxima_out,
+                         unsigned char* desc_out,
+                         int max_features) {
+    if (!handle || !handle->db || !image || w <= 0 || h <= 0) {
+        return -1;
+    }
+
+    std::vector<vision::FeaturePoint> featurePoints;
+    std::vector<unsigned char> descriptors;
+    handle->db->computeFreakFeaturesAndDescriptors(
+        const_cast<unsigned char*>(image),
+        static_cast<size_t>(w), static_cast<size_t>(h),
+        featurePoints, descriptors);
+
+    int count = static_cast<int>(featurePoints.size());
+
+    // Count-only mode: caller passes NULL for output arrays.
+    if (x_out == nullptr) {
+        return count;
+    }
+
+    int n = (count < max_features) ? count : max_features;
+    for (int i = 0; i < n; i++) {
+        x_out[i]      = featurePoints[i].x;
+        y_out[i]      = featurePoints[i].y;
+        angle_out[i]  = featurePoints[i].angle;
+        scale_out[i]  = featurePoints[i].scale;
+        maxima_out[i] = featurePoints[i].maxima ? 1 : 0;
+    }
+    if (desc_out && !descriptors.empty()) {
+        std::memcpy(desc_out, descriptors.data(),
+                    static_cast<size_t>(n) * 96);
+    }
+
+    return n;
+}
+
 } // extern "C"

--- a/crates/core/src/kpm/kpm_c_api.h
+++ b/crates/core/src/kpm/kpm_c_api.h
@@ -95,6 +95,28 @@ int kpm_get_3d_feature_points(KpmOpaqueHandle* handle, int image_id,
 /* Return the matched image ID from the most recent query, or -1. */
 int kpm_matched_id(KpmOpaqueHandle* handle);
 
+/* ---- Feature extraction without database storage (#51) ---- */
+
+/* Extract FREAK features and descriptors from an image without storing them.
+ *
+ * If x_out is NULL: returns the feature count and ignores all output arrays.
+ * If x_out is not NULL: fills at most min(count, max_features) entries into
+ *   each output array and returns the actual feature count.
+ *
+ * Output array sizes (when x_out != NULL):
+ *   x_out / y_out / angle_out / scale_out: max_features floats each.
+ *   maxima_out: max_features ints.
+ *   desc_out:   max_features * 96 unsigned chars.
+ *
+ * Returns feature count (>= 0) on success, -1 on error. */
+int kpm_extract_features(KpmOpaqueHandle* handle,
+                         const unsigned char* image, int w, int h,
+                         float* x_out, float* y_out,
+                         float* angle_out, float* scale_out,
+                         int* maxima_out,
+                         unsigned char* desc_out,
+                         int max_features);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crates/core/src/kpm/ref_data_set.rs
+++ b/crates/core/src/kpm/ref_data_set.rs
@@ -283,20 +283,26 @@ impl KpmRefDataSet {
             resized = compressed;
         }
 
-        // 3. Feed into the backend for feature extraction.
-        matcher.add_image(&resized, xsize2, ysize2, image_no as usize)?;
-
-        // 4. Retrieve detected feature points from the backend.
-        let points = matcher.query_feature_points().to_vec();
+        // 3. Extract FREAK features and descriptors (no database storage).
+        //    Fix for issue #51: the previous code called add_image() then
+        //    query_feature_points(), but query_feature_points() returns the
+        //    query-side cache (populated only by query(), not add_image()).
+        //    extract_features() returns the actual reference features with
+        //    their full 96-byte descriptors.
+        let (points, descriptors) = matcher.extract_features(&resized, xsize2, ysize2)?;
         let num = points.len();
 
-        // 5. Compute scale factor and offset for 3D coordinate conversion.
+        // 4. Compute scale factor and pixel-to-mm offset.
+        //    Formula matches the original C++ kpmRefDataSet.cpp (kpmGenRefDataSet):
+        //      coord3D.x = (x * scale + half_scale) / dpi * 25.4  [mm, top-left origin]
+        //      coord3D.y = ((ysize - half_scale) - y * scale) / dpi * 25.4
+        //    where x/y are in the resized image and ysize is the ORIGINAL height.
         let scale = proc_mode.scale_factor();
         let half_scale = scale / 2.0;
 
-        // 6. Build ref_point array.
+        // 5. Build ref_point array with real descriptors.
         let mut ref_point = Vec::with_capacity(num);
-        for pt in &points {
+        for (i, pt) in points.iter().enumerate() {
             let mut y = pt.y;
             if comp_mode == KpmCompMode::CompY {
                 y *= 2.0;
@@ -305,6 +311,10 @@ impl KpmRefDataSet {
             let coord3d_x = (pt.x * scale + half_scale) / dpi * MM_PER_INCH;
             let coord3d_y = ((ysize as f32 - half_scale) - pt.y * scale) / dpi * MM_PER_INCH;
 
+            let desc_start = i * FREAK_SUB_DIMENSION;
+            let mut v = [0u8; FREAK_SUB_DIMENSION];
+            v.copy_from_slice(&descriptors[desc_start..desc_start + FREAK_SUB_DIMENSION]);
+
             ref_point.push(KpmRefData {
                 coord2d: KpmCoord2D { x: pt.x, y },
                 coord3d: KpmCoord2D {
@@ -312,7 +322,7 @@ impl KpmRefDataSet {
                     y: coord3d_y,
                 },
                 feature_vec: FreakFeature {
-                    v: [0u8; FREAK_SUB_DIMENSION], // descriptors not exposed via trait yet
+                    v,
                     angle: pt.angle,
                     scale: pt.scale,
                     maxima: if pt.maxima { 1 } else { 0 },
@@ -322,7 +332,7 @@ impl KpmRefDataSet {
             });
         }
 
-        // 7. Build page info.
+        // 6. Build page info.
         let page_info = vec![KpmPageInfo {
             page_no,
             image_num: 1,


### PR DESCRIPTION
## Summary

Fixes #51 — `KpmRefDataSet::generate()` produced 0 FREAK features, making `.fset3` files empty and unusable for AR tracking initialization.

**Root cause:** two bugs in the KPM ffi-backend pipeline:
1. `generate()` called `query_feature_points()` after `add_image()`, but that method returns the query-side cache (only populated by `query()`, never by `add_image()`) — always empty during NFT generation
2. `CppFreakMatcher::add_image()` hardcoded DPI=72 regardless of the actual pyramid scale DPI

**Fix:** Added `kpm_extract_features()` C API that calls `computeFreakFeaturesAndDescriptors()` without storing in the visual database. `generate()` now uses `extract_features()` to get real 2D coords + 96-byte FREAK descriptors, computes 3D coords in Rust using the correct top-left-origin formula matching the original C++ `kpmGenRefDataSet`, and builds `KpmRefDataSet` with fully populated descriptors.

- **Before:** `[fset3] 0 FREAK features`
- **After:** `[fset3] 7081 FREAK features` (913 KB, 83/96 non-zero descriptor bytes per feature)

## Changes

| File | Change |
|---|---|
| `kpm_c_api.h/.cpp` | New `kpm_extract_features()` — extract-only, no DB storage |
| `backend.rs` | New `extract_features()` on `FreakMatcherBackend` trait |
| `cpp_backend.rs` | `CppFreakMatcher::extract_features()` impl (two-call pattern) |
| `handle.rs` | `MockBackend` stub for new trait method |
| `ref_data_set.rs` | `generate()` rewritten to use `extract_features()` |

## Test plan

- [x] `cargo test -p webarkitlib-rs --features ffi-backend --lib` — 67 passed
- [x] `cargo clippy -p webarkitlib-rs --features ffi-backend` — no warnings
- [x] `cargo run --example nft_marker_gen --features ffi-backend --release` — verified 7081 features with real descriptors

🤖 Generated with [Claude Code](https://claude.com/claude-code)