### PR TITLE
feat(ar2): add JPEG compression to .iset save

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,32 @@ cargo run --example simple
 
 This example loads a camera parameter file, a marker (pattern or barcode), and a sample image, performing detection and outputting the 3D pose extrinsics.
 
+#### NFT Marker Generation Example
+
+Generate NFT (Natural Feature Tracking) marker files compatible with ARnft and NFT-Marker-Creator-App:
+
+```bash
+cargo run --features ffi-backend --example nft_marker_gen -- \
+  --input path/to/image.jpg \
+  --output path/to/output_name \
+  --dpi 220
+```
+
+This produces three files:
+- **`output_name.iset`** — JPEG-compressed image pyramid (~300 KB, matches C++ `ar2WriteImageSet()` format)
+- **`output_name.fset`** — Feature map with one entry per pyramid level
+- **`output_name.fset3`** — FREAK descriptors for KPM-based recognition
+
+**Options:**
+
+| Flag | Long form | Description | Default |
+|------|-----------|-------------|---------|
+| `-i` | `--input` | Path to the source image (JPEG/PNG) | required |
+| `-o` | `--output` | Output base path (without extension) | required |
+| `-d` | `--dpi` | Source image resolution in DPI | required |
+| `-l` | `--level` | Tracking extraction level (0–4) | `2` |
+| `-n` | `--search-feature-num` | Max features per pyramid level | `250` |
+
 #### Barcode Detection Example
 
 A unified, parameterized barcode example is available for testing all supported matrix code types:
@@ -144,8 +170,8 @@ cargo bench -- --save-baseline milestone-20260307
 The workspace contains two crates:
 
 - **`crates/core`** (`webarkitlib-rs`): The unified core AR engine (pure Rust), including:
-  - `ar2` module: NFT tracking algorithms, `.iset` / `.fset` marker I/O.
-  - `kpm` module: Keypoint Matching with pluggable backends (Rust + C++ FFI).
+  - `ar2` module: NFT marker generation pipeline — image pyramid (`ar2_gen_image_set`), feature map (`ar2_gen_feature_map`), JPEG-compressed `.iset` save, `.fset` / `.fset3` I/O.
+  - `kpm` module: Keypoint Matching with pluggable backends (Rust + C++ FFI), FREAK descriptor extraction.
   - Core modules: image processing, pattern matching, labeling, ICP, pose estimation.
 - **`crates/wasm`** (`webarkitlib-wasm`): WASM bindings, dual-build scripts, and diagnostic web demo.
 - `benchmarks`: C vs Rust performance comparison suite.
@@ -158,6 +184,11 @@ The workspace contains two crates:
 - **M1 -- KPM/NFT Core (partial)**: Ported the initial KPM (Keypoint Matching) scaffolding -- binary feature types, matching orchestration, ICP-based pose refinement, and `.fset3` / `.iset` / `.fset` I/O. The C++ FreakMatcher FFI backend works but the full pipeline is not yet wired end-to-end.
 - **M2 -- AR2 I/O**: Ported AR2 image set (`.iset`) and feature set (`.fset`) binary I/O from C to Rust.
 - **M3 -- Architectural Consolidation**: Unified the workspace from 4 crates down to 2 (`webarkitlib-rs` + `webarkitlib-wasm`), with KPM and AR2 as submodules of the core crate.
+- **M4 -- Working NFT Marker Generator**: End-to-end `nft_marker_gen` example producing `.iset` / `.fset` / `.fset3` files fully compatible with ARnft and NFT-Marker-Creator-App, including:
+  - JPEG-compressed `.iset` save matching C++ `ar2WriteImageSet()` format (~300 KB vs ~10 MB raw)
+  - All pyramid levels included in `.fset` (including 0-feature levels), matching C++ output exactly
+  - FREAK descriptor extraction via `kpm_extract_features` C API (7000+ features per marker)
+  - Detailed step-by-step logging with timestamps and per-level statistics
 
 ### 🎯 Short-term Goals (toward v1.0.0)
 - **Complete KPM in idiomatic Rust**: Port the remaining KPM feature extraction and matching logic to pure Rust, removing the C++ FFI dependency, and ship a working end-to-end NFT example.

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -13,11 +13,11 @@ readme.workspace = true
 
 [dependencies]
 image = "0.25.0"
-imageproc = "0.25.0"
+imageproc = "0.26.0"
 byteorder = "1.5.0"
 jpeg-decoder = "0.3"
 log = "0.4.0"
-rand = "0.8.0"
+rand = "0.9"
 
 [build-dependencies]
 cc = "1"
@@ -34,7 +34,7 @@ dual-mode = []
 
 [dev-dependencies]
 chrono = "0.4"
-env_logger = "0.10.0"
+env_logger = "0.11"
 criterion = "0.5.1"
 clap = { version = "4.5", features = ["derive"] }
 tempfile = "3"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -33,6 +33,7 @@ ffi-backend = []
 dual-mode = []
 
 [dev-dependencies]
+chrono = "0.4"
 env_logger = "0.10.0"
 criterion = "0.5.1"
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/core/examples/nft_marker_gen.rs
+++ b/crates/core/examples/nft_marker_gen.rs
@@ -59,6 +59,7 @@
 //! | `<output>.fset` | AR2 feature points per scale (always generated) |
 //! | `<output>.fset3` | KPM/FREAK keypoints (`ffi-backend` only) |
 
+use chrono::Local;
 use clap::Parser;
 use std::path::Path;
 use std::time::Instant;
@@ -128,6 +129,7 @@ fn file_kb(path: &Path) -> String {
 fn main() {
     let cli = Cli::parse();
     let start = Instant::now();
+    let start_time = Local::now();
 
     // -----------------------------------------------------------------------
     // Warn the user if .fset3 won't be generated (no ffi-backend).
@@ -156,6 +158,16 @@ fn main() {
     }
 
     // -----------------------------------------------------------------------
+    // Header
+    // -----------------------------------------------------------------------
+    println!("--");
+    println!(
+        "Generator started at {}",
+        start_time.format("%Y-%m-%d %H:%M:%S %z")
+    );
+    println!();
+
+    // -----------------------------------------------------------------------
     // Load input image as RGB.
     // -----------------------------------------------------------------------
     let img = image::open(&cli.input).unwrap_or_else(|e| {
@@ -165,11 +177,14 @@ fn main() {
     let rgb = img.to_rgb8();
     let w = rgb.width() as i32;
     let h = rgb.height() as i32;
+    let nc = 3;
     let pixels = rgb.into_raw(); // nc=3, length = w * h * 3
 
+    println!("Tracking Extraction Level = {}", cli.level);
+    println!();
     println!(
-        "Input:  {:?}  ({}×{}  {:.1} dpi  level {})",
-        cli.input, w, h, cli.dpi, cli.level
+        "Input:  {:?}  (xsize={}, ysize={}, channels={}, dpi={:.1})",
+        cli.input, w, h, nc, cli.dpi
     );
     println!("Output: {:?}.*", cli.output);
     println!();
@@ -177,12 +192,22 @@ fn main() {
     // -----------------------------------------------------------------------
     // Step 1: build image pyramid → .iset
     // -----------------------------------------------------------------------
-    let image_set = ar2_gen_image_set(&pixels, w, h, 3, cli.dpi).unwrap_or_else(|e| {
+    println!("Generating ImageSet...");
+    let step_start = Instant::now();
+
+    let image_set = ar2_gen_image_set(&pixels, w, h, nc, cli.dpi).unwrap_or_else(|e| {
         eprintln!("Error: ar2_gen_image_set failed: {}", e);
         std::process::exit(1);
     });
 
+    // Print DPI levels.
+    for (i, scale) in image_set.scale.iter().enumerate() {
+        println!("  Image DPI ({}): {:.6}", image_set.num() - i, scale.dpi);
+    }
+    println!();
+
     let iset_path = cli.output.with_extension("iset");
+    println!("Saving to {:?}...", iset_path);
     image_set.save(&iset_path).unwrap_or_else(|e| {
         eprintln!("Error: failed to save {:?}: {}", iset_path, e);
         std::process::exit(1);
@@ -191,43 +216,56 @@ fn main() {
     let first_dpi = image_set.scale.first().map_or(0.0, |s| s.dpi);
     let last_dpi = image_set.scale.last().map_or(0.0, |s| s.dpi);
     println!(
-        "[iset]  {} levels: {:.1} → {:.1} dpi   (saved {:?}, {})",
+        "  Done. {} levels: {:.1} -> {:.1} dpi  ({}, {:.1}s)",
         image_set.num(),
         first_dpi,
         last_dpi,
-        iset_path,
-        file_kb(&iset_path)
+        file_kb(&iset_path),
+        step_start.elapsed().as_secs_f64()
     );
+    println!();
 
     // -----------------------------------------------------------------------
     // Step 2: generate AR2 features → .fset
     // -----------------------------------------------------------------------
+    println!("Generating FeatureList...");
+    let step_start = Instant::now();
+
     // search_size = AR2_DEFAULT_GEN_FEATURE_MAP_SEARCH_SIZE1 = 10 (from C config.h)
     let feature_set = ar2_gen_feature_map(&image_set, 10, 250, cli.level).unwrap_or_else(|e| {
         eprintln!("Error: ar2_gen_feature_map failed: {}", e);
         std::process::exit(1);
     });
 
+    // Print per-level feature counts.
+    for pts in &feature_set.list {
+        let scale_img = &image_set.scale[pts.scale as usize];
+        println!(
+            "  {:.6} dpi ({}x{}): {} features selected",
+            scale_img.dpi,
+            scale_img.xsize,
+            scale_img.ysize,
+            pts.coord.len()
+        );
+    }
+    println!();
+
     let fset_path = cli.output.with_extension("fset");
+    println!("Saving FeatureSet to {:?}...", fset_path);
     feature_set.save(&fset_path).unwrap_or_else(|e| {
         eprintln!("Error: failed to save {:?}: {}", fset_path, e);
         std::process::exit(1);
     });
 
-    let counts: Vec<String> = feature_set
-        .list
-        .iter()
-        .map(|p| p.coord.len().to_string())
-        .collect();
     let total_features: usize = feature_set.list.iter().map(|p| p.coord.len()).sum();
     println!(
-        "[fset]  {} levels: {} features ({})   (saved {:?}, {})",
+        "  Done. {} levels, {} features total  ({}, {:.1}s)",
         feature_set.num(),
         total_features,
-        counts.join(" / "),
-        fset_path,
-        file_kb(&fset_path)
+        file_kb(&fset_path),
+        step_start.elapsed().as_secs_f64()
     );
+    println!();
 
     // -----------------------------------------------------------------------
     // Step 3: generate KPM/FREAK keypoints → .fset3  (ffi-backend only)
@@ -236,6 +274,9 @@ fn main() {
     {
         use webarkitlib_rs::kpm::types::KpmRefDataSet;
         use webarkitlib_rs::kpm::{CppFreakMatcher, KpmCompMode, KpmError, KpmProcMode};
+
+        println!("Generating FeatureSet3...");
+        let step_start = Instant::now();
 
         let fset3_path = cli.output.with_extension("fset3");
         let mut combined: Option<KpmRefDataSet> = None;
@@ -265,6 +306,10 @@ fn main() {
 
             match result {
                 Ok(ref_data) => {
+                    println!(
+                        "  ({}, {}) {:.6} dpi: Freak features - {}",
+                        scale.xsize, scale.ysize, scale.dpi, ref_data.num
+                    );
                     combined = Some(match combined.take() {
                         Some(mut existing) => {
                             existing.merge(ref_data);
@@ -274,7 +319,10 @@ fn main() {
                     });
                 }
                 Err(KpmError::InvalidInput(_)) => {
-                    // Scale too small — skip silently.
+                    println!(
+                        "  ({}, {}) {:.6} dpi: Freak features - 0 (scale too small)",
+                        scale.xsize, scale.ysize, scale.dpi
+                    );
                 }
                 Err(e) => {
                     eprintln!(
@@ -284,7 +332,9 @@ fn main() {
                 }
             }
         }
+        println!();
 
+        println!("Saving FeatureSet3 to {:?}...", fset3_path);
         if let Some(ref_data) = combined {
             let total_kpm = ref_data.num as usize;
             ref_data.save(&fset3_path).unwrap_or_else(|e| {
@@ -292,10 +342,10 @@ fn main() {
                 std::process::exit(1);
             });
             println!(
-                "[fset3] {} FREAK features   (saved {:?}, {})",
+                "  Done. {} FREAK features total  ({}, {:.1}s)",
                 total_kpm,
-                fset3_path,
-                file_kb(&fset3_path)
+                file_kb(&fset3_path),
+                step_start.elapsed().as_secs_f64()
             );
         } else {
             eprintln!("Warning: no KPM features extracted — .fset3 not written.");
@@ -308,6 +358,14 @@ fn main() {
     // -----------------------------------------------------------------------
     // Done
     // -----------------------------------------------------------------------
+    let finish_time = Local::now();
+    let elapsed = start.elapsed().as_secs_f64();
     println!();
-    println!("Done in {:.1}s", start.elapsed().as_secs_f64());
+    println!(
+        "Generator finished at {}",
+        finish_time.format("%Y-%m-%d %H:%M:%S %z")
+    );
+    println!("--");
+    println!();
+    println!("NFTMarkerGenerator took {:.6} seconds to execute", elapsed);
 }

--- a/crates/core/src/ar2/feature_map.rs
+++ b/crates/core/src/ar2/feature_map.rs
@@ -530,10 +530,6 @@ pub fn ar2_gen_feature_map(
             params.occ_size,
         );
 
-        if coords.is_empty() {
-            continue;
-        }
-
         // Compute mindpi: next lower DPI in the set, or current × 0.5.
         // Ports the scale1 loop in markerCreator.cpp.
         let mindpi = scales

--- a/crates/core/src/ar2/image_set.rs
+++ b/crates/core/src/ar2/image_set.rs
@@ -73,6 +73,13 @@ use std::path::Path;
 /// Matches `KPM_MINIMUM_IMAGE_SIZE` in `markerCreator.cpp`.
 const KPM_MINIMUM_IMAGE_SIZE: i32 = 28;
 
+/// Default JPEG quality for `.iset` file encoding.
+///
+/// Matches `AR2_DEFAULT_JPEG_IMAGE_QUALITY` in the C source (`imageSet.c`).
+/// Value 80 provides a good balance between file size (~300 KB for typical
+/// markers) and visual fidelity.
+const AR2_DEFAULT_JPEG_IMAGE_QUALITY: u8 = 80;
+
 /// A single image scale in the pyramid.
 #[derive(Debug, Clone)]
 pub struct AR2ImageT {
@@ -251,43 +258,100 @@ impl AR2ImageSetT {
 
     /// Save the image set to an `.iset` file on disk.
     ///
-    /// Writes the **legacy (ARToolKit v4.x) raw pixel format** so that the
-    /// resulting file is readable by both the Rust [`load()`](Self::load)
-    /// and the C/C++ `ar2LoadImageSet()` functions.
+    /// Writes the **JPEG-compressed format** matching the C++
+    /// `ar2WriteImageSet()`: only the base scale (highest DPI) is stored
+    /// as an embedded JPEG; lower scales are regenerated at load time.
+    /// This produces files ~30× smaller than the raw pixel format.
     ///
-    /// ## Binary layout (little-endian)
+    /// The JPEG quality defaults to 80, matching `AR2_DEFAULT_JPEG_IMAGE_QUALITY`.
+    ///
+    /// ## Binary layout
     ///
     /// ```text
-    /// [i32 LE]  num_scales          — number of pyramid levels
-    /// For each scale:
-    ///   [i32 LE]  xsize             — width in pixels
-    ///   [i32 LE]  ysize             — height in pixels
-    ///   [f32 LE]  dpi               — resolution in dots-per-inch
-    ///   [u8 × xsize*ysize]          — raw grayscale pixels (row-major)
+    /// [i32 LE]           num          — number of scales
+    /// [bytes]            JPEG data    — grayscale JPEG of scale[0] with DPI in JFIF
+    /// [f32 LE × (num-1)] DPI values   — for scales 1..num-1
     /// ```
     pub fn save<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         let file = std::fs::File::create(path)?;
         let mut w = BufWriter::new(file);
-        self.write_to(&mut w)?;
+        self.write_jpeg_to(&mut w, AR2_DEFAULT_JPEG_IMAGE_QUALITY)?;
+        w.flush()
+    }
+
+    /// Save the image set using the **legacy raw pixel format**.
+    ///
+    /// This produces larger files but is lossless. Useful for debugging
+    /// or when exact pixel values must be preserved.
+    pub fn save_raw<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        let file = std::fs::File::create(path)?;
+        let mut w = BufWriter::new(file);
+        self.write_raw_to(&mut w)?;
         w.flush()
     }
 
     /// Serialize the image set into an in-memory byte vector.
     ///
-    /// Uses the same legacy binary format as [`save()`](Self::save).
+    /// Uses the JPEG-compressed format. See [`save()`](Self::save).
     pub fn to_bytes(&self) -> io::Result<Vec<u8>> {
         let mut buf = Vec::new();
-        self.write_to(&mut buf)?;
+        self.write_jpeg_to(&mut buf, AR2_DEFAULT_JPEG_IMAGE_QUALITY)?;
         Ok(buf)
     }
 
-    /// Write the image set to any [`Write`] implementor.
+    /// Serialize the image set as raw pixels into an in-memory byte vector.
     ///
-    /// This is the shared serialization core used by both [`save()`](Self::save)
-    /// and [`to_bytes()`](Self::to_bytes). The field ordering mirrors
-    /// [`read_legacy_format()`] so that `write_to` → `read_legacy_format` is a
-    /// lossless roundtrip.
-    fn write_to<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+    /// Uses the legacy format. See [`save_raw()`](Self::save_raw).
+    pub fn to_bytes_raw(&self) -> io::Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        self.write_raw_to(&mut buf)?;
+        Ok(buf)
+    }
+
+    /// Write the image set in JPEG-compressed format.
+    ///
+    /// Matches the C++ `ar2WriteImageSet()` format: `num(i32)` +
+    /// JPEG blob (scale 0 with DPI embedded in JFIF) + trailing
+    /// DPI values (`f32 × (num-1)`).
+    fn write_jpeg_to<W: Write>(&self, writer: &mut W, quality: u8) -> io::Result<()> {
+        if self.scale.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "image set has no scales to write",
+            ));
+        }
+
+        let num = self.scale.len();
+        let base = &self.scale[0];
+
+        // 1. Write number of scales.
+        writer.write_i32::<LittleEndian>(num as i32)?;
+
+        // 2. Encode scale[0] as grayscale JPEG and embed DPI in JFIF header.
+        let jpeg_data = encode_grayscale_jpeg(
+            &base.img_bw,
+            base.xsize as u32,
+            base.ysize as u32,
+            base.dpi,
+            quality,
+        )?;
+        writer.write_all(&jpeg_data)?;
+
+        // 3. Write DPI values for scales 1..num-1.
+        for img in &self.scale[1..] {
+            writer.write_f32::<LittleEndian>(img.dpi)?;
+        }
+
+        Ok(())
+    }
+
+    /// Write the image set in legacy raw pixel format.
+    ///
+    /// This is the shared serialization core for [`save_raw()`](Self::save_raw)
+    /// and [`to_bytes_raw()`](Self::to_bytes_raw). The field ordering mirrors
+    /// [`read_legacy_format()`] so that `write_raw_to` → `read_legacy_format`
+    /// is a lossless roundtrip.
+    fn write_raw_to<W: Write>(&self, writer: &mut W) -> io::Result<()> {
         if self.scale.is_empty() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -440,6 +504,73 @@ pub fn ar2_gen_image_set(
     }
 
     Ok(AR2ImageSetT { scale: scales })
+}
+
+/// Encode grayscale pixels as a JPEG with DPI embedded in the JFIF header.
+///
+/// This mirrors the C `jpgwrite()` function from `AR2/jpeg.c`, which:
+/// 1. Encodes the grayscale image as a JPEG at the given quality level.
+/// 2. Sets the JFIF APP0 density fields to the specified DPI so that
+///    `ar2LoadImageSet()` (and our [`parse_jfif_dpi()`]) can recover
+///    the resolution at load time.
+///
+/// # JFIF density patch
+///
+/// The JFIF APP0 header has this layout after `SOI (0xFFD8)`:
+///
+/// ```text
+/// offset 2:  FF E0           — APP0 marker
+/// offset 4:  <length:2>      — segment length
+/// offset 6:  "JFIF\0"        — identifier (5 bytes)
+/// offset 11: <version:2>     — e.g. 1.1
+/// offset 13: <units:1>       — 0=no units, 1=DPI, 2=dots/cm
+/// offset 14: <Xdensity:2>    — big-endian u16
+/// offset 16: <Ydensity:2>    — big-endian u16
+/// ```
+///
+/// We patch bytes 13–17 to set `units=1` and `X/Y density = dpi`.
+fn encode_grayscale_jpeg(
+    pixels: &[u8],
+    width: u32,
+    height: u32,
+    dpi: f32,
+    quality: u8,
+) -> io::Result<Vec<u8>> {
+    use image::codecs::jpeg::JpegEncoder;
+    use image::ColorType;
+
+    let mut jpeg_buf: Vec<u8> = Vec::new();
+    {
+        let mut encoder = JpegEncoder::new_with_quality(&mut jpeg_buf, quality);
+        encoder
+            .encode(pixels, width, height, ColorType::L8.into())
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    }
+
+    // Patch the JFIF APP0 header to embed DPI.
+    // Ensure we have a valid JFIF header to patch.
+    if jpeg_buf.len() >= 18
+        && jpeg_buf[0] == 0xFF
+        && jpeg_buf[1] == 0xD8
+        && jpeg_buf[2] == 0xFF
+        && jpeg_buf[3] == 0xE0
+        && &jpeg_buf[6..11] == b"JFIF\0"
+    {
+        let dpi_u16 = (dpi as u16).max(1);
+        let dpi_bytes = dpi_u16.to_be_bytes();
+        jpeg_buf[13] = 1; // units = DPI
+        jpeg_buf[14] = dpi_bytes[0]; // X density high byte
+        jpeg_buf[15] = dpi_bytes[1]; // X density low byte
+        jpeg_buf[16] = dpi_bytes[0]; // Y density high byte
+        jpeg_buf[17] = dpi_bytes[1]; // Y density low byte
+    } else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "JPEG encoder did not produce a valid JFIF header; cannot embed DPI",
+        ));
+    }
+
+    Ok(jpeg_buf)
 }
 
 /// Parse JFIF APP0 marker to extract DPI.
@@ -807,12 +938,12 @@ mod tests {
         assert_eq!(set.scale[0].img_bw, vec![10, 20, 30, 40]);
     }
 
-    /// Roundtrip test: build → save() → load() → compare.
+    /// Roundtrip test: build → save_raw() → load() → compare.
     ///
     /// Verifies that the save/load cycle is lossless for a 2-level image
     /// pyramid written in legacy raw format.
     #[test]
-    fn test_image_set_save_load_roundtrip() {
+    fn test_image_set_save_raw_load_roundtrip() {
         // Level 0: 8×8 at 200 DPI — checkerboard pattern.
         let mut pixels_0 = vec![0u8; 64];
         for y in 0..8i32 {
@@ -845,7 +976,7 @@ mod tests {
         };
 
         let tmp = tempfile::NamedTempFile::new().unwrap();
-        original.save(tmp.path()).unwrap();
+        original.save_raw(tmp.path()).unwrap();
         let loaded = AR2ImageSetT::load(tmp.path()).unwrap();
 
         assert_eq!(loaded.num(), original.num());
@@ -855,5 +986,96 @@ mod tests {
             assert_eq!(load.dpi, orig.dpi);
             assert_eq!(load.img_bw, orig.img_bw);
         }
+    }
+
+    /// JPEG roundtrip test: build → save() → load() → compare dimensions/DPI.
+    ///
+    /// JPEG is lossy so pixel values won't match exactly, but dimensions,
+    /// DPI, and scale count must be preserved. Pixel values are checked
+    /// within a tolerance of ±5.
+    #[test]
+    fn test_image_set_save_jpeg_load_roundtrip() {
+        // 16×16 gradient at 150 DPI — single scale for simplicity.
+        let mut pixels = vec![0u8; 256];
+        for i in 0..256 {
+            pixels[i] = i as u8;
+        }
+
+        let original = AR2ImageSetT {
+            scale: vec![AR2ImageT {
+                img_bw: pixels.clone(),
+                xsize: 16,
+                ysize: 16,
+                dpi: 150.0,
+            }],
+        };
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        original.save(tmp.path()).unwrap();
+        let loaded = AR2ImageSetT::load(tmp.path()).unwrap();
+
+        assert_eq!(loaded.num(), 1);
+        assert_eq!(loaded.scale[0].xsize, 16);
+        assert_eq!(loaded.scale[0].ysize, 16);
+        assert!((loaded.scale[0].dpi - 150.0).abs() < 0.01);
+
+        // Check pixels within tolerance (JPEG is lossy).
+        for (orig, loaded) in pixels.iter().zip(loaded.scale[0].img_bw.iter()) {
+            let diff = (*orig as i16 - *loaded as i16).unsigned_abs();
+            assert!(
+                diff <= 5,
+                "pixel difference too large: orig={}, loaded={}, diff={}",
+                orig,
+                loaded,
+                diff
+            );
+        }
+    }
+
+    /// Verify encode_grayscale_jpeg embeds DPI correctly in JFIF header.
+    #[test]
+    fn test_encode_grayscale_jpeg_dpi() {
+        let pixels = vec![128u8; 8 * 8];
+        let jpeg = encode_grayscale_jpeg(&pixels, 8, 8, 220.0, 80).unwrap();
+
+        // Verify JPEG SOI marker.
+        assert_eq!(jpeg[0], 0xFF);
+        assert_eq!(jpeg[1], 0xD8);
+
+        // Verify DPI was embedded.
+        let dpi = parse_jfif_dpi(&jpeg);
+        assert_eq!(dpi, Some(220.0));
+    }
+
+    /// Multi-scale JPEG roundtrip: verifies trailing DPI values are preserved.
+    #[test]
+    fn test_image_set_jpeg_multiscale_roundtrip() {
+        let original = AR2ImageSetT {
+            scale: vec![
+                AR2ImageT {
+                    img_bw: vec![100u8; 16 * 16],
+                    xsize: 16,
+                    ysize: 16,
+                    dpi: 200.0,
+                },
+                AR2ImageT {
+                    img_bw: vec![100u8; 8 * 8],
+                    xsize: 8,
+                    ysize: 8,
+                    dpi: 100.0,
+                },
+            ],
+        };
+
+        let bytes = original.to_bytes().unwrap();
+        let loaded = AR2ImageSetT::from_bytes(&bytes).unwrap();
+
+        assert_eq!(loaded.num(), 2);
+        // Scale 0: from JPEG decode.
+        assert_eq!(loaded.scale[0].xsize, 16);
+        assert_eq!(loaded.scale[0].ysize, 16);
+        assert!((loaded.scale[0].dpi - 200.0).abs() < 0.01);
+        // Scale 1: regenerated from scale 0 at trailing DPI.
+        assert!((loaded.scale[1].dpi - 100.0).abs() < 0.01);
     }
 }

--- a/crates/core/src/ar2/tracking.rs
+++ b/crates/core/src/ar2/tracking.rs
@@ -887,8 +887,8 @@ pub fn ar2_select_template(
         }
 
         use rand::Rng;
-        let mut rng = rand::thread_rng();
-        let idx = available[rng.gen_range(0..available.len())];
+        let mut rng = rand::rng();
+        let idx = available[rng.random_range(0..available.len())];
         candidate[idx].flag = 1;
         idx as i32
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -42,6 +42,20 @@
 //! - Thresholding and labeling
 //! - Marker detection and identification
 //! - Pose estimation and matrix calculations
+//! - NFT (Natural Feature Tracking) marker generation pipeline
+//!
+//! ## NFT Marker Generation
+//!
+//! The [`ar2`] module provides a complete pipeline for generating NFT marker files
+//! compatible with ARnft and the C++ NFT-Marker-Creator-App:
+//!
+//! - [`ar2::ar2_gen_image_set`] — builds a multi-resolution image pyramid (`.iset`)
+//! - [`ar2::ar2_gen_feature_map`] — extracts gradient-based features at each pyramid level (`.fset`)
+//! - [`ar2::AR2ImageSetT::save`] — writes the image pyramid as a JPEG-compressed `.iset` file
+//!   matching `ar2WriteImageSet()` format (~300 KB vs ~10 MB raw)
+//! - [`kpm::KpmRefDataSet::generate`] — extracts FREAK descriptors for KPM recognition (`.fset3`)
+//!
+//! See the `nft_marker_gen` example for a complete end-to-end usage.
 //!
 //! ## Performance and SIMD
 //!


### PR DESCRIPTION
## Summary

This PR brings NFT marker generation output to full parity with the C++ NFT-Marker-Creator-App, and updates several outdated dependencies.

- **Fixes #55** — `.iset` files now use JPEG compression matching C++ `ar2WriteImageSet()` format (~300 KB vs ~10 MB raw)
- **Fixes #54** — `.fset` now includes all pyramid levels, even those with 0 features (19 levels vs 18)
- **Improved logging** — `nft_marker_gen` output mirrors NFT-Marker-Creator-App with timestamps, per-step timing, and per-level details
- **Dependency updates** — `imageproc` 0.26, `env_logger` 0.11, `rand` 0.9 (with `tracking.rs` API fix)

## Commits

| Commit | Change |
|---|---|
| `37db6f1` | feat(ar2): JPEG-compressed `.iset` save — fixes #55 |
| `76fd596` | fix(ar2): include all pyramid levels in `.fset` — fixes #54 |
| `61be914` | feat(nft_marker_gen): detailed logging with timestamps and per-level stats |
| `48ebe14` | docs: README + `lib.rs` updated with NFT marker generation pipeline |
| `40bf195` | chore(deps): `imageproc` 0.26, `env_logger` 0.11, `rand` 0.9 |

## Changes in detail

### 1. JPEG-compressed `.iset` save (`image_set.rs`) — Fixes #55

- `save()` encodes scale[0] as grayscale JPEG with DPI embedded in the JFIF APP0 header
- `encode_grayscale_jpeg()` patches bytes 13–17 (`density_unit=1`, `X/Y_density=dpi`) — mirrors C's `jpgwrite()`
- `AR2_DEFAULT_JPEG_IMAGE_QUALITY = 80` constant matches C++ default
- `save_raw()` / `to_bytes_raw()` preserved for lossless legacy format
- **File size**: Rust 315 KB vs C++ 316 KB — near-identical; JFIF headers identical

### 2. Include all fset levels (`feature_map.rs`) — Fixes #54

- Removed `if coords.is_empty() { continue; }` that skipped levels with 0 detected features
- Now produces 19 fset levels matching the 19 iset levels (C++ behavior)

### 3. Improved logging (`nft_marker_gen.rs`)

- Start/finish timestamps with timezone
- DPI levels listed during ImageSet generation
- Per-level details: dimensions, feature counts, FREAK features per scale
- Per-step timing and total execution time
- Adds `chrono` dev-dependency for timestamp formatting

### 4. Dependency updates (`Cargo.toml`, `tracking.rs`)

- `imageproc` 0.25 → 0.26 (examples only, no API changes needed)
- `env_logger` 0.10 → 0.11 (dev-dep, `init()` API unchanged)
- `rand` 0.8 → 0.9 (`thread_rng()` removed — updated `tracking.rs` to use `rand::rng()` and `random_range()`)

## Test plan

- [x] 13 image_set unit tests pass (including 4 new JPEG-specific tests)
- [x] `test_encode_grayscale_jpeg_dpi` — JFIF header DPI=220 embedded correctly
- [x] `test_image_set_save_jpeg_load_roundtrip` — JPEG roundtrip with pixel tolerance ±5
- [x] `test_image_set_jpeg_multiscale_roundtrip` — multi-scale DPI preservation
- [x] `test_image_set_save_raw_load_roundtrip` — legacy format lossless roundtrip
- [x] 4 feature_map tests pass (0-feature level now included)
- [x] `nft_marker_gen --dpi 220` produces 19 iset levels, 19 fset levels, 7108 FREAK features
- [x] Generated markers tested with ARnft — detection and tracking verified
- [x] `cargo check` clean after all dependency updates

## Verification

JPEG header comparison (Rust vs C++):
```
Rust: num=19, SOI=ffd8, APP0=ffe0, units=1, X_density=220
C++:  num=19, SOI=ffd8, APP0=ffe0, units=1, X_density=220
```

Sample log output:
```
--
Generator started at 2026-04-14 16:04:50 +0200

Tracking Extraction Level = 2

Generating ImageSet...
  Image DPI (19): 220.000000
  ...
  Image DPI (1): 3.762000

Saving to "output.iset"...
  Done. 19 levels: 220.0 -> 3.8 dpi  (307 KB, 3.9s)

Generating FeatureList...
  220.000000 dpi (1637x2048): 250 features selected
  ...
  3.762000 dpi (28x35): 0 features selected

Saving FeatureSet to "output.fset"...
  Done. 19 levels, 1914 features total  (37 KB, 625.9s)

Generating FeatureSet3...
  (1637, 2048) 220.000000 dpi: Freak features - 647
  ...

Generator finished at 2026-04-14 16:15:27 +0200
--
NFTMarkerGenerator took 637.33 seconds to execute
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)