### PR TITLE
feat(arlog): port ARToolKit logging API over log crate facade (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,63 @@ The `crates/wasm/www` folder contains interactive web demos. To run them you nee
    - **`simple.html`** – static image demo with engine selector and threshold visualization.
    - **`simple_video_marker_example.html`** – live webcam demo with engine selector, marker type (pattern/barcode) selector, and threshold slider.
 
+## 📝 Logging
+
+WebARKitLib-rs uses the standard [`log`](https://crates.io/crates/log) crate facade, with ARToolKit-style macros (`arlog_d!`, `arlog_i!`, `arlog_w!`, `arlog_e!`, `arlog_rel!`, `arlog_perror!`) that mirror the C `ARLOG*` API:
+
+| C macro                   | Rust macro               |
+|---------------------------|--------------------------|
+| `ARLOGd("x=%d", x);`      | `arlog_d!("x={}", x);`   |
+| `ARLOGi("x=%d", x);`      | `arlog_i!("x={}", x);`   |
+| `ARLOGw("x=%d", x);`      | `arlog_w!("x={}", x);`   |
+| `ARLOGe("x=%d", x);`      | `arlog_e!("x={}", x);`   |
+| `ARLOG("banner\n");`      | `arlog_rel!("banner");`  |
+| `ARLOGperror("open");`    | `arlog_perror!("open");` |
+
+### Quick start — reproduce ARToolKit's C output format
+
+Enable the `log-helpers` feature and call the bundled initializer once in your binary:
+
+```toml
+[dependencies]
+webarkitlib-rs = { version = "0.3", features = ["log-helpers"] }
+```
+
+```rust
+fn main() {
+    webarkitlib_rs::arlog::ar_log_init_default();
+    // ... your application
+}
+```
+
+Produces `[info] ...`, `[warning] ...`, `[error] ...`, `[debug] ...` — matching the C output exactly. Release-info messages (`arlog_rel!`) print unprefixed.
+
+### Controlling verbosity
+
+Set via environment variable (honored by the default helper):
+
+```bash
+RUST_LOG=debug cargo run --example simple
+```
+
+Or programmatically:
+
+```rust
+use webarkitlib_rs::arlog::{set_ar_log_level, ArLogLevel};
+set_ar_log_level(ArLogLevel::Debug);
+```
+
+### Other backends
+
+Because it's the `log` crate facade, any compatible backend works:
+
+- **WASM / browser** — `console_log` (or the bundled `ar_log_init_wasm()` helper under the `log-helpers` feature)
+- **Android** — `android_logger`
+- **Apple (iOS/macOS)** — `oslog`
+- **Structured / OpenTelemetry** — `tracing` + `tracing-log`
+
+No library code change is needed — pick the backend in your application's entry point.
+
 ## 📊 Benchmarking
 
 We maintain a strict performance comparison with the original C library to ensure our Rust port remains competitive. 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,27 @@ fn main() {
 
 Produces `[info] ...`, `[warning] ...`, `[error] ...`, `[debug] ...` — matching the C output exactly. Release-info messages (`arlog_rel!`) print unprefixed.
 
+### Verbose mode
+
+For richer output (timestamp + originating module), use the verbose initializer:
+
+```rust
+fn main() {
+    webarkitlib_rs::arlog::ar_log_init_default_verbose();
+    // ... your application
+}
+```
+
+Produces a single bracketed header per line:
+
+```text
+[info - 2026-04-21T14:23:45Z - webarkitlib_rs::marker] hello
+[warning - 2026-04-21T14:23:45Z - webarkitlib_rs::ar2] low mem
+[error - 2026-04-21T14:23:45Z - webarkitlib_rs::kpm] bad fd
+```
+
+Filtering still respects `RUST_LOG`; only the formatting changes. `arlog_rel!` messages stay prefix-free in verbose mode too. On `wasm32`, use `ar_log_init_wasm_verbose()`, which raises the level to `Debug` (browser DevTools renders the timestamp and source location natively).
+
 ### Controlling verbosity
 
 Set via environment variable (honored by the default helper):

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -25,6 +25,12 @@ log = "0.4.0"
 rand = "0.9"
 rayon = "1.12"
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+env_logger = { version = "0.11", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_log = { version = "1", optional = true }
+
 [build-dependencies]
 cc = "1"
 bindgen = "0.72.1"
@@ -38,6 +44,8 @@ simd-x86-sse41 = []
 simd-x86-avx2 = []
 ffi-backend = []
 dual-mode = []
+# Pulls env_logger (desktop) or console_log (wasm) for the `ar_log_init_*` helpers.
+log-helpers = ["dep:env_logger", "dep:console_log"]
 
 [dev-dependencies]
 chrono = "0.4"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -58,6 +58,10 @@ tempfile = "3"
 name = "simple_nft"
 required-features = ["ffi-backend"]
 
+[[example]]
+name = "load_nft"
+required-features = ["log-helpers"]
+
 [[bench]]
 name = "marker_bench"
 harness = false

--- a/crates/core/examples/load_nft.rs
+++ b/crates/core/examples/load_nft.rs
@@ -47,18 +47,31 @@
 //! ```sh
 //! cargo run -p webarkitlib-rs --example load_nft
 //! ```
+//!
+//! This example uses [`webarkitlib_rs::arlog`] for logging via `arlog_i!`
+//! and installs the bundled `env_logger`-based backend with
+//! [`webarkitlib_rs::arlog::ar_log_init_default`]. The initializer is gated
+//! behind the `log-helpers` Cargo feature, which is declared as
+//! `required-features` for this example in `crates/core/Cargo.toml` — so
+//! `cargo run --example load_nft` enables it automatically; no `--features`
+//! flag needed.
+//!
+//! Adjust verbosity via the `RUST_LOG` env var (e.g. `RUST_LOG=debug`) or
+//! programmatically with [`webarkitlib_rs::arlog::set_ar_log_level`].
 
 use std::path::Path;
 use webarkitlib_rs::ar2::{AR2FeatureSetT, AR2ImageSetT};
+use webarkitlib_rs::arlog_i;
 use webarkitlib_rs::kpm::types::KpmRefDataSet;
 
 fn main() {
+    webarkitlib_rs::arlog::ar_log_init_default();
     let data_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("examples")
         .join("Data");
     let marker_name = "pinball";
 
-    println!("Loading NFT marker: '{}'", marker_name);
+    arlog_i!("Loading NFT marker: '{}'", marker_name);
     println!("========================================\n");
 
     // ---------------------------------------------------------------

--- a/crates/core/src/arlog.rs
+++ b/crates/core/src/arlog.rs
@@ -75,7 +75,28 @@
 //!
 //! Produces output like `[info] hello`, `[warning] low mem`, `[error] bad fd`.
 //!
-//! Examples that call `ar_log_init_default()` / `ar_log_init_wasm()` should
+//! For richer diagnostic output, use the verbose variant
+//! [`ar_log_init_default_verbose`] (or [`ar_log_init_wasm_verbose`] on
+//! `wasm32`):
+//!
+//! ```no_run
+//! # #[cfg(all(feature = "log-helpers", not(target_arch = "wasm32")))]
+//! webarkitlib_rs::arlog::ar_log_init_default_verbose();
+//! ```
+//!
+//! Verbose output uses a single bracketed header:
+//!
+//! ```text
+//! [info - 2026-04-21T14:23:45Z - webarkitlib_rs::marker] hello
+//! [warning - 2026-04-21T14:23:45Z - webarkitlib_rs::ar2] low mem
+//! ```
+//!
+//! Filtering is unchanged — `RUST_LOG` controls which records pass; the
+//! verbose flag only changes how passing records are formatted.
+//! [`arlog_rel!`] messages stay prefix-free in both modes.
+//!
+//! Examples that call `ar_log_init_default()` / `ar_log_init_wasm()` (or
+//! their `_verbose` siblings) should
 //! declare the dependency in `Cargo.toml` so `cargo run --example …` and
 //! rust-analyzer pick the feature up automatically:
 //!
@@ -205,6 +226,67 @@ macro_rules! arlog_perror {
 
 // --- Init helpers ---------------------------------------------------------
 
+/// Maps a [`log::Level`] to the lower-case ARToolKit C label
+/// (`error` / `warning` / `info` / `debug`). `Trace` collapses to `debug`.
+#[cfg(not(target_arch = "wasm32"))]
+fn level_label(level: log::Level) -> &'static str {
+    match level {
+        log::Level::Error => "error",
+        log::Level::Warn => "warning",
+        log::Level::Info => "info",
+        log::Level::Debug | log::Level::Trace => "debug",
+    }
+}
+
+/// Pure formatter used by the desktop init helpers. Extracted from the
+/// `env_logger` closure so it can be unit-tested without installing a
+/// global logger. `timestamp` is taken as a `&str` so tests can pass a
+/// fixed value while production code passes `env_logger`'s timestamp.
+#[cfg(not(target_arch = "wasm32"))]
+fn format_line(
+    verbose: bool,
+    level: log::Level,
+    target: &str,
+    module: Option<&str>,
+    timestamp: &str,
+    args: &std::fmt::Arguments<'_>,
+) -> String {
+    // Release-info channel is always prefix-free, in both modes —
+    // it's intended for clean banner / version output.
+    if target == AR_LOG_REL_TARGET {
+        return format!("{}", args);
+    }
+    let label = level_label(level);
+    if verbose {
+        let module = module.unwrap_or("?");
+        format!("[{} - {} - {}] {}", label, timestamp, module, args)
+    } else {
+        format!("[{}] {}", label, args)
+    }
+}
+
+/// Shared init for desktop env_logger backends. `verbose` toggles between the
+/// terse C-style format (`[info] msg`) and the verbose unified format
+/// (`[info - 2026-04-21T14:23:45Z - webarkitlib_rs::marker] msg`).
+#[cfg(all(feature = "log-helpers", not(target_arch = "wasm32")))]
+fn init_env_logger(verbose: bool) {
+    use std::io::Write;
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format(move |buf, record| {
+            let ts = buf.timestamp().to_string();
+            let line = format_line(
+                verbose,
+                record.level(),
+                record.target(),
+                record.module_path(),
+                &ts,
+                record.args(),
+            );
+            writeln!(buf, "{}", line)
+        })
+        .init();
+}
+
 /// Installs [`env_logger`] with a formatter that reproduces ARToolKit's C
 /// output format (`[info] msg`, `[warning] msg`, `[error] msg`, `[debug] msg`,
 /// and unprefixed release-info). Honors `RUST_LOG` if set, defaults to `info`.
@@ -219,23 +301,25 @@ macro_rules! arlog_perror {
 /// ```
 #[cfg(all(feature = "log-helpers", not(target_arch = "wasm32")))]
 pub fn ar_log_init_default() {
-    use std::io::Write;
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
-        .format(|buf, record| {
-            if record.target() == AR_LOG_REL_TARGET {
-                writeln!(buf, "{}", record.args())
-            } else {
-                let label = match record.level() {
-                    log::Level::Error => "error",
-                    log::Level::Warn => "warning",
-                    log::Level::Info => "info",
-                    log::Level::Debug => "debug",
-                    log::Level::Trace => "debug",
-                };
-                writeln!(buf, "[{}] {}", label, record.args())
-            }
-        })
-        .init();
+    init_env_logger(false);
+}
+
+/// Verbose variant of [`ar_log_init_default`]. Uses a single bracketed
+/// header containing level, ISO-8601 UTC timestamp, and the originating
+/// module path:
+///
+/// ```text
+/// [info - 2026-04-21T14:23:45Z - webarkitlib_rs::marker] hello
+/// ```
+///
+/// Release-info messages (via [`arlog_rel!`]) stay prefix-free even in
+/// verbose mode, so they remain suitable for banners.
+///
+/// Filtering is unchanged from the terse variant — `RUST_LOG` still
+/// controls which records pass; this only changes how they are formatted.
+#[cfg(all(feature = "log-helpers", not(target_arch = "wasm32")))]
+pub fn ar_log_init_default_verbose() {
+    init_env_logger(true);
 }
 
 /// Installs [`console_log`] so `arlog_*!` macros appear in the browser DevTools
@@ -244,6 +328,19 @@ pub fn ar_log_init_default() {
 pub fn ar_log_init_wasm() {
     console_log::init_with_level(log::Level::Info).expect("console_log init failed");
     log::set_max_level(log::LevelFilter::Info);
+}
+
+/// Verbose WASM variant: initializes [`console_log`] at `Debug` level so
+/// `arlog_d!` records also reach the DevTools console.
+///
+/// Note: browser DevTools renders its own timestamp and source-location
+/// columns for each console entry, so the verbose format used by the
+/// desktop init helper is unnecessary here — DevTools already shows that
+/// metadata natively.
+#[cfg(all(feature = "log-helpers", target_arch = "wasm32"))]
+pub fn ar_log_init_wasm_verbose() {
+    console_log::init_with_level(log::Level::Debug).expect("console_log init failed");
+    log::set_max_level(log::LevelFilter::Debug);
 }
 
 // --- Tests ----------------------------------------------------------------
@@ -432,6 +529,104 @@ mod tests {
             0,
             "arlog_d! must not evaluate args when filtered"
         );
+    }
+
+    // --- format_line tests (verbose mode wiring) ---
+
+    const FAKE_TS: &str = "2026-04-21T14:23:45Z";
+
+    #[test]
+    fn format_line_terse_info() {
+        let s = format_line(
+            false,
+            log::Level::Info,
+            "webarkitlib_rs::marker",
+            Some("webarkitlib_rs::marker"),
+            FAKE_TS,
+            &format_args!("hello {}", 42),
+        );
+        assert_eq!(s, "[info] hello 42");
+    }
+
+    #[test]
+    fn format_line_terse_warn_uses_warning_label() {
+        let s = format_line(
+            false,
+            log::Level::Warn,
+            "x",
+            Some("x"),
+            FAKE_TS,
+            &format_args!("low mem"),
+        );
+        assert_eq!(s, "[warning] low mem");
+    }
+
+    #[test]
+    fn format_line_verbose_includes_ts_and_module() {
+        let s = format_line(
+            true,
+            log::Level::Info,
+            "webarkitlib_rs::marker",
+            Some("webarkitlib_rs::marker"),
+            FAKE_TS,
+            &format_args!("hello"),
+        );
+        assert_eq!(
+            s,
+            "[info - 2026-04-21T14:23:45Z - webarkitlib_rs::marker] hello"
+        );
+    }
+
+    #[test]
+    fn format_line_verbose_falls_back_to_question_mark_module() {
+        let s = format_line(
+            true,
+            log::Level::Error,
+            "x",
+            None,
+            FAKE_TS,
+            &format_args!("bad fd"),
+        );
+        assert_eq!(s, "[error - 2026-04-21T14:23:45Z - ?] bad fd");
+    }
+
+    #[test]
+    fn format_line_rel_channel_is_prefix_free_in_terse_mode() {
+        let s = format_line(
+            false,
+            log::Level::Info,
+            AR_LOG_REL_TARGET,
+            Some("webarkitlib_rs::version"),
+            FAKE_TS,
+            &format_args!("WebARKitLib-rs v0.3.3"),
+        );
+        assert_eq!(s, "WebARKitLib-rs v0.3.3");
+    }
+
+    #[test]
+    fn format_line_rel_channel_is_prefix_free_in_verbose_mode() {
+        let s = format_line(
+            true,
+            log::Level::Info,
+            AR_LOG_REL_TARGET,
+            Some("webarkitlib_rs::version"),
+            FAKE_TS,
+            &format_args!("WebARKitLib-rs v0.3.3"),
+        );
+        assert_eq!(s, "WebARKitLib-rs v0.3.3");
+    }
+
+    #[test]
+    fn format_line_trace_collapses_to_debug_label() {
+        let s = format_line(
+            false,
+            log::Level::Trace,
+            "x",
+            Some("x"),
+            FAKE_TS,
+            &format_args!("trace msg"),
+        );
+        assert_eq!(s, "[debug] trace msg");
     }
 
     #[test]

--- a/crates/core/src/arlog.rs
+++ b/crates/core/src/arlog.rs
@@ -1,0 +1,425 @@
+/*
+ *  arlog.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! ARToolKit-style logging on top of the [`log`] crate facade.
+//!
+//! Provides the familiar `arlog_d!`/`arlog_i!`/`arlog_w!`/`arlog_e!`/`arlog_rel!`/`arlog_perror!`
+//! macros for code ported from the C++ WebARKitLib. Every call routes through
+//! the standard `log` crate, so any backend (`env_logger`, `android_logger`,
+//! `oslog`, `console_log`, `tracing`, …) works without change.
+//!
+//! # C ↔ Rust mapping
+//!
+//! | C macro                   | Rust macro               |
+//! |---------------------------|--------------------------|
+//! | `ARLOGd("x=%d", x);`      | `arlog_d!("x={}", x);`   |
+//! | `ARLOGi("x=%d", x);`      | `arlog_i!("x={}", x);`   |
+//! | `ARLOGw("x=%d", x);`      | `arlog_w!("x={}", x);`   |
+//! | `ARLOGe("x=%d", x);`      | `arlog_e!("x={}", x);`   |
+//! | `ARLOG("banner\n");`      | `arlog_rel!("banner");`  |
+//! | `ARLOGperror("open");`    | `arlog_perror!("open");` |
+//!
+//! Drop the trailing `\n` — the macros emit newlines automatically through
+//! the backend formatter.
+//!
+//! # Setup
+//!
+//! Applications/examples initialize a backend **once** at startup. With the
+//! `log-helpers` feature enabled, this crate ships a ready-made initializer
+//! that reproduces the C ARToolKit output format:
+//!
+//! ```no_run
+//! # #[cfg(all(feature = "log-helpers", not(target_arch = "wasm32")))]
+//! webarkitlib_rs::arlog::ar_log_init_default();
+//! ```
+//!
+//! Produces output like `[info] hello`, `[warning] low mem`, `[error] bad fd`.
+//!
+//! # `RelInfo` semantics
+//!
+//! `arlog_rel!` routes through `target: "arlog::rel"` at `Level::Info`. To
+//! reproduce the C behavior "only `RelInfo` passes", users set
+//! `RUST_LOG=off,arlog::rel=info`. The bundled `ar_log_init_default()`
+//! formatter emits `arlog::rel` messages without the `[level]` prefix.
+
+/// Logging severity. Mirrors the C `AR_LOG_LEVEL_*` constants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(i32)]
+pub enum ArLogLevel {
+    Debug = 0,
+    Info = 1,
+    Warn = 2,
+    Error = 3,
+    /// Release-info: unconditional informational output with no `[level]` prefix.
+    /// Routed through target `"arlog::rel"`.
+    RelInfo = 4,
+}
+
+/// Matches the C `AR_LOG_LEVEL_DEFAULT`.
+pub const AR_LOG_LEVEL_DEFAULT: ArLogLevel = ArLogLevel::Info;
+
+impl From<ArLogLevel> for log::LevelFilter {
+    fn from(v: ArLogLevel) -> Self {
+        match v {
+            ArLogLevel::Debug => log::LevelFilter::Debug,
+            ArLogLevel::Info => log::LevelFilter::Info,
+            ArLogLevel::Warn => log::LevelFilter::Warn,
+            ArLogLevel::Error => log::LevelFilter::Error,
+            // No exact equivalent in `log::LevelFilter`; `RelInfo` is a marker,
+            // not a filter threshold. Map to Info so messages are not silenced.
+            ArLogLevel::RelInfo => log::LevelFilter::Info,
+        }
+    }
+}
+
+impl From<log::LevelFilter> for ArLogLevel {
+    fn from(v: log::LevelFilter) -> Self {
+        match v {
+            log::LevelFilter::Off | log::LevelFilter::Error => ArLogLevel::Error,
+            log::LevelFilter::Warn => ArLogLevel::Warn,
+            log::LevelFilter::Info => ArLogLevel::Info,
+            log::LevelFilter::Debug | log::LevelFilter::Trace => ArLogLevel::Debug,
+        }
+    }
+}
+
+/// Sets the global minimum log level. Equivalent to assigning `arLogLevel` in C.
+pub fn set_ar_log_level(level: ArLogLevel) {
+    log::set_max_level(level.into());
+}
+
+/// Returns the current global minimum log level.
+pub fn ar_log_level() -> ArLogLevel {
+    log::max_level().into()
+}
+
+/// Target string used by [`arlog_rel!`] so backends can distinguish
+/// release-info messages from plain `info` records.
+pub const AR_LOG_REL_TARGET: &str = "arlog::rel";
+
+#[macro_export]
+macro_rules! arlog_d {
+    ($($arg:tt)*) => { ::log::debug!($($arg)*); };
+}
+
+#[macro_export]
+macro_rules! arlog_i {
+    ($($arg:tt)*) => { ::log::info!($($arg)*); };
+}
+
+#[macro_export]
+macro_rules! arlog_w {
+    ($($arg:tt)*) => { ::log::warn!($($arg)*); };
+}
+
+#[macro_export]
+macro_rules! arlog_e {
+    ($($arg:tt)*) => { ::log::error!($($arg)*); };
+}
+
+/// Release-info: informational output without a level prefix. Uses
+/// `target: "arlog::rel"` so backends can format it without the `[info]` tag.
+#[macro_export]
+macro_rules! arlog_rel {
+    ($($arg:tt)*) => {
+        ::log::log!(target: $crate::arlog::AR_LOG_REL_TARGET, ::log::Level::Info, $($arg)*);
+    };
+}
+
+/// C `ARLOGperror` equivalent: logs `std::io::Error::last_os_error()` at error
+/// level, optionally prefixed by a caller-supplied string.
+///
+/// ```no_run
+/// use webarkitlib_rs::arlog_perror;
+/// arlog_perror!();            // → "[error] No such file or directory (os error 2)"
+/// arlog_perror!("open");      // → "[error] open: No such file or directory (os error 2)"
+/// ```
+#[macro_export]
+macro_rules! arlog_perror {
+    () => {
+        ::log::error!("{}", ::std::io::Error::last_os_error());
+    };
+    ($prefix:expr) => {
+        ::log::error!("{}: {}", $prefix, ::std::io::Error::last_os_error());
+    };
+}
+
+// --- Init helpers ---------------------------------------------------------
+
+/// Installs [`env_logger`] with a formatter that reproduces ARToolKit's C
+/// output format (`[info] msg`, `[warning] msg`, `[error] msg`, `[debug] msg`,
+/// and unprefixed release-info). Honors `RUST_LOG` if set, defaults to `info`.
+///
+/// Call once in your binary's `main()` — never from library code.
+///
+/// ```no_run
+/// fn main() {
+///     webarkitlib_rs::arlog::ar_log_init_default();
+///     // ... rest of your application
+/// }
+/// ```
+#[cfg(all(feature = "log-helpers", not(target_arch = "wasm32")))]
+pub fn ar_log_init_default() {
+    use std::io::Write;
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format(|buf, record| {
+            if record.target() == AR_LOG_REL_TARGET {
+                writeln!(buf, "{}", record.args())
+            } else {
+                let label = match record.level() {
+                    log::Level::Error => "error",
+                    log::Level::Warn => "warning",
+                    log::Level::Info => "info",
+                    log::Level::Debug => "debug",
+                    log::Level::Trace => "debug",
+                };
+                writeln!(buf, "[{}] {}", label, record.args())
+            }
+        })
+        .init();
+}
+
+/// Installs [`console_log`] so `arlog_*!` macros appear in the browser DevTools
+/// console. Call once from your WASM entry point.
+#[cfg(all(feature = "log-helpers", target_arch = "wasm32"))]
+pub fn ar_log_init_wasm() {
+    console_log::init_with_level(log::Level::Info).expect("console_log init failed");
+    log::set_max_level(log::LevelFilter::Info);
+}
+
+// --- Tests ----------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Mutex, OnceLock};
+
+    type Captured = (log::Level, String, String);
+
+    static CAPTURES: OnceLock<Mutex<Vec<Captured>>> = OnceLock::new();
+    static TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    static INIT: OnceLock<()> = OnceLock::new();
+
+    fn captures() -> &'static Mutex<Vec<Captured>> {
+        CAPTURES.get_or_init(|| Mutex::new(Vec::new()))
+    }
+
+    fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+        TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
+
+    struct CaptureLogger;
+    impl log::Log for CaptureLogger {
+        fn enabled(&self, _m: &log::Metadata) -> bool {
+            true
+        }
+        fn log(&self, record: &log::Record) {
+            captures().lock().unwrap().push((
+                record.level(),
+                record.target().to_string(),
+                record.args().to_string(),
+            ));
+        }
+        fn flush(&self) {}
+    }
+
+    static LOGGER: CaptureLogger = CaptureLogger;
+
+    fn init_capture() {
+        INIT.get_or_init(|| {
+            let _ = log::set_logger(&LOGGER);
+            log::set_max_level(log::LevelFilter::Trace);
+        });
+    }
+
+    fn drain() -> Vec<Captured> {
+        std::mem::take(&mut *captures().lock().unwrap())
+    }
+
+    #[test]
+    fn level_roundtrip_debug() {
+        let _g = test_lock();
+        init_capture();
+        set_ar_log_level(ArLogLevel::Debug);
+        assert_eq!(ar_log_level(), ArLogLevel::Debug);
+    }
+
+    #[test]
+    fn level_roundtrip_info() {
+        let _g = test_lock();
+        init_capture();
+        set_ar_log_level(ArLogLevel::Info);
+        assert_eq!(ar_log_level(), ArLogLevel::Info);
+    }
+
+    #[test]
+    fn level_roundtrip_warn() {
+        let _g = test_lock();
+        init_capture();
+        set_ar_log_level(ArLogLevel::Warn);
+        assert_eq!(ar_log_level(), ArLogLevel::Warn);
+    }
+
+    #[test]
+    fn level_roundtrip_error() {
+        let _g = test_lock();
+        init_capture();
+        set_ar_log_level(ArLogLevel::Error);
+        assert_eq!(ar_log_level(), ArLogLevel::Error);
+    }
+
+    #[test]
+    fn level_relinfo_is_lossy() {
+        let _g = test_lock();
+        init_capture();
+        set_ar_log_level(ArLogLevel::RelInfo);
+        assert_eq!(ar_log_level(), ArLogLevel::Info);
+    }
+
+    #[test]
+    fn level_filter_off_maps_to_error() {
+        let _g = test_lock();
+        init_capture();
+        log::set_max_level(log::LevelFilter::Off);
+        assert_eq!(ar_log_level(), ArLogLevel::Error);
+    }
+
+    #[test]
+    fn level_filter_trace_maps_to_debug() {
+        let _g = test_lock();
+        init_capture();
+        log::set_max_level(log::LevelFilter::Trace);
+        assert_eq!(ar_log_level(), ArLogLevel::Debug);
+    }
+
+    #[test]
+    fn arlog_i_emits_info_record() {
+        let _g = test_lock();
+        init_capture();
+        log::set_max_level(log::LevelFilter::Trace);
+        drain();
+        arlog_i!("hello {}", 42);
+        let records = drain();
+        assert_eq!(records.len(), 1);
+        let (lvl, _target, msg) = &records[0];
+        assert_eq!(*lvl, log::Level::Info);
+        assert_eq!(msg, "hello 42");
+    }
+
+    #[test]
+    fn arlog_rel_uses_distinct_target() {
+        let _g = test_lock();
+        init_capture();
+        log::set_max_level(log::LevelFilter::Trace);
+        drain();
+        arlog_rel!("banner v{}", "0.3.3");
+        let records = drain();
+        assert_eq!(records.len(), 1);
+        let (lvl, target, msg) = &records[0];
+        assert_eq!(*lvl, log::Level::Info);
+        assert_eq!(target, AR_LOG_REL_TARGET);
+        assert_eq!(msg, "banner v0.3.3");
+    }
+
+    #[test]
+    fn arlog_perror_no_prefix() {
+        let _g = test_lock();
+        init_capture();
+        log::set_max_level(log::LevelFilter::Error);
+        drain();
+        arlog_perror!();
+        let records = drain();
+        assert_eq!(records.len(), 1);
+        let (lvl, _t, msg) = &records[0];
+        assert_eq!(*lvl, log::Level::Error);
+        assert!(!msg.is_empty());
+        assert!(!msg.starts_with(": "), "unexpected prefix: {msg}");
+    }
+
+    #[test]
+    fn arlog_perror_with_prefix() {
+        let _g = test_lock();
+        init_capture();
+        log::set_max_level(log::LevelFilter::Error);
+        drain();
+        arlog_perror!("my_op");
+        let records = drain();
+        assert_eq!(records.len(), 1);
+        let (lvl, _t, msg) = &records[0];
+        assert_eq!(*lvl, log::Level::Error);
+        assert!(msg.starts_with("my_op: "), "got: {msg}");
+        assert!(msg.len() > "my_op: ".len(), "missing os error text: {msg}");
+    }
+
+    static EVAL_COUNT: AtomicUsize = AtomicUsize::new(0);
+    fn side_effect() -> &'static str {
+        EVAL_COUNT.fetch_add(1, Ordering::SeqCst);
+        "x"
+    }
+
+    #[test]
+    fn filtered_debug_arg_is_not_evaluated() {
+        let _g = test_lock();
+        init_capture();
+        set_ar_log_level(ArLogLevel::Info);
+        EVAL_COUNT.store(0, Ordering::SeqCst);
+        arlog_d!("{}", side_effect());
+        assert_eq!(
+            EVAL_COUNT.load(Ordering::SeqCst),
+            0,
+            "arlog_d! must not evaluate args when filtered"
+        );
+    }
+
+    #[test]
+    fn unfiltered_debug_arg_is_evaluated() {
+        let _g = test_lock();
+        init_capture();
+        set_ar_log_level(ArLogLevel::Debug);
+        drain();
+        EVAL_COUNT.store(0, Ordering::SeqCst);
+        arlog_d!("{}", side_effect());
+        assert_eq!(EVAL_COUNT.load(Ordering::SeqCst), 1);
+        let records = drain();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].0, log::Level::Debug);
+        assert_eq!(records[0].2, "x");
+    }
+}

--- a/crates/core/src/arlog.rs
+++ b/crates/core/src/arlog.rs
@@ -57,9 +57,16 @@
 //!
 //! # Setup
 //!
-//! Applications/examples initialize a backend **once** at startup. With the
-//! `log-helpers` feature enabled, this crate ships a ready-made initializer
-//! that reproduces the C ARToolKit output format:
+//! The `arlog_*!` macros are **always available** — they compile and run
+//! without any extra feature. However, log records are only *displayed* when
+//! a logger backend has been installed in the process; otherwise output is
+//! silently dropped (this is standard `log` crate behavior).
+//!
+//! ## Option 1 — bundled initializer (`log-helpers` feature)
+//!
+//! With the `log-helpers` feature enabled, this crate ships a ready-made
+//! initializer that reproduces the C ARToolKit output format
+//! (`env_logger` on native, `console_log` on `wasm32`):
 //!
 //! ```no_run
 //! # #[cfg(all(feature = "log-helpers", not(target_arch = "wasm32")))]
@@ -67,6 +74,25 @@
 //! ```
 //!
 //! Produces output like `[info] hello`, `[warning] low mem`, `[error] bad fd`.
+//!
+//! Examples that call `ar_log_init_default()` / `ar_log_init_wasm()` should
+//! declare the dependency in `Cargo.toml` so `cargo run --example …` and
+//! rust-analyzer pick the feature up automatically:
+//!
+//! ```toml
+//! [[example]]
+//! name = "load_nft"
+//! required-features = ["log-helpers"]
+//! ```
+//!
+//! See `examples/load_nft.rs` for the canonical usage pattern.
+//!
+//! ## Option 2 — bring your own backend
+//!
+//! If `log-helpers` is **off**, the `arlog_*!` macros still compile and emit
+//! `log::Record`s. Install any `log`-compatible backend yourself
+//! (`env_logger`, `tracing-subscriber`, `android_logger`, `oslog`, …) and
+//! records will flow through it unchanged.
 //!
 //! # `RelInfo` semantics
 //!

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -100,6 +100,7 @@
 //! ```
 
 pub mod ar2;
+pub mod arlog;
 pub mod bch;
 pub mod filter;
 pub mod icp;


### PR DESCRIPTION
## Summary

Ports the ARToolKit C logging API (`ARLOGd`/`i`/`w`/`e`/`ARLOG`/`ARLOGperror`) to Rust as **thin macros over the standard `log` crate facade**, rather than as a custom from-scratch implementation.

Full design rationale and decision log: [#57 comment](https://github.com/webarkit/WebARKitLib-rs/issues/57#issuecomment-4287095104).

## Key design choices

- **Hybrid over `log` crate** instead of a custom `RwLock<LogState>` + callback mechanism. The `log` crate was already a dependency used in 7 files — reinventing it would fight existing code. We keep the ARToolKit macro vocabulary (`arlog_d!`/`i!`/`w!`/`e!`) as **1-line wrappers** over `log::debug!`/`info!`/`warn!`/`error!`.
- **Module named `arlog`** (not `log`) to avoid shadowing the external `log` crate at the crate root. Macro names remain `arlog_*!`.
- **`set_ar_log_level()` / `ar_log_level()`** wrap `log::set_max_level()` / `log::max_level()` — preserves the C API name, reuses the battle-tested lock-free atomic.
- **`arlog_rel!`** routes through `target: "arlog::rel"` at `Level::Info` so backends can distinguish release-info from plain info messages.
- **`arlog_perror!`** is the one genuine addition — formats `std::io::Error::last_os_error()` with optional prefix at error level.
- **Optional `log-helpers` feature** ships four batteries-included initializers:
  - `ar_log_init_default()` (desktop) — installs `env_logger` with a formatter that reproduces C ARToolKit's `[info] msg` / `[warning] msg` / etc. output format
  - `ar_log_init_default_verbose()` (desktop) — same but with timestamp + module path in a single bracketed header: `[info - 2026-04-21T14:23:45Z - webarkitlib_rs::marker] hello`
  - `ar_log_init_wasm()` (browser) — installs `console_log` at `Info` level
  - `ar_log_init_wasm_verbose()` (browser) — same at `Debug` level (browser DevTools renders timestamp + source location natively, so desktop-style formatting would be redundant)

## Verbose mode details

- **Single bracketed header** — dash-separated level / ISO-8601 UTC timestamp / module path — rather than stacking `[info]` + env_logger's default `[ts LEVEL target]`. Level appears once, output is easier to scan.
- **Filtering is unchanged** — `RUST_LOG` still controls which records pass; the verbose flag only affects how passing records are formatted.
- **`arlog_rel!` stays prefix-free in both modes** — it's for banner / version output and should never get timestamps.
- Format logic extracted into a pure `format_line()` helper so it's **unit-testable without installing a global logger**. 7 new tests cover terse/verbose/rel-channel/trace-collapse/missing-module-path.

## Example pinning

`crates/core/examples/load_nft.rs` is the first example calling `ar_log_init_default()`. It's declared with `required-features = ["log-helpers"]` in `Cargo.toml` so `cargo run --example load_nft` auto-enables the feature (no `--features` flag needed), and rust-analyzer no longer flags E0425 on the init call.

## What's NOT in this PR

Per the [2-PR split agreed in the issue comment](https://github.com/webarkit/WebARKitLib-rs/issues/57#issuecomment-4287095104):
- **This PR (PR1): purely additive infrastructure.** No existing call sites are modified.
- **PR2 (to follow): the C→Rust call-site sweep** — replace `param.rs:85` `println!` + import `ARLOG*` calls from upstream `WebARKitLib/lib/SRC/` across all Rust modules.

## Test plan

- [x] `cargo build -p webarkitlib-rs` — clean, no warnings
- [x] `cargo build -p webarkitlib-rs --features log-helpers` — clean
- [x] `cargo build --target wasm32-unknown-unknown -p webarkitlib-rs --features log-helpers` — clean
- [x] `cargo test -p webarkitlib-rs --lib` — **all passing** (20 `arlog` tests)
- [x] `cargo clippy -p webarkitlib-rs --lib --tests --features log-helpers` — zero warnings in `arlog.rs`
- [x] `cargo fmt --check -p webarkitlib-rs` — clean
- [x] End-to-end sanity: `cargo run --example load_nft` with verbose init prints `[info - 2026-04-21T14:35:18Z - load_nft] hello`

### Tests (all in `crates/core/src/arlog.rs`)

Level API:
- `level_roundtrip_{debug,info,warn,error}` — `set_ar_log_level` / `ar_log_level` symmetry
- `level_relinfo_is_lossy` — documents intentional `RelInfo → Info` round-trip
- `level_filter_off_maps_to_error`, `level_filter_trace_maps_to_debug` — edge mappings

Macros:
- `arlog_i_emits_info_record` — captures level + args via a test `log::Log` impl
- `arlog_rel_uses_distinct_target` — verifies `target: "arlog::rel"`
- `arlog_perror_{no_prefix,with_prefix}` — verifies error-level routing + prefix formatting
- `filtered_debug_arg_is_not_evaluated` — asserts lazy formatting (zero alloc when filtered)
- `unfiltered_debug_arg_is_evaluated` — complementary positive case

Formatter (verbose mode):
- `format_line_terse_info`, `format_line_terse_warn_uses_warning_label`
- `format_line_verbose_includes_ts_and_module`
- `format_line_verbose_falls_back_to_question_mark_module`
- `format_line_rel_channel_is_prefix_free_in_{terse,verbose}_mode`
- `format_line_trace_collapses_to_debug_label`

## Docs

- `README.md` gains a 📝 Logging section with the C↔Rust macro mapping table, quick-start, **Verbose mode** subsection, verbosity control, and backend options (WASM / Android / Apple / tracing).
- `arlog.rs` module doc-comment includes the same mapping, both init options, and bring-your-own-backend guidance.
- `load_nft.rs` header documents the example's use of `arlog_i!`, the `required-features` mechanism, and how to tune verbosity.

## Follow-up

- PR2 — C→Rust log-call sweep — will be opened on a separate branch `feat/issue-57-log-sweep` from `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)