### PR TITLE
refactor(log): swap bare log::* for arlog_* vocabulary (Pass B1)

### DIFF
--- a/crates/core/src/ar2/image_set.rs
+++ b/crates/core/src/ar2/image_set.rs
@@ -64,6 +64,7 @@
 //! ```
 
 use super::Ar2Error;
+use crate::arlog_d;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use rayon::prelude::*;
 use std::io::{self, BufWriter, Cursor, Read, Write};
@@ -140,7 +141,7 @@ impl AR2ImageSetT {
                 Ok(set) => return Ok(set),
                 Err(_) => {
                     // Fall through to legacy.
-                    log::debug!("JPEG decode failed, trying legacy format");
+                    arlog_d!("JPEG decode failed, trying legacy format");
                 }
             }
         }

--- a/crates/core/src/marker.rs
+++ b/crates/core/src/marker.rs
@@ -37,8 +37,8 @@
 //! Marker Detection Pipeline
 //! Ported from arDetectMarker.c, arDetectMarker2.c, and arGetMarkerInfo.c
 
+use crate::arlog_d;
 use crate::types::{ARLabelInfo, ARMarkerInfo2, ARdouble};
-use log::debug;
 
 pub const AR_AREA_MAX: i32 = 100000;
 pub const AR_AREA_MIN: i32 = 70;
@@ -124,7 +124,7 @@ pub fn ar_detect_marker(
     )?;
 
     if ar_handle.ar_debug != 0 {
-        debug!(
+        arlog_d!(
             "ar_labeling found {} labels.",
             ar_handle.label_info.label_num
         );
@@ -149,7 +149,7 @@ pub fn ar_detect_marker(
     )?;
 
     if ar_handle.ar_debug != 0 {
-        debug!(
+        arlog_d!(
             "ar_detect_marker2 found {} square candidates.",
             ar_handle.marker2_num
         );
@@ -191,7 +191,7 @@ pub fn ar_detect_marker(
     )?;
 
     if ar_handle.ar_debug != 0 {
-        debug!(
+        arlog_d!(
             "ar_get_marker_info produced {} final markers.",
             ar_handle.marker_num
         );
@@ -246,18 +246,21 @@ pub fn ar_detect_marker2(
     let label_num = label_info.label_num as usize;
     for i in 0..label_num {
         if label_info.area[i] < area_min_local || label_info.area[i] > area_max_local {
-            debug!(
+            arlog_d!(
                 "Label {} skipped due to Area ({}) not in [{}, {}]",
-                i, label_info.area[i], area_min_local, area_max_local
+                i,
+                label_info.area[i],
+                area_min_local,
+                area_max_local
             );
             continue;
         }
         if label_info.clip[i][0] <= 1 || label_info.clip[i][1] >= xsize_local - 2 {
-            debug!("Label {} skipped due to X-Clip bounds", i);
+            arlog_d!("Label {} skipped due to X-Clip bounds", i);
             continue;
         }
         if label_info.clip[i][2] <= 1 || label_info.clip[i][3] >= ysize_local - 2 {
-            debug!("Label {} skipped due to Y-Clip bounds", i);
+            arlog_d!("Label {} skipped due to Y-Clip bounds", i);
             continue;
         }
 
@@ -273,7 +276,7 @@ pub fn ar_detect_marker2(
         );
 
         if ret.is_err() {
-            debug!(
+            arlog_d!(
                 "ar_get_contour failed for label {}: {:?}",
                 i,
                 ret.unwrap_err()
@@ -283,7 +286,7 @@ pub fn ar_detect_marker2(
 
         let ret = check_square(label_info.area[i], &mut current_marker, square_fit_thresh);
         if ret.is_err() {
-            debug!(
+            arlog_d!(
                 "check_square failed for label {}: {:?}",
                 i,
                 ret.unwrap_err()
@@ -391,7 +394,7 @@ fn ar_get_contour(
     }
 
     if sx == -1 {
-        debug!("ar_get_contour failed. label={}. clip={:?}.", label, clip);
+        arlog_d!("ar_get_contour failed. label={}. clip={:?}.", label, clip);
         return Err("Contour start point not found");
     }
 
@@ -858,13 +861,15 @@ pub fn ar_get_marker_info(
                     marker_info[j].dir_matrix = mc_dir;
                     marker_info[j].cf_matrix = mc_cf;
                     marker_info[j].error_corrected = mc_err;
-                    debug!(
+                    arlog_d!(
                         "ar_get_marker_info: barcode id={}, dir={}, cf={:.4}",
-                        mc_id, mc_dir, mc_cf
+                        mc_id,
+                        mc_dir,
+                        mc_cf
                     );
                 }
                 Err(e) => {
-                    debug!("ar_get_marker_info: barcode decode failed: {}", e);
+                    arlog_d!("ar_get_marker_info: barcode decode failed: {}", e);
                     marker_info[j].id_matrix = -1;
                     marker_info[j].dir_matrix = -1;
                     marker_info[j].cf_matrix = 0.0;

--- a/crates/core/src/matrix.rs
+++ b/crates/core/src/matrix.rs
@@ -26,9 +26,10 @@
 //! Matrix Code (Barcode) Marker Decoding
 //! Ported from arGetMatrixCode.c and associated ECC logic.
 
+use crate::arlog_d;
 use crate::marker::ar_get_line;
 use crate::types::{ARHandle, ARMarkerInfo, ARMarkerInfo2, ARMatrixCodeType, ARdouble};
-use log::{debug, trace};
+use log::trace;
 
 /// Results of a matrix code decoding attempt.
 #[derive(Debug, Clone, PartialEq)]
@@ -112,7 +113,7 @@ pub fn ar_matrix_code_get_id(
         &mut bits,
     )?;
 
-    debug!("ar_matrix_code_get_id: vertices v0=({:.1},{:.1}) v1=({:.1},{:.1}) v2=({:.1},{:.1}) v3=({:.1},{:.1})",
+    arlog_d!("ar_matrix_code_get_id: vertices v0=({:.1},{:.1}) v1=({:.1},{:.1}) v2=({:.1},{:.1}) v3=({:.1},{:.1})",
         vertex[0][0], vertex[0][1], vertex[1][0], vertex[1][1],
         vertex[2][0], vertex[2][1], vertex[3][0], vertex[3][1]);
 
@@ -128,9 +129,11 @@ pub fn ar_matrix_code_get_id(
     }
 
     let mid_thresh = ((min_val as u32 + max_val as u32) / 2) as u8;
-    debug!(
+    arlog_d!(
         "ar_matrix_code_get_id: min={}, max={}, thresh={}",
-        min_val, max_val, mid_thresh
+        min_val,
+        max_val,
+        mid_thresh
     );
 
     if (max_val as i32 - min_val as i32) < 30 {
@@ -147,7 +150,7 @@ pub fn ar_matrix_code_get_id(
         grid_size,
         core_bits
     );
-    debug!("ar_matrix_code_get_id: core_bits={:?}", core_bits);
+    arlog_d!("ar_matrix_code_get_id: core_bits={:?}", core_bits);
 
     // The C reference `get_matrix_code` receives only the dim×dim inner data.
     // Check orientation based on corners of the core data:
@@ -257,9 +260,10 @@ pub fn ar_matrix_code_get_id(
         }
     }
 
-    debug!(
+    arlog_d!(
         "ar_matrix_code_get_id: code_raw={}, dir={}",
-        code_raw, matched_dir
+        code_raw,
+        matched_dir
     );
 
     *dir = matched_dir;

--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -60,7 +60,7 @@ pub fn get_version() -> &'static str {
 /// Call this early in your application (e.g. during initialization) so the
 /// version appears in the console / log output.
 pub fn print_version() {
-    log::info!("WebARKitLib-rs v{}", VERSION);
+    crate::arlog_i!("WebARKitLib-rs v{}", VERSION);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Pass B1 of the issue #57 log sweep — pure mechanical consistency change.

Swaps remaining bare \`log::debug!\`/\`log::info!\` calls to the ARToolKit-flavored \`arlog_*!\` wrappers so module call-sites speak one vocabulary.

| File | Change |
|---|---|
| \`marker.rs\` | 12× \`debug!\` → \`arlog_d!\`; import swap |
| \`matrix.rs\` | 4× \`debug!\` → \`arlog_d!\`; \`trace!\` kept |
| \`ar2/image_set.rs\` | 1× \`log::debug!\` → \`arlog_d!\` |
| \`version.rs\` | \`log::info!\` → \`arlog_i!\` |
| \`labeling.rs\` | untouched (only \`trace!\` calls; no \`arlog_t!\` yet) |

Runtime behavior is unchanged — \`arlog_*!\` macros delegate to the same \`log\` crate facade at the same levels.

Follows PR #66 (Phase 1) and PR #67 (Pass A). Pass B2/B3 (C↔Rust parity sweep) will come in separate PRs.

## Test plan
- [x] \`cargo build -p webarkitlib-rs\` — clean (pre-existing warnings only)
- [x] \`cargo test -p webarkitlib-rs --lib\` — 87 passed, 2 ignored
- [x] \`cargo fmt\` — applied
- [x] \`cargo clippy -p webarkitlib-rs --lib\` — no new warnings

Refs #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)