### PR TITLE
feat(log): port informational arlog_i! calls in ar2/feature_map.rs (B2)

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -62,6 +62,10 @@ required-features = ["ffi-backend"]
 name = "load_nft"
 required-features = ["log-helpers"]
 
+[[example]]
+name = "nft_marker_gen"
+required-features = ["log-helpers"]
+
 [[bench]]
 name = "marker_bench"
 harness = false

--- a/crates/core/examples/nft_marker_gen.rs
+++ b/crates/core/examples/nft_marker_gen.rs
@@ -127,6 +127,7 @@ fn file_kb(path: &Path) -> String {
 // ---------------------------------------------------------------------------
 
 fn main() {
+    webarkitlib_rs::arlog::ar_log_init_default();
     let cli = Cli::parse();
     let start = Instant::now();
     let start_time = Local::now();

--- a/crates/core/src/ar2/feature_map.rs
+++ b/crates/core/src/ar2/feature_map.rs
@@ -43,6 +43,7 @@
 use super::feature_set::{AR2FeatureCoordT, AR2FeaturePointsT, AR2FeatureSetT};
 use super::image_set::AR2ImageSetT;
 use super::Ar2Error;
+use crate::arlog_i;
 use rayon::prelude::*;
 
 // ---------------------------------------------------------------------------
@@ -552,7 +553,6 @@ fn gen_feature_map_for_level(
             }
         }
     }
-    let _ = sum; // used implicitly via the 2% threshold
     let threshold_pixels = (total as f32 * 0.02) as u32;
     let mut acc = 0u32;
     let mut thresh_bin = 0usize;
@@ -563,6 +563,10 @@ fn gen_feature_map_for_level(
             break;
         }
     }
+
+    arlog_i!("         ImageSize = {:7}[pixel]", total);
+    arlog_i!("Extracted features = {:7}[pixel]", sum);
+    arlog_i!(" Filtered features = {:7}[pixel]", acc);
 
     // Stage 3: For each pixel passing NMS + threshold, compute template
     // similarity in the annular search region.
@@ -662,6 +666,8 @@ fn select_features(
     let mut work = fmap.to_vec();
     let mut tmpl = vec![0.0f32; template_area];
     let mut coords = Vec::new();
+
+    arlog_i!("Max feature = {}", max_feature_num);
 
     while (coords.len() as i32) < max_feature_num {
         // Find pixel with minimum similarity score


### PR DESCRIPTION
## Summary

Pass B2 of the issue #57 log sweep — module: \`ar2/feature_map.rs\`.

C↔Rust parity sweep against \`AR2/featureMap.c\` in \`benchmarks/c_benchmark/\`.

### Diff report

| # | C site | Rust site | Action |
|---|---|---|---|
| 1 | \`featureMap.c:77\` \`ARLOGe "Error saving feature map"\` | — | N/A — \`ar2SaveFeatureMap\` not ported |
| 2 | \`featureMap.c:191-193\` \`ARLOGi\` ImageSize / Extracted / Filtered | \`gen_feature_map_for_level\` | **Added 3× \`arlog_i!\`** |
| 3 | \`featureMap.c:203\` progress-bar \`ARLOGd "\r%4d/%4d."\` | — | Skip — terminal-oriented |
| 4 | \`featureMap.c:257\` \`ARLOGi "\n"\` | — | Skip — formatting artifact |
| 5 | \`featureMap.c:300\` \`ARLOGi "Max feature = %d"\` (ar2SelectFeature) | \`select_features\` | **Added \`arlog_i!\`** |
| 6 | \`featureMap.c:371\` per-feature dump | — | Skip — inner loop (B3 trace-level candidate) |
| 7 | \`featureMap.c:425\` same "Max feature" (ar2SelectFeature2) | — | N/A — covered by #5 (Rust has one unified \`select_features\`) |
| 8 | \`featureMap.c:496\` per-feature dump | — | Skip |
| 9 | \`featureMap.c:523\` \`---\` divider | — | Skip |
| 10 | \`featureMap.c:550-586\` \`ARLOG(...)\` | — | Skip — \`#ifdef AR2_ANALYSIS\` compile-time dumps |

Net: **4× \`arlog_i!\`** added (3 feature counts + 1 max-feature).

### Level choice

All four match C \`ARLOGi\` 1:1. These fire once per pyramid level during marker generation (not per-frame), so info level is appropriate.

## Test plan
- [x] \`cargo build -p webarkitlib-rs\` — clean (pre-existing warnings only)
- [x] \`cargo test -p webarkitlib-rs --lib\` — 87 passed, 2 ignored
- [x] \`cargo fmt\`

Refs #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)