### PR TITLE
feat(log): fill in missing arlog_d! calls in marker.rs (Pass B2)

### DIFF
--- a/crates/core/src/marker.rs
+++ b/crates/core/src/marker.rs
@@ -422,6 +422,11 @@ fn ar_get_contour(
         }
 
         if !found {
+            arlog_d!(
+                "ar_get_contour: contour broken for label {} at coord_num={}",
+                label,
+                marker_info2.coord_num
+            );
             return Err("Contour broken");
         }
 
@@ -435,6 +440,11 @@ fn ar_get_contour(
 
         marker_info2.coord_num += 1;
         if marker_info2.coord_num as usize >= AR_CHAIN_MAX - 1 {
+            arlog_d!(
+                "ar_get_contour: contour exceeded AR_CHAIN_MAX={} for label {}",
+                AR_CHAIN_MAX,
+                label
+            );
             return Err("Contour too long");
         }
     }


### PR DESCRIPTION
## Summary

Pass B2 of the issue #57 log sweep — first module: \`marker.rs\`.

C↔Rust parity sweep against \`arDetectMarker.c\`, \`arDetectMarker2.c\`, and \`arGetMarkerInfo.c\` in \`benchmarks/c_benchmark/\`.

### Diff report

| # | C site | Rust site | Action |
|---|---|---|---|
| 1 | \`arDetectMarker.c:98\` (Auto threshold counts) | — | N/A — auto-threshold not ported |
| 2 | \`arDetectMarker.c:123\` (bracket adjusted) | — | N/A — same |
| 3 | \`arDetectMarker.c:156\` (median/Otsu adjusted) | — | N/A — same |
| 4 | \`arDetectMarker2.c:156\` \`ARLOGe("??? 1")\` | \`marker.rs:397\` \`arlog_d!\` | Already covered (Pass A) |
| 5 | \`arDetectMarker2.c:172\` \`ARLOGe("??? 2")\` | \`marker.rs:425\` silent \`Err\` | **Added \`arlog_d!\`** |
| 6 | \`arDetectMarker2.c:182\` \`ARLOGe("??? 3")\` | \`marker.rs:438\` silent \`Err\` | **Added \`arlog_d!\`** |
| — | \`arGetMarkerInfo.c\` | — | No logs on either side |

### Level choice

C uses \`ARLOGe\` (error). This PR uses \`arlog_d!\` for the two additions for symmetry with the existing contour-start log — these are per-label per-frame failures on any non-convex region and would spam error output otherwise.

## Test plan
- [x] \`cargo build -p webarkitlib-rs\` — clean (pre-existing warnings only)
- [x] \`cargo test -p webarkitlib-rs --lib\` — 87 passed, 2 ignored
- [x] \`cargo fmt\`

Refs #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)