### PR TITLE
feat(log): fill in missing arlog_* calls in ar2/tracking.rs (Pass B2)

### DIFF
--- a/crates/core/src/ar2/tracking.rs
+++ b/crates/core/src/ar2/tracking.rs
@@ -42,6 +42,7 @@
 use crate::ar2::surface::AR2SurfaceSet;
 use crate::icp::ICPHandleT;
 use crate::types::{ARParamLT, ARPixelFormat, ARdouble};
+use crate::{arlog_d, arlog_e};
 
 pub const AR2_TRACKING_6DOF: i32 = 1;
 pub const AR2_TRACKING_HOMOGRAPHY: i32 = 2;
@@ -545,6 +546,10 @@ pub fn extract_visible_features(
 
                 if w[1] <= feature_points.maxdpi && w[1] >= feature_points.mindpi {
                     if l >= AR2_TRACKING_CANDIDATE_MAX {
+                        arlog_e!(
+                            "### Feature candidates for tracking are overflow (max={}).",
+                            AR2_TRACKING_CANDIDATE_MAX
+                        );
                         candidate[l].flag = -1;
                         return Err("Feature candidates overflow");
                     }
@@ -619,6 +624,10 @@ pub fn extract_visible_features_homography(
 
                 if w[1] <= feature_points.maxdpi && w[1] >= feature_points.mindpi {
                     if l >= AR2_TRACKING_CANDIDATE_MAX {
+                        arlog_e!(
+                            "### Feature candidates for tracking are overflow (max={}).",
+                            AR2_TRACKING_CANDIDATE_MAX
+                        );
                         candidate[l].flag = -1;
                         return Err("Feature candidates overflow");
                     }
@@ -1118,6 +1127,7 @@ pub fn ar2_tracking(
     err: &mut f32,
 ) -> Result<(), i32> {
     if surface_set.cont_num <= 0 {
+        arlog_d!("ar2_tracking() error: set_init_trans() must be called first.");
         return Err(-2);
     }
 


### PR DESCRIPTION
## Summary

Pass B2 of the issue #57 log sweep — next module: \`ar2/tracking.rs\`.

C↔Rust parity sweep against \`AR2/tracking.c\` and \`AR2/tracking2d.c\` in \`benchmarks/c_benchmark/\`.

### Diff report

| # | C site | Rust site | Action |
|---|---|---|---|
| 1 | \`tracking.c:80\` \`ARLOGd "ar2SetInitTrans() must be called first"\` | \`tracking.rs:1120\` silent \`Err(-2)\` | **Added \`arlog_d!\`** |
| 2 | \`tracking.c:321\` \`ARLOGe "Feature candidates for tracking are overflow"\` | \`tracking.rs:547-549\` silent \`Err\` | **Added \`arlog_e!\`** |
| 3 | \`tracking.c:406\` same | \`tracking.rs:621-623\` silent \`Err\` | **Added \`arlog_e!\`** |
| 4-9 | \`tracking.c: 529/533/639/643/648/654\` \`ARLOGe "Error: malloc"\` | — | N/A — Rust allocator |
| 10 | \`tracking2d.c:66/79\` \`ARLOGi "Start/End tracking_thread #%d"\` | — | N/A — Rust uses rayon |

### Level choice

- #1 matches C \`ARLOGd\` → \`arlog_d!\` (misuse diagnostic).
- #2, #3 match C \`ARLOGe\` → \`arlog_e!\` (hitting \`AR2_TRACKING_CANDIDATE_MAX=1000\` is a real config limit being exceeded).

## Test plan
- [x] \`cargo build -p webarkitlib-rs\` — clean (pre-existing warnings only)
- [x] \`cargo test -p webarkitlib-rs --lib\` — 87 passed, 2 ignored
- [x] \`cargo fmt\`

Refs #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)