### PR TITLE
docs(log): use arlog_i! instead of println! in doc examples

### DIFF
--- a/crates/core/src/labeling.rs
+++ b/crates/core/src/labeling.rs
@@ -82,6 +82,7 @@ pub enum ImageProcMode {
 ///
 /// # Example
 /// ```rust,no_run
+/// use webarkitlib_rs::arlog_i;
 /// use webarkitlib_rs::labeling::{ar_labeling, LabelingMode, ImageProcMode};
 /// use webarkitlib_rs::types::ARLabelInfo;
 ///
@@ -91,7 +92,7 @@ pub enum ImageProcMode {
 /// let mut label_info = ARLabelInfo::default();
 /// ar_labeling(&luma, width, height, LabelingMode::BlackRegion, 100,
 ///             ImageProcMode::FrameImage, &mut label_info, false).unwrap();
-/// println!("{} regions found", label_info.label_num);
+/// arlog_i!("{} regions found", label_info.label_num);
 /// ```
 pub fn ar_labeling(
     image: &[u8],

--- a/crates/core/src/marker.rs
+++ b/crates/core/src/marker.rs
@@ -70,6 +70,7 @@ pub enum ImageProcMode {
 ///
 /// # Example
 /// ```rust,no_run
+/// use webarkitlib_rs::arlog_i;
 /// use webarkitlib_rs::marker::ar_detect_marker;
 /// use webarkitlib_rs::types::{ARHandle, AR2VideoBufferT};
 ///
@@ -79,7 +80,7 @@ pub enum ImageProcMode {
 /// if ar_detect_marker(&mut handle, &frame).is_ok() {
 ///     for i in 0..handle.marker_num as usize {
 ///         let m = &handle.marker_info[i];
-///         println!("Marker id={}, cf={:.2}", m.id, m.cf);
+///         arlog_i!("Marker id={}, cf={:.2}", m.id, m.cf);
 ///     }
 /// }
 /// ```

--- a/crates/core/src/matrix.rs
+++ b/crates/core/src/matrix.rs
@@ -66,6 +66,7 @@ pub struct MatrixCodeResult {
 ///
 /// # Example
 /// ```rust,no_run
+/// use webarkitlib_rs::arlog_i;
 /// use webarkitlib_rs::matrix::ar_matrix_code_get_id;
 /// use webarkitlib_rs::types::ARMatrixCodeType;
 ///
@@ -78,7 +79,7 @@ pub struct MatrixCodeResult {
 /// if ar_matrix_code_get_id(&image, 640, 480, &vertex, ARMatrixCodeType::default(),
 ///         webarkitlib_rs::types::ARPixelFormat::RGB, 0.5,
 ///         &mut id, &mut dir, &mut cf, &mut err).is_ok() {
-///     println!("Decoded barcode id={}, dir={}, cf={:.2}", id, dir, cf);
+///     arlog_i!("Decoded barcode id={}, dir={}, cf={:.2}", id, dir, cf);
 /// }
 /// ```
 pub fn ar_matrix_code_get_id(


### PR DESCRIPTION
## Summary

Follow-up to PR #69. Three rustdoc examples in \`labeling.rs\`, \`marker.rs\`, and \`matrix.rs\` still used \`println!\` to show detection output. Swap them to \`arlog_i!\` so the examples teach the same vocabulary the module call-sites now use.

This commit was part of the original PR #69 branch but was pushed after the merge, so it didn't land. Re-submitting as its own small PR.

## Test plan
- [x] \`cargo test -p webarkitlib-rs --doc\` — 10 passed

Refs #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)