### PR TITLE
perf(ar2): SIMD get_similarity (SSE4.1+AVX2) + parallel pyramid (1.70x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,22 +131,33 @@ cargo run --example barcode -- -m 5x5 -t 120 -i path/to/marker.jpg
 | `-t` | `--threshold` | Fixed labeling threshold (0–255). When omitted, sweeps 60–180 in steps of 20 | *(auto-sweep)* |
 | `-i` | `--image` | Path to the input image | bundled 3x3 marker image |
 
-### WebAssembly (WASM) Demo
+### WebAssembly (WASM)
 
 The WASM port allows you to run the AR engine directly in most modern browsers.
 
-1. **Build the modules**:
-   Use the npm script to generate both Standard and SIMD bundles (works on all platforms):
+#### Using the npm package
+
+For integration into your own project, install the pre-built package from npm — no local build required:
+
+```bash
+npm install @webarkit/webarkitlib-wasm
+```
+
+See [@webarkit/webarkitlib-wasm](https://www.npmjs.com/package/@webarkit/webarkitlib-wasm) for API documentation and usage examples.
+
+#### Running the bundled demos
+
+The `crates/wasm/www` folder contains interactive web demos. To run them you need to build the WASM modules locally:
+
+1. **Build the modules** (generates both Standard and SIMD bundles):
    ```bash
    npm run build:wasm
    ```
    > **Alternatively**, download the pre-built `wasm-package` artifact from the latest [CI run](https://github.com/webarkit/WebARKitLib-rs/actions) and extract its contents into `crates/wasm/pkg/`.
 
-2. **Run the demo**:
-   The `www` folder contains two web demos. Serve it with any local HTTP server:
+2. **Serve the demo**:
    ```bash
    cd crates/wasm/www
-   # Serve using any local HTTP server, e.g.:
    npx serve .
    ```
    - **`simple.html`** – static image demo with engine selector and threshold visualization.

--- a/README.md
+++ b/README.md
@@ -63,11 +63,21 @@ This example loads a camera parameter file, a marker (pattern or barcode), and a
 Generate NFT (Natural Feature Tracking) marker files compatible with ARnft and NFT-Marker-Creator-App:
 
 ```bash
-cargo run --features ffi-backend --example nft_marker_gen -- \
+# Basic usage (requires C++ FREAK backend for .fset3):
+cargo run --release --features ffi-backend --example nft_marker_gen -- \
+  --input path/to/image.jpg \
+  --output path/to/output_name \
+  --dpi 220
+
+# With SIMD acceleration + Rayon parallelism (recommended for x86_64):
+cargo run --release --features "ffi-backend,simd-x86-sse41,simd-x86-avx2" \
+  --example nft_marker_gen -- \
   --input path/to/image.jpg \
   --output path/to/output_name \
   --dpi 220
 ```
+
+> **Important:** Always use the `--release` flag. Debug builds are 5–10× slower due to missing compiler optimizations.
 
 This produces three files:
 - **`output_name.iset`** — JPEG-compressed image pyramid (~300 KB, matches C++ `ar2WriteImageSet()` format)
@@ -83,6 +93,17 @@ This produces three files:
 | `-d` | `--dpi` | Source image resolution in DPI | required |
 | `-l` | `--level` | Tracking extraction level (0–4) | `2` |
 | `-n` | `--search-feature-num` | Max features per pyramid level | `250` |
+
+**Performance feature flags:**
+
+| Feature flag | What it enables |
+|---|---|
+| `ffi-backend` | C++ FREAK backend for `.fset3` generation (required for full NFT markers) |
+| `simd-x86-sse41` | SSE4.1 SIMD acceleration for feature map correlation (`get_similarity`) |
+| `simd-x86-avx2` | AVX2+FMA SIMD acceleration for feature map correlation (faster than SSE4.1) |
+| `simd` | Umbrella flag — enables all SIMD optimizations (SSE4.1, AVX2, WASM SIMD, image, pattern) |
+
+Rayon-based parallelism is always enabled (no feature flag needed): pyramid level generation and Stage-3 feature scoring run in parallel across CPU cores.
 
 #### Barcode Detection Example
 
@@ -189,6 +210,7 @@ The workspace contains two crates:
   - All pyramid levels included in `.fset` (including 0-feature levels), matching C++ output exactly
   - FREAK descriptor extraction via `kpm_extract_features` C API (7000+ features per marker)
   - Detailed step-by-step logging with timestamps and per-level statistics
+- **M5 -- NFT Pipeline Performance**: Rayon parallelism for pyramid generation and Stage-3 feature scoring, plus optional SSE4.1/AVX2+FMA SIMD vectorization of the `get_similarity` correlation kernel. ~1.7× total speedup on x86_64.
 
 ### 🎯 Short-term Goals (toward v1.0.0)
 - **Complete KPM in idiomatic Rust**: Port the remaining KPM feature extraction and matching logic to pure Rust, removing the C++ FFI dependency, and ship a working end-to-end NFT example.

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -25,11 +25,12 @@ cc = "1"
 bindgen = "0.72.1"
 
 [features]
-simd = ["simd-image", "simd-pattern", "simd-wasm32", "simd-x86-sse41"]
+simd = ["simd-image", "simd-pattern", "simd-wasm32", "simd-x86-sse41", "simd-x86-avx2"]
 simd-image = []
 simd-pattern = []
 simd-wasm32 = []
 simd-x86-sse41 = []
+simd-x86-avx2 = []
 ffi-backend = []
 dual-mode = []
 

--- a/crates/core/examples/nft_marker_gen.rs
+++ b/crates/core/examples/nft_marker_gen.rs
@@ -200,6 +200,8 @@ fn main() {
         std::process::exit(1);
     });
 
+    let gen_elapsed = step_start.elapsed().as_secs_f64();
+
     // Print DPI levels.
     for (i, scale) in image_set.scale.iter().enumerate() {
         println!("  Image DPI ({}): {:.6}", image_set.num() - i, scale.dpi);
@@ -208,19 +210,26 @@ fn main() {
 
     let iset_path = cli.output.with_extension("iset");
     println!("Saving to {:?}...", iset_path);
+    let save_start = Instant::now();
     image_set.save(&iset_path).unwrap_or_else(|e| {
         eprintln!("Error: failed to save {:?}: {}", iset_path, e);
         std::process::exit(1);
     });
+    let save_elapsed = save_start.elapsed().as_secs_f64();
 
     let first_dpi = image_set.scale.first().map_or(0.0, |s| s.dpi);
     let last_dpi = image_set.scale.last().map_or(0.0, |s| s.dpi);
     println!(
-        "  Done. {} levels: {:.1} -> {:.1} dpi  ({}, {:.1}s)",
+        "  Done. {} levels: {:.1} -> {:.1} dpi  ({})",
         image_set.num(),
         first_dpi,
         last_dpi,
         file_kb(&iset_path),
+    );
+    println!(
+        "  Pyramid generation: {:.1}s | Save: {:.1}s | Total: {:.1}s",
+        gen_elapsed,
+        save_elapsed,
         step_start.elapsed().as_secs_f64()
     );
     println!();
@@ -237,6 +246,8 @@ fn main() {
         std::process::exit(1);
     });
 
+    let gen_elapsed = step_start.elapsed().as_secs_f64();
+
     // Print per-level feature counts.
     for pts in &feature_set.list {
         let scale_img = &image_set.scale[pts.scale as usize];
@@ -252,17 +263,24 @@ fn main() {
 
     let fset_path = cli.output.with_extension("fset");
     println!("Saving FeatureSet to {:?}...", fset_path);
+    let save_start = Instant::now();
     feature_set.save(&fset_path).unwrap_or_else(|e| {
         eprintln!("Error: failed to save {:?}: {}", fset_path, e);
         std::process::exit(1);
     });
+    let save_elapsed = save_start.elapsed().as_secs_f64();
 
     let total_features: usize = feature_set.list.iter().map(|p| p.coord.len()).sum();
     println!(
-        "  Done. {} levels, {} features total  ({}, {:.1}s)",
+        "  Done. {} levels, {} features total  ({})",
         feature_set.num(),
         total_features,
         file_kb(&fset_path),
+    );
+    println!(
+        "  Feature extraction: {:.1}s | Save: {:.1}s | Total: {:.1}s",
+        gen_elapsed,
+        save_elapsed,
         step_start.elapsed().as_secs_f64()
     );
     println!();
@@ -334,17 +352,26 @@ fn main() {
         }
         println!();
 
+        let gen_elapsed = step_start.elapsed().as_secs_f64();
+
         println!("Saving FeatureSet3 to {:?}...", fset3_path);
         if let Some(ref_data) = combined {
             let total_kpm = ref_data.num as usize;
+            let save_start = Instant::now();
             ref_data.save(&fset3_path).unwrap_or_else(|e| {
                 eprintln!("Error: failed to save {:?}: {}", fset3_path, e);
                 std::process::exit(1);
             });
+            let save_elapsed = save_start.elapsed().as_secs_f64();
             println!(
-                "  Done. {} FREAK features total  ({}, {:.1}s)",
+                "  Done. {} FREAK features total  ({})",
                 total_kpm,
                 file_kb(&fset3_path),
+            );
+            println!(
+                "  FREAK extraction: {:.1}s | Save: {:.1}s | Total: {:.1}s",
+                gen_elapsed,
+                save_elapsed,
                 step_start.elapsed().as_secs_f64()
             );
         } else {

--- a/crates/core/src/ar2/feature_map.rs
+++ b/crates/core/src/ar2/feature_map.rs
@@ -164,11 +164,51 @@ fn make_template(
 ///
 /// Returns `None` if the patch is out of bounds or has zero variance.
 ///
+/// Dispatches to AVX2/FMA or SSE4.1 SIMD kernels when the corresponding
+/// feature flags are enabled and the CPU supports them at runtime. Falls
+/// back to the scalar implementation otherwise. All three paths produce
+/// near-identical results; SIMD paths may differ from scalar by tiny FP
+/// rounding due to lane-parallel summation of `sxy`.
+///
 /// `sx` (sum of u8 values) and `sxx` (sum of squared u8 values) are
-/// accumulated as `u64` and converted to `f32` only at the end. This avoids
-/// f32-rounding loss once `sxx` grows past 2^24 (which happens easily on
-/// 23×23 patches of saturated pixels — max `sxx ≈ 34 M`).
+/// accumulated as `u64` integers in all paths — no FP drift on those.
+#[inline]
 fn get_similarity(
+    image: &[u8],
+    xsize: i32,
+    ysize: i32,
+    template: &[f32],
+    vlen: f32,
+    ts1: i32,
+    ts2: i32,
+    cx: i32,
+    cy: i32,
+) -> Option<f32> {
+    #[cfg(all(feature = "simd-x86-avx2", target_arch = "x86_64"))]
+    {
+        if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
+            return unsafe {
+                get_similarity_avx2(image, xsize, ysize, template, vlen, ts1, ts2, cx, cy)
+            };
+        }
+    }
+    #[cfg(all(feature = "simd-x86-sse41", target_arch = "x86_64"))]
+    {
+        if is_x86_feature_detected!("sse4.1") {
+            return unsafe {
+                get_similarity_sse41(image, xsize, ysize, template, vlen, ts1, ts2, cx, cy)
+            };
+        }
+    }
+    get_similarity_scalar(image, xsize, ysize, template, vlen, ts1, ts2, cx, cy)
+}
+
+/// Scalar reference implementation of [`get_similarity`].
+///
+/// `sx`/`sxx` use `u64` integer accumulation to avoid f32 rounding past
+/// 2^24. `sxy` is accumulated left-to-right in row-major order.
+#[inline]
+fn get_similarity_scalar(
     image: &[u8],
     xsize: i32,
     ysize: i32,
@@ -186,9 +226,6 @@ fn get_similarity(
     let patch_size = (ts1 + ts2 + 1) as usize;
     let n = (patch_size * patch_size) as f32;
 
-    // `sx` and `sxx` are sums over u8 values (and their squares) and are
-    // accumulated as integers to avoid f32 rounding when `sxx` grows past
-    // 2^24. Kept in sync with the SIMD kernel so both paths are bit-equal.
     let mut sx_i: u64 = 0;
     let mut sxx_i: u64 = 0;
     let mut sxy: f32 = 0.0;
@@ -204,6 +241,246 @@ fn get_similarity(
             idx += 1;
         }
     }
+
+    let sx = sx_i as f32;
+    let sxx = sxx_i as f32;
+
+    let vlen2_sq = sxx - sx * sx / n;
+    if vlen2_sq <= 0.0 {
+        return None;
+    }
+    let vlen2 = vlen2_sq.sqrt();
+
+    Some(sxy / (vlen * vlen2))
+}
+
+/// SSE4.1 SIMD implementation of [`get_similarity`].
+///
+/// Vectorises all three accumulators:
+/// - `sx`: `_mm_sad_epu8` (16 bytes/iter) — integer-exact
+/// - `sxx`: `_mm_cvtepu8_epi16` + `_mm_madd_epi16` — integer-exact
+/// - `sxy`: 4-wide f32 multiply-accumulate (`_mm_cvtepi32_ps` + `_mm_mul_ps`
+///   + `_mm_add_ps`), horizontal reduce once at the end
+///
+/// # Safety
+///
+/// Caller must ensure SSE4.1 is available. Only called from [`get_similarity`]
+/// after `is_x86_feature_detected!`.
+#[cfg(all(feature = "simd-x86-sse41", target_arch = "x86_64"))]
+#[target_feature(enable = "sse4.1")]
+unsafe fn get_similarity_sse41(
+    image: &[u8],
+    xsize: i32,
+    ysize: i32,
+    template: &[f32],
+    vlen: f32,
+    ts1: i32,
+    ts2: i32,
+    cx: i32,
+    cy: i32,
+) -> Option<f32> {
+    use std::arch::x86_64::*;
+
+    if cy - ts1 < 0 || cy + ts2 >= ysize || cx - ts1 < 0 || cx + ts2 >= xsize {
+        return None;
+    }
+
+    let patch_size = (ts1 + ts2 + 1) as usize;
+    let n = (patch_size * patch_size) as f32;
+
+    let mut sx_i: u64 = 0;
+    let mut sxx_i: u64 = 0;
+    let mut sxy_acc = _mm_setzero_ps(); // 4 f32 lanes
+    let zero = _mm_setzero_si128();
+
+    let mut idx: usize = 0;
+    for j in -ts1..=ts2 {
+        let row = ((cy + j) * xsize + (cx - ts1)) as usize;
+        let img_row = &image[row..row + patch_size];
+        let tmpl_row = &template[idx..idx + patch_size];
+
+        let mut i = 0usize;
+
+        // Process 16 bytes at a time for sx/sxx
+        while i + 16 <= patch_size {
+            let v = _mm_loadu_si128(img_row.as_ptr().add(i) as *const __m128i);
+
+            // sx: sum of u8 via SAD against zero
+            let sad = _mm_sad_epu8(v, zero);
+            sx_i += _mm_cvtsi128_si64(sad) as u64;
+            sx_i += _mm_extract_epi64(sad, 1) as u64;
+
+            // sxx: expand to i16, self-multiply → i32 sums
+            let lo16 = _mm_cvtepu8_epi16(v);
+            let hi16 = _mm_cvtepu8_epi16(_mm_srli_si128(v, 8));
+            let sq = _mm_add_epi32(_mm_madd_epi16(lo16, lo16), _mm_madd_epi16(hi16, hi16));
+            let sq_hi = _mm_unpackhi_epi64(sq, sq);
+            let sum2 = _mm_add_epi32(sq, sq_hi);
+            let sum1 = _mm_add_epi32(sum2, _mm_shuffle_epi32(sum2, 0b01));
+            sxx_i += _mm_cvtsi128_si32(sum1) as u32 as u64;
+
+            i += 16;
+        }
+        // Tail for sx/sxx (scalar)
+        for ii in i..patch_size {
+            let p = img_row[ii] as u64;
+            sx_i += p;
+            sxx_i += p * p;
+        }
+
+        // sxy: 4-wide f32 multiply-accumulate
+        let mut i = 0usize;
+        while i + 4 <= patch_size {
+            // Load 4 u8 → i32 → f32 (unaligned read — u8 slice has no
+            // alignment guarantee for i32).
+            let v4 = _mm_cvtepu8_epi32(_mm_cvtsi32_si128(std::ptr::read_unaligned(
+                img_row.as_ptr().add(i) as *const i32,
+            )));
+            let pf = _mm_cvtepi32_ps(v4);
+            let tf = _mm_loadu_ps(tmpl_row.as_ptr().add(i));
+            sxy_acc = _mm_add_ps(sxy_acc, _mm_mul_ps(pf, tf));
+            i += 4;
+        }
+        // Tail for sxy (scalar)
+        for ii in i..patch_size {
+            let p = img_row[ii] as f32;
+            sxy_acc = _mm_add_ps(sxy_acc, _mm_set_ss(p * tmpl_row[ii]));
+        }
+
+        idx += patch_size;
+    }
+
+    // Horizontal sum of sxy_acc (4 lanes → 1)
+    let shuf = _mm_movehdup_ps(sxy_acc); // [1,1,3,3]
+    let s1 = _mm_add_ps(sxy_acc, shuf); // [0+1, ?, 2+3, ?]
+    let s2 = _mm_movehl_ps(s1, s1); // [2+3, ?, ?, ?]
+    let sxy = _mm_cvtss_f32(_mm_add_ss(s1, s2));
+
+    let sx = sx_i as f32;
+    let sxx = sxx_i as f32;
+
+    let vlen2_sq = sxx - sx * sx / n;
+    if vlen2_sq <= 0.0 {
+        return None;
+    }
+    let vlen2 = vlen2_sq.sqrt();
+
+    Some(sxy / (vlen * vlen2))
+}
+
+/// AVX2/FMA SIMD implementation of [`get_similarity`].
+///
+/// 8-wide f32 vectorisation of `sxy` using `_mm256_fmadd_ps`. Integer
+/// accumulators `sx`/`sxx` use the same SSE4.1 ops (AVX2 doesn't improve
+/// 16-byte SAD/MADD meaningfully for our 23-byte rows).
+///
+/// # Safety
+///
+/// Caller must ensure AVX2 and FMA are available. Only called from
+/// [`get_similarity`] after `is_x86_feature_detected!`.
+#[cfg(all(feature = "simd-x86-avx2", target_arch = "x86_64"))]
+#[target_feature(enable = "avx2,fma")]
+unsafe fn get_similarity_avx2(
+    image: &[u8],
+    xsize: i32,
+    ysize: i32,
+    template: &[f32],
+    vlen: f32,
+    ts1: i32,
+    ts2: i32,
+    cx: i32,
+    cy: i32,
+) -> Option<f32> {
+    use std::arch::x86_64::*;
+
+    if cy - ts1 < 0 || cy + ts2 >= ysize || cx - ts1 < 0 || cx + ts2 >= xsize {
+        return None;
+    }
+
+    let patch_size = (ts1 + ts2 + 1) as usize;
+    let n = (patch_size * patch_size) as f32;
+
+    let mut sx_i: u64 = 0;
+    let mut sxx_i: u64 = 0;
+    let mut sxy_acc = _mm256_setzero_ps(); // 8 f32 lanes
+    let zero128 = _mm_setzero_si128();
+
+    let mut idx: usize = 0;
+    for j in -ts1..=ts2 {
+        let row = ((cy + j) * xsize + (cx - ts1)) as usize;
+        let img_row = &image[row..row + patch_size];
+        let tmpl_row = &template[idx..idx + patch_size];
+
+        // sx/sxx: SSE4.1 integer ops (16 bytes at a time)
+        let mut i = 0usize;
+        while i + 16 <= patch_size {
+            let v = _mm_loadu_si128(img_row.as_ptr().add(i) as *const __m128i);
+            let sad = _mm_sad_epu8(v, zero128);
+            sx_i += _mm_cvtsi128_si64(sad) as u64;
+            sx_i += _mm_extract_epi64(sad, 1) as u64;
+
+            let lo16 = _mm_cvtepu8_epi16(v);
+            let hi16 = _mm_cvtepu8_epi16(_mm_srli_si128(v, 8));
+            let sq = _mm_add_epi32(_mm_madd_epi16(lo16, lo16), _mm_madd_epi16(hi16, hi16));
+            let sq_hi = _mm_unpackhi_epi64(sq, sq);
+            let sum2 = _mm_add_epi32(sq, sq_hi);
+            let sum1 = _mm_add_epi32(sum2, _mm_shuffle_epi32(sum2, 0b01));
+            sxx_i += _mm_cvtsi128_si32(sum1) as u32 as u64;
+            i += 16;
+        }
+        for ii in i..patch_size {
+            let p = img_row[ii] as u64;
+            sx_i += p;
+            sxx_i += p * p;
+        }
+
+        // sxy: 8-wide FMA (load 8 u8 → 2×4 i32 → 8 f32, fmadd)
+        let mut i = 0usize;
+        while i + 8 <= patch_size {
+            // Load 8 u8 bytes via unaligned u64 read → lower 64 bits of xmm.
+            let v8 = _mm_cvtsi64_si128(std::ptr::read_unaligned(
+                img_row.as_ptr().add(i) as *const i64
+            ));
+            // Expand lower 4 u8 → i32 and upper 4 u8 → i32
+            let lo4 = _mm_cvtepu8_epi32(v8);
+            let hi4 = _mm_cvtepu8_epi32(_mm_srli_si128(v8, 4));
+            // Combine into 256-bit i32 vector and convert to f32
+            let v8_i32 = _mm256_set_m128i(hi4, lo4);
+            let pf = _mm256_cvtepi32_ps(v8_i32);
+            let tf = _mm256_loadu_ps(tmpl_row.as_ptr().add(i));
+            sxy_acc = _mm256_fmadd_ps(pf, tf, sxy_acc);
+            i += 8;
+        }
+        // 4-wide tail
+        while i + 4 <= patch_size {
+            let v4 = _mm_cvtepu8_epi32(_mm_cvtsi32_si128(std::ptr::read_unaligned(
+                img_row.as_ptr().add(i) as *const i32,
+            )));
+            let pf = _mm_cvtepi32_ps(v4);
+            let tf = _mm_loadu_ps(tmpl_row.as_ptr().add(i));
+            let prod = _mm_mul_ps(pf, tf);
+            // Add 128-bit product into lower lane of 256-bit accumulator
+            sxy_acc = _mm256_add_ps(sxy_acc, _mm256_castps128_ps256(prod));
+            i += 4;
+        }
+        // Scalar tail
+        for ii in i..patch_size {
+            let p = img_row[ii] as f32;
+            let s = _mm_set_ss(p * tmpl_row[ii]);
+            sxy_acc = _mm256_add_ps(sxy_acc, _mm256_castps128_ps256(s));
+        }
+
+        idx += patch_size;
+    }
+
+    // Horizontal sum of sxy_acc (8 lanes → 1)
+    let hi128 = _mm256_extractf128_ps(sxy_acc, 1);
+    let lo128 = _mm256_castps256_ps128(sxy_acc);
+    let sum128 = _mm_add_ps(lo128, hi128);
+    let shuf = _mm_movehdup_ps(sum128);
+    let s1 = _mm_add_ps(sum128, shuf);
+    let s2 = _mm_movehl_ps(s1, s1);
+    let sxy = _mm_cvtss_f32(_mm_add_ss(s1, s2));
 
     let sx = sx_i as f32;
     let sxx = sxx_i as f32;
@@ -695,5 +972,143 @@ mod tests {
         let mut tmpl = vec![0.0f32; 529]; // (11+11+1)^2 = 529
                                           // Centre at (0,0) with ts1=11 → out of bounds
         assert!(make_template(&data, 10, 10, 0, 0, 11, 11, 0.0, &mut tmpl).is_none());
+    }
+
+    /// Helper: build a deterministic 64×64 pseudo-random image and template
+    /// for SIMD correctness tests.
+    fn make_deterministic_test_data() -> (Vec<u8>, Vec<f32>, f32) {
+        let w: i32 = 64;
+        let h: i32 = 64;
+        let mut image = vec![0u8; (w * h) as usize];
+        let mut s: u32 = 0x9E3779B9;
+        for b in image.iter_mut() {
+            s ^= s << 13;
+            s ^= s >> 17;
+            s ^= s << 5;
+            *b = (s & 0xFF) as u8;
+        }
+        let ts1 = AR2_DEFAULT_TS1;
+        let ts2 = AR2_DEFAULT_TS2;
+        let patch = (ts1 + ts2 + 1) as usize;
+        let mut template = vec![0.0f32; patch * patch];
+        for (i, t) in template.iter_mut().enumerate() {
+            *t = ((i as f32) * 0.123).sin();
+        }
+        let vlen: f32 = template.iter().map(|v| v * v).sum::<f32>().sqrt();
+        (image, template, vlen)
+    }
+
+    /// Helper: assert SIMD result matches scalar within relative tolerance.
+    fn assert_similarity_close(scalar: Option<f32>, simd: Option<f32>, cx: i32, cy: i32) {
+        match (scalar, simd) {
+            (Some(a), Some(b)) => {
+                let tol = 1e-5 * a.abs().max(1.0);
+                assert!(
+                    (a - b).abs() <= tol,
+                    "mismatch at ({cx},{cy}): scalar={a} simd={b} diff={}",
+                    (a - b).abs()
+                );
+            }
+            (None, None) => {}
+            other => panic!("Option mismatch at ({cx},{cy}): {other:?}"),
+        }
+    }
+
+    /// SSE4.1 SIMD `get_similarity` produces results within FP tolerance
+    /// of the scalar path across all valid centres on a deterministic image.
+    #[cfg(all(feature = "simd-x86-sse41", target_arch = "x86_64"))]
+    #[test]
+    fn test_get_similarity_sse41_tolerance() {
+        if !is_x86_feature_detected!("sse4.1") {
+            eprintln!("SSE4.1 not available — skipping");
+            return;
+        }
+
+        let (image, template, vlen) = make_deterministic_test_data();
+        let w: i32 = 64;
+        let h: i32 = 64;
+        let ts1 = AR2_DEFAULT_TS1;
+        let ts2 = AR2_DEFAULT_TS2;
+
+        let mut checked = 0usize;
+        for cy in ts1..(h - ts2) {
+            for cx in ts1..(w - ts2) {
+                let scalar = get_similarity_scalar(&image, w, h, &template, vlen, ts1, ts2, cx, cy);
+                let simd = unsafe {
+                    get_similarity_sse41(&image, w, h, &template, vlen, ts1, ts2, cx, cy)
+                };
+                assert_similarity_close(scalar, simd, cx, cy);
+                checked += 1;
+            }
+        }
+        assert!(checked > 0, "no centres were tested");
+    }
+
+    /// AVX2/FMA SIMD `get_similarity` produces results within FP tolerance
+    /// of the scalar path across all valid centres on a deterministic image.
+    #[cfg(all(feature = "simd-x86-avx2", target_arch = "x86_64"))]
+    #[test]
+    fn test_get_similarity_avx2_tolerance() {
+        if !is_x86_feature_detected!("avx2") || !is_x86_feature_detected!("fma") {
+            eprintln!("AVX2/FMA not available — skipping");
+            return;
+        }
+
+        let (image, template, vlen) = make_deterministic_test_data();
+        let w: i32 = 64;
+        let h: i32 = 64;
+        let ts1 = AR2_DEFAULT_TS1;
+        let ts2 = AR2_DEFAULT_TS2;
+
+        let mut checked = 0usize;
+        for cy in ts1..(h - ts2) {
+            for cx in ts1..(w - ts2) {
+                let scalar = get_similarity_scalar(&image, w, h, &template, vlen, ts1, ts2, cx, cy);
+                let simd =
+                    unsafe { get_similarity_avx2(&image, w, h, &template, vlen, ts1, ts2, cx, cy) };
+                assert_similarity_close(scalar, simd, cx, cy);
+                checked += 1;
+            }
+        }
+        assert!(checked > 0, "no centres were tested");
+    }
+
+    /// Pipeline stability: `ar2_gen_feature_map` on pinball.jpg must produce
+    /// the same per-level feature counts regardless of SIMD backend. This
+    /// catches FP drift that might change feature selection at decision
+    /// boundaries.
+    #[test]
+    #[ignore] // Loads pinball.jpg — run with `cargo test --release -- --ignored`
+    fn test_feature_counts_stable_pinball() {
+        let expected_counts: &[usize] = &[
+            250, 250, 250, 250, 250, 223, 159, 102, 73, 43, 29, 12, 8, 4, 4, 4, 2, 1, 0,
+        ];
+
+        let img = image::open("examples/Data/pinball.jpg").expect("failed to open pinball.jpg");
+        let gray = img.to_luma8();
+        let w = gray.width() as i32;
+        let h = gray.height() as i32;
+        let data = gray.into_raw();
+
+        let image_set = ar2_gen_image_set(&data, w, h, 1, 220.0).expect("ar2_gen_image_set failed");
+        let result =
+            ar2_gen_feature_map(&image_set, 10, 250, 2).expect("ar2_gen_feature_map failed");
+
+        assert_eq!(
+            result.list.len(),
+            expected_counts.len(),
+            "pyramid level count mismatch: got {} expected {}",
+            result.list.len(),
+            expected_counts.len()
+        );
+
+        for (i, (pts, &expected)) in result.list.iter().zip(expected_counts.iter()).enumerate() {
+            assert_eq!(
+                pts.coord.len(),
+                expected,
+                "feature count mismatch at level {i}: got {} expected {expected}",
+                pts.coord.len()
+            );
+        }
     }
 }

--- a/crates/core/src/ar2/image_set.rs
+++ b/crates/core/src/ar2/image_set.rs
@@ -65,6 +65,7 @@
 
 use super::Ar2Error;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use rayon::prelude::*;
 use std::io::{self, BufWriter, Cursor, Read, Write};
 use std::path::Path;
 
@@ -497,11 +498,12 @@ pub fn ar2_gen_image_set(
     // Build each level from the original source using gen_image_layer1,
     // which handles colour-to-grayscale conversion (nc parameter) and
     // area-averaging downscale — matching C's `ar2GenImageSet` loop.
-    let mut scales = Vec::with_capacity(dpi_levels.len());
-    for &target_dpi in &dpi_levels {
-        let layer = gen_image_layer1(image, xsize, ysize, nc, dpi, target_dpi);
-        scales.push(layer);
-    }
+    // Levels are independent (each downscales from the original), so we
+    // build them in parallel with Rayon.
+    let scales: Vec<_> = dpi_levels
+        .par_iter()
+        .map(|&target_dpi| gen_image_layer1(image, xsize, ysize, nc, dpi, target_dpi))
+        .collect();
 
     Ok(AR2ImageSetT { scale: scales })
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -60,14 +60,36 @@
 //! ## Performance and SIMD
 //!
 //! This crate includes high-performance SIMD optimizations for critical image processing
-//! paths (grayscale conversion, filtering, and pattern matching).
-//! - **SSE4.1** is supported for x86_64 targets.
-//! - **WASM SIMD** is supported for web targets.
+//! paths (grayscale conversion, filtering, pattern matching, and NFT feature correlation).
 //!
-//! To enable these optimizations, compile with the `simd` feature:
+//! ### SIMD feature flags
+//!
+//! | Feature | What it accelerates |
+//! |---|---|
+//! | `simd-x86-sse41` | `get_similarity` correlation kernel (SSE4.1 intrinsics) |
+//! | `simd-x86-avx2` | `get_similarity` correlation kernel (AVX2+FMA intrinsics, fastest) |
+//! | `simd-image` | Grayscale conversion and image processing |
+//! | `simd-pattern` | Pattern matching correlation |
+//! | `simd-wasm32` | WASM SIMD for web targets |
+//! | `simd` | Umbrella — enables all of the above |
+//!
+//! SIMD dispatch is automatic at runtime: AVX2+FMA → SSE4.1 → scalar fallback.
+//!
+//! ### Rayon parallelism
+//!
+//! Rayon is always enabled (no feature flag). The NFT pipeline parallelizes:
+//! - **Image pyramid generation** — each pyramid level is built in parallel
+//! - **Stage-3 feature scoring** — row-level parallelism via `par_chunks_mut`
+//!
+//! ### Recommended build for NFT marker generation (x86_64)
+//!
 //! ```bash
-//! cargo build --release --features simd
+//! cargo run --release --features "ffi-backend,simd-x86-sse41,simd-x86-avx2" \
+//!     --example nft_marker_gen -- --input marker.jpg --output marker --dpi 220
 //! ```
+//!
+//! > **Always use `--release`** — debug builds are 5–10× slower.
+//!
 //! Detailed benchmark results can be found in `crates/core/benches/BENCHMARKS.md`.
 //!
 //! ## Example


### PR DESCRIPTION
Closes #59. Part of #48.

## Summary

- Vectorise `get_similarity()` `sxy` loop with two SIMD tiers (SSE4.1 4-wide, AVX2/FMA 8-wide), runtime-detected
- Integer accumulators `sx`/`sxx` vectorised with `_mm_sad_epu8` + `_mm_madd_epi16` (exact, no FP drift)
- Parallelize `ar2_gen_image_set()` pyramid level generation with Rayon `par_iter`

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Add `simd-x86-avx2 = []` feature, update `simd` umbrella |
| `feature_map.rs` | `get_similarity` 3-tier dispatch (avx2 → sse41 → scalar), SSE4.1 kernel, AVX2/FMA kernel, tolerance tests, pinball stability test |
| `image_set.rs` | `ar2_gen_image_set` sequential loop → `par_iter` |

## Benchmarks

Full `nft_marker_gen` on `pinball.jpg` (1637×2048, release, identical feature output):

| Configuration | Stage-2 time | vs Serial |
|---|---|---|
| Serial, scalar | 82.1 s | 1.00× |
| Rayon only (PR #60) | 55.1 s | 1.49× |
| **Rayon + SIMD + pyramid par** | **48.2 s** | **1.70×** |

SIMD contributes 1.14× on top of Rayon. The 23-byte row width limits vectorisation efficiency (5×4 SSE or 2×8+1×4 AVX with 3-byte scalar tail per row), and memory-bandwidth contention caps the practical gain.

Feature counts identical across all 19 pyramid levels (1914 total, per-level: 250/250/250/250/250/223/159/102/73/43/29/12/8/4/4/4/2/1/0).

## SIMD architecture

```
get_similarity()
  → AVX2+FMA detected? → get_similarity_avx2()   // 8-wide f32 FMA
  → SSE4.1 detected?   → get_similarity_sse41()   // 4-wide f32 mul+add
  → else               → get_similarity_scalar()  // u64 integer accum
```

All three paths:
- `sx`/`sxx`: integer-exact (u64 accumulation, no FP rounding)
- `sxy`: f32 SIMD lanes with horizontal reduce — may differ from scalar by ≤1e-5 relative tolerance
- Bounds-checked before any SIMD load; unaligned reads via `std::ptr::read_unaligned`

## Test plan

- [x] `cargo test -p webarkitlib-rs` — 81 passed, 6 ignored
- [x] `cargo test --features simd-x86-sse41,simd-x86-avx2` — both SIMD tolerance tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --features simd-x86-sse41,simd-x86-avx2` — no new warnings
- [x] `cargo bench --bench feature_map_bench --features simd-x86-sse41,simd-x86-avx2` — ~810 ms (400px fixture)
- [x] Full `nft_marker_gen` release run: 48.2 s, feature counts match baseline
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)