### PR TITLE
fix(ffi-backend): vendor WebARKitLib C++ via git submodule (#72)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,25 +36,48 @@ jobs:
       run: cargo test --workspace --features simd
 
   kpm-build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v5
+      with:
+        submodules: recursive
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
 
-    - name: Install libclang
+    - name: Install libclang (Linux)
+      if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install -y libclang-dev
-
-    - name: Bootstrap WebARKitLib C++ sources
-      working-directory: benchmarks/c_benchmark
-      run: python ../bootstrap.py --bootstrap-file libraries.json
 
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2
 
     - name: Build kpm backend (FFI backend)
       run: cargo build -p webarkitlib-rs --features ffi-backend
+
+  submodule-drift-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        submodules: recursive
+
+    - name: Verify submodule SHA matches libraries.json commit
+      run: |
+        SUB=$(git -C crates/core/third_party/WebARKitLib rev-parse HEAD)
+        JSON=$(jq -r '.[] | select(.name=="WebARKitLib") | .source.commit' \
+               benchmarks/c_benchmark/libraries.json)
+        if [ "$SUB" != "$JSON" ]; then
+          echo "::error::Submodule SHA ($SUB) does not match libraries.json commit ($JSON)"
+          echo "Run: git -C crates/core/third_party/WebARKitLib rev-parse HEAD"
+          echo "Then update benchmarks/c_benchmark/libraries.json accordingly."
+          exit 1
+        fi
+        echo "OK: submodule and libraries.json both pinned at $SUB"
 
   wasm-build:
     runs-on: ubuntu-latest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "crates/core/third_party/WebARKitLib"]
+	path = crates/core/third_party/WebARKitLib
+	url = https://github.com/webarkit/WebARKitLib.git
+	branch = master

--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ To enable the C++ FFI backend for KPM (Natural Feature Tracking):
 webarkitlib-rs = { version = "0.3", features = ["ffi-backend"] }
 ```
 
+> When installing from crates.io, no extra setup is required — the C++
+> sources needed by `ffi-backend` ship inside the published crate.
+
+### Contributing — clone with submodules
+
+This repository uses a git submodule for the WebARKitLib C++ sources that
+back the `ffi-backend` feature. Clone recursively:
+
+```bash
+git clone --recursive https://github.com/webarkit/WebARKitLib-rs.git
+```
+
+If you already cloned without `--recursive`:
+
+```bash
+git submodule update --init --recursive
+```
+
+The submodule lives at `crates/core/third_party/WebARKitLib` and is pinned
+to a specific upstream commit. Building from a non-recursive clone will
+fail early in `build.rs` with an actionable message.
+
 ### Native Rust Example
 
 To see the marker detection in action on your local machine, run the provided simple example:
@@ -254,6 +276,12 @@ Detailed SIMD performance results and reproduction steps can be found in the [BE
     cd benchmarks/c_benchmark
     python ../bootstrap.py --bootstrap-file libraries.json
     ```
+
+    > Note: this Python bootstrap is only required for the standalone
+    > **C benchmark** build here. The Rust `ffi-backend` feature gets its
+    > C++ sources from the git submodule at
+    > `crates/core/third_party/WebARKitLib` and does **not** require
+    > Python.
 
 2.  **Execute the Suite**:
     ```bash

--- a/benchmarks/bootstrap.py
+++ b/benchmarks/bootstrap.py
@@ -158,7 +158,7 @@ def escapifyPath(path):
         return "\"" + path + "\""
     return path.replace("\\ ", " ")
 
-def cloneRepository(type, url, target_name, revision, try_only_local_operations = False, recursive = True):
+def cloneRepository(type, url, target_name, revision, try_only_local_operations = False, recursive = True, branch = None):
     target_dir = escapifyPath(os.path.join(SRC_DIR, target_name))
     target_dir_exists = os.path.exists(target_dir)
     log("Cloning " + url + " to " + target_dir)
@@ -191,10 +191,11 @@ def cloneRepository(type, url, target_name, revision, try_only_local_operations 
             if target_dir_exists:
                 dlog("Removing directory " + target_dir + " before cloning")
                 shutil.rmtree(target_dir)
+            branch_arg = " --branch " + branch if branch else ""
             if recursive:
-                dieIfNonZero(executeCommand(TOOL_COMMAND_GIT + " clone --recursive " + url + " " + target_dir))
+                dieIfNonZero(executeCommand(TOOL_COMMAND_GIT + " clone --recursive" + branch_arg + " " + url + " " + target_dir))
             else:
-                dieIfNonZero(executeCommand(TOOL_COMMAND_GIT + " clone " + url + " " + target_dir))
+                dieIfNonZero(executeCommand(TOOL_COMMAND_GIT + " clone" + branch_arg + " " + url + " " + target_dir))
         elif not try_only_local_operations:
             log("Repository " + target_dir + " already exists; fetching instead of cloning")
             if recursive:
@@ -848,8 +849,10 @@ def main(argv):
                             raise
 
                 else:
-                    revision = source.get('revision', None)
+                    # `commit` is an alias for `revision` (clearer name in JSON schemas).
+                    revision = source.get('revision', source.get('commit', None))
                     recursive = source.get('recursive', True)
+                    branch = source.get('branch', None)
 
                     archive_name = name + ".tar.gz" # for reading or writing of snapshot archives
                     if revision is not None:
@@ -858,7 +861,7 @@ def main(argv):
                     try:
                         if force_fallback:
                             raise RuntimeError
-                        cloneRepository(src_type, src_url, name, revision, False, recursive)
+                        cloneRepository(src_type, src_url, name, revision, False, recursive, branch)
 
                         if create_repo_snapshots:
                             log("Creating snapshot of library repository '" + name + "'")
@@ -882,7 +885,7 @@ def main(argv):
                             downloadAndExtractFile(fallback_src_url, SNAPSHOT_DIR, name, force_download = True)
 
                             # reset repository state to particular revision (only using local operations inside the function)
-                            cloneRepository(src_type, src_url, name, revision, True, True)
+                            cloneRepository(src_type, src_url, name, revision, True, True, branch)
                         else:
                             raise
             else:

--- a/benchmarks/c_benchmark/libraries.json
+++ b/benchmarks/c_benchmark/libraries.json
@@ -3,7 +3,9 @@
     "name": "WebARKitLib",
     "source": {
       "type": "git",
-      "url": "https://github.com/webarkit/WebARKitLib.git"
+      "url": "https://github.com/webarkit/WebARKitLib.git",
+      "branch": "master",
+      "commit": "656436e36bbebd9c269cf2a9f47fb4a962359f92"
     }
   },
   {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -10,10 +10,31 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 readme.workspace = true
-exclude = [
-    "examples/Data/",
-    "benches/",
-    "tests/",
+include = [
+    "src/**/*",
+    "examples/**/*.rs",
+    "build.rs",
+    "Cargo.toml",
+    # Vendored WebARKitLib C++ sources (via git submodule). See
+    # docs/design/issue-72-ffi-backend-vendoring.md.
+    # Only the subtrees build.rs actually compiles or includes — we
+    # intentionally exclude Eigen's test/, bench/, and doc/ directories.
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/facade/**/*",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/detectors/**/*",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/matchers/**/*",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/framework/**/*",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/homography_estimation/**/*",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/math/**/*",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/utils/**/*",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/Eigen/**/*",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/unsupported/Eigen/**/*",
+    "third_party/WebARKitLib/include/**/*",
+    # Licenses required to ship alongside vendored code.
+    "third_party/WebARKitLib/LICENSE*",
+    "third_party/WebARKitLib/COPYING*",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/Eigen/COPYING*",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/unsupported/COPYING*",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/unsupported/README.txt",
 ]
 
 [dependencies]

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -49,9 +49,7 @@ fn build_freak_matcher() {
 
     // WebARKitLib C++ sources ship with the crate via the git submodule at
     // `crates/core/third_party/WebARKitLib`. See docs/design/issue-72-ffi-backend-vendoring.md.
-    let webarkitlib = manifest_dir
-        .join("third_party")
-        .join("WebARKitLib");
+    let webarkitlib = manifest_dir.join("third_party").join("WebARKitLib");
 
     let freak_matcher_root = webarkitlib
         .join("lib")

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -47,12 +47,10 @@ fn main() {
 fn build_freak_matcher() {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
 
-    // Workspace root is two levels up from crates/core/
-    let workspace_root = manifest_dir.join("..").join("..");
-    let webarkitlib = workspace_root
-        .join("benchmarks")
-        .join("c_benchmark")
-        .join("src")
+    // WebARKitLib C++ sources ship with the crate via the git submodule at
+    // `crates/core/third_party/WebARKitLib`. See docs/design/issue-72-ffi-backend-vendoring.md.
+    let webarkitlib = manifest_dir
+        .join("third_party")
         .join("WebARKitLib");
 
     let freak_matcher_root = webarkitlib
@@ -62,6 +60,16 @@ fn build_freak_matcher() {
         .join("FreakMatcher");
 
     let include_root = webarkitlib.join("include");
+
+    if !freak_matcher_root.exists() {
+        panic!(
+            "WebARKitLib C++ sources not found at {}. \
+             If you are building from a git clone, run \
+             `git submodule update --init --recursive`. \
+             (Installs from crates.io ship the sources inside the .crate tarball.)",
+            freak_matcher_root.display()
+        );
+    }
 
     // C++ wrapper files now live under src/kpm/
     let src_dir = manifest_dir.join("src").join("kpm");

--- a/docs/design/issue-72-ffi-backend-vendoring.md
+++ b/docs/design/issue-72-ffi-backend-vendoring.md
@@ -1,0 +1,232 @@
+# Design: Fix `ffi-backend` build from crates.io (issue #72)
+
+- **Issue:** [webarkit/WebARKitLib-rs#72](https://github.com/webarkit/WebARKitLib-rs/issues/72)
+- **Status:** Approved design, ready for implementation
+- **Author:** @kalwalt (with brainstorming assistance)
+- **Date:** 2026-04-22
+
+---
+
+## Understanding Summary
+
+- **What:** Fix `ffi-backend` build failure from crates.io by making the required `WebARKitLib` C++ sources available to `crates/core/build.rs` without Python bootstrapping.
+- **Why:** Today `build.rs` references `../../benchmarks/c_benchmark/src/WebARKitLib` which is gitignored and populated only by `python bootstrap.py` — so published crates ship without the C++ code and fail to build for every consumer.
+- **Who:** Any user of `webarkitlib-rs` with the `ffi-backend` (or `dual-mode`) feature — from crates.io, git dependency, or docs.rs.
+- **Approach:** Add upstream `webarkit/WebARKitLib` as a **git submodule** at `crates/core/third_party/WebARKitLib`, pinned by commit SHA, with `.gitmodules` tracking `master`. Point `build.rs` at the new path. Scope the published `.crate` with explicit `include = [...]` so only `lib/SRC/KPM/FreakMatcher/` + `include/` ship (~2.5 MB compressed).
+- **Non-goals:**
+  - No download-at-build-time logic.
+  - No changes to what `ffi-backend` actually compiles or how it links.
+  - No new platform support.
+  - No change to the benchmark suite's `bootstrap.py` workflow — it keeps working at its existing location.
+  - No CHANGELOG edits in this PR (project rule: CHANGELOG is updated at release time only).
+
+## Assumptions
+
+1. crates.io's 10 MiB `.crate` limit applies to the compressed tarball; measured ~2.5 MB fits comfortably.
+2. Eigen (MPL-2.0) and any other upstream licenses inside `WebARKitLib` are compatible with LGPL-3.0 linking; vendored `COPYING.*` files will be preserved via `include = [...]`.
+3. docs.rs will build `ffi-backend` successfully once C++ sources are present in the `.crate` (no network needed).
+4. Maintainers will run `git submodule update --init --recursive` before `cargo publish`; CI will guard this.
+5. The upstream `webarkit/WebARKitLib` repo URL is stable.
+
+## Size measurements (recorded)
+
+| Metric | Size |
+|---|---|
+| `lib/SRC/KPM/FreakMatcher/` + `include/`, uncompressed | ~11.5 MB |
+| Same, compressed (zip Optimal ≈ gzip) | ~2.5 MB |
+| crates.io `.crate` limit | 10 MiB |
+
+Breakdown of FreakMatcher:
+- `Eigen/` — 6.5 MB (header-only, transitively required)
+- `unsupported/` — 4.1 MB (header-only Eigen modules)
+- Detectors/matchers/framework/facade/etc. — ~550 KB
+- Actually compiled: **12 `.cpp` files** (~200 KB)
+
+---
+
+## Decision Log
+
+| # | Decision | Chosen | Alternatives | Rationale |
+|---|----------|--------|--------------|-----------|
+| 1 | How to deliver C++ sources on crates.io | Vendor via git submodule | Download-at-build; copy-vendored tree; upstream tarball per release | Works offline + on docs.rs; no duplicated bytes; reproducible |
+| 2 | Submodule location | `crates/core/third_party/WebARKitLib` | `vendor/`, `cpp/` | `third_party/` unambiguous, no overlap with Cargo's vocabulary |
+| 3 | Pinning policy | Commit SHA, `.gitmodules` tracks `master` | Always-latest, tag-based | Reproducible builds; easy `--remote` updates when desired |
+| 4 | `libraries.json` schema | Add `branch` + optional `commit`; keep aligned with submodule SHA | Leave as-is | Prevents drift between C benchmark and Rust build |
+| 5 | Publish payload | Explicit `include = [...]` limiting to `FreakMatcher/` + `include/` | Ship whole submodule | Smaller `.crate`; avoids shipping unused OSG/emscripten/test code |
+| 6 | Old path in `build.rs` | Replace entirely | Keep as fallback | Single source of truth; avoids confusion |
+| 7 | CI | Add job: init submodules + `cargo build --features ffi-backend` on 3 OSes + drift check | No CI change | Catches missing-submodule & drift regressions before release |
+| 8 | README | Update clone instructions for `--recursive` + note Python-free Rust build | Skip | Contributors will hit this otherwise |
+
+---
+
+## Final Design
+
+### 1. Repo layout
+
+```
+crates/core/
+├── third_party/
+│   └── WebARKitLib/         ← NEW submodule → webarkit/WebARKitLib @ <pinned-sha>
+├── src/kpm/                 (unchanged)
+├── build.rs                 (modified)
+└── Cargo.toml               (modified: `include = [...]`)
+.gitmodules                  ← NEW
+```
+
+### 2. `.gitmodules`
+
+```ini
+[submodule "crates/core/third_party/WebARKitLib"]
+    path = crates/core/third_party/WebARKitLib
+    url = https://github.com/webarkit/WebARKitLib.git
+    branch = master
+```
+
+### 3. `build.rs` — minimal diff
+
+Remove `workspace_root` computation; point `webarkitlib` at the new path; add a fail-fast check:
+
+```rust
+let webarkitlib = manifest_dir
+    .join("third_party")
+    .join("WebARKitLib");
+
+let freak_matcher_root = webarkitlib.join("lib").join("SRC").join("KPM").join("FreakMatcher");
+let include_root       = webarkitlib.join("include");
+
+if !freak_matcher_root.exists() {
+    panic!(
+        "WebARKitLib C++ sources not found at {}. \
+         Run `git submodule update --init --recursive` \
+         (this is handled automatically for crates.io installs).",
+        freak_matcher_root.display()
+    );
+}
+```
+
+File list, compiler flags, bindgen section, `rerun-if-changed` lines — unchanged.
+
+### 4. `crates/core/Cargo.toml` — allowlist publish payload
+
+Replace current `exclude` with:
+
+```toml
+include = [
+    "src/**/*",
+    "build.rs",
+    "Cargo.toml",
+    "README.md",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/**/*.cpp",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/**/*.h",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/**/*.hpp",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/**/*.inc",
+    "third_party/WebARKitLib/include/**/*",
+    "third_party/WebARKitLib/LICENSE*",
+    "third_party/WebARKitLib/COPYING*",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/Eigen/COPYING*",
+    "third_party/WebARKitLib/lib/SRC/KPM/FreakMatcher/unsupported/COPYING*",
+]
+```
+
+Verify with `cargo package --list -p webarkitlib-rs --features ffi-backend` before merge.
+
+### 5. `benchmarks/c_benchmark/libraries.json` — schema update
+
+```json
+{
+  "name": "WebARKitLib",
+  "source": {
+    "type": "git",
+    "url": "https://github.com/webarkit/WebARKitLib.git",
+    "branch": "master",
+    "commit": "<same-sha-as-submodule>"
+  }
+}
+```
+
+### 6. `benchmarks/bootstrap.py` — backwards-compatible field support
+
+- If `commit` present → after clone, `git checkout <commit>`.
+- If only `branch` present → clone with `--branch <branch>`.
+- Neither → current default-branch behavior.
+
+### 7. CI
+
+New job (or extend existing) in `.github/workflows/`:
+
+```yaml
+ffi-backend-build:
+  runs-on: ${{ matrix.os }}
+  strategy:
+    matrix:
+      os: [ubuntu-latest, windows-latest, macos-latest]
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - uses: dtolnay/rust-toolchain@stable
+    - run: cargo build -p webarkitlib-rs --features ffi-backend
+```
+
+Linux-only drift check step:
+
+```yaml
+- name: Verify submodule SHA matches libraries.json commit
+  run: |
+    SUB=$(git -C crates/core/third_party/WebARKitLib rev-parse HEAD)
+    JSON=$(jq -r '.[] | select(.name=="WebARKitLib") | .source.commit' \
+           benchmarks/c_benchmark/libraries.json)
+    test "$SUB" = "$JSON" || { echo "drift: submodule=$SUB json=$JSON"; exit 1; }
+```
+
+### 8. README updates
+
+- Clone instructions mention `git clone --recursive` / `git submodule update --init --recursive`.
+- Note under Bootstrap section: Python bootstrap only needed for the standalone C benchmark, not for the Rust `ffi-backend` build.
+
+### 9. Error handling
+
+| Scenario | Behavior |
+|---|---|
+| Missing submodule in local clone | `build.rs` panics with actionable message |
+| Missing sources on crates.io install | Cannot happen (publish-time file presence + CI guard) |
+| Upstream repo unreachable during `git submodule update` | Standard git error surfaces; not a `build.rs` concern |
+| Submodule SHA drifts from `libraries.json` | CI drift-check job fails |
+
+### 10. Testing strategy
+
+**Pre-merge:**
+1. `cargo clean && cargo build -p webarkitlib-rs --features ffi-backend` on Win/Linux/macOS.
+2. `cargo package --list -p webarkitlib-rs --features ffi-backend` — inspect payload.
+3. `cargo package` then unpack + build from the unpacked `.crate` — simulates crates.io consumer.
+4. New CI jobs green on all three OSes.
+5. Drift-check CI job green.
+
+**Post-merge, pre-release:**
+6. `cargo publish --dry-run`.
+7. Real publish, consume from throwaway project for smoke test.
+
+**Post-publish:**
+8. Verify docs.rs build page green for `ffi-backend` on new version.
+
+---
+
+## Non-functional baseline (confirmed)
+
+- Offline builds: **must work** — no network at build time.
+- docs.rs: **must work** for `ffi-backend` feature.
+- First-build time impact: negligible (no downloads; cc-rs compile time unchanged).
+- Reproducibility: byte-identical output for a given submodule SHA.
+- Target platforms: same as today (Win MSVC, Linux, macOS) — no new platform coverage intended.
+
+## Rollout
+
+Single PR, branched fresh from `dev` (per project rule: new branch per sub-issue). Includes:
+- Submodule add (`.gitmodules` + pointer)
+- `build.rs` repoint + fail-fast guard
+- `Cargo.toml` `include = [...]`
+- `libraries.json` schema change + `bootstrap.py` field support
+- CI job + drift check
+- README updates
+
+**Not in this PR:** CHANGELOG edits (release-time only).


### PR DESCRIPTION
## Summary

Fixes #72 — `ffi-backend` build failure from crates.io.

- Add `webarkit/WebARKitLib` as a git submodule at `crates/core/third_party/WebARKitLib` (pinned @ `656436e`, v1.7.6).
- Repoint `crates/core/build.rs` at the new path; add a fail-fast guard with actionable message if the submodule is missing.
- Switch `crates/core/Cargo.toml` from `exclude` to an explicit `include` allowlist that scopes the published `.crate` to the C++ subtrees `build.rs` actually needs — result: **1.8 MiB compressed** (well under crates.io's 10 MiB limit).
- Extend `benchmarks/c_benchmark/libraries.json` with `branch` + `commit` fields; teach `bootstrap.py` to honor them (`commit` accepted as an alias for the existing `revision`).
- CI: `kpm-build` now uses `submodules: recursive` on a 3-OS matrix (Linux/Windows/macOS); new `submodule-drift-check` job guards against submodule SHA diverging from `libraries.json`.
- README: added clone-with-submodules section + note that the Python bootstrap is only needed for the standalone C benchmark build.

Full design rationale (alternatives considered, decision log, size measurements) in [docs/design/issue-72-ffi-backend-vendoring.md](docs/design/issue-72-ffi-backend-vendoring.md).

## Why a submodule (vs. download-at-build or copy-vendoring)

- **Offline / docs.rs compatible** — sources ship inside the `.crate`; no network at build time.
- **Reproducible** — the commit SHA is pinned in the superproject tree.
- **No duplication** — the C++ tree lives once, managed by upstream's git history.
- `build.rs` stays tiny; no new build-deps (`ureq`/`flate2`/`tar`).

## Test plan

- [x] `cargo build -p webarkitlib-rs --features ffi-backend` passes locally on Windows (MSVC).
- [x] `cargo package -p webarkitlib-rs --features ffi-backend` produces a 1.8 MiB `.crate` containing all 12 required `.cpp` files, Eigen headers, and license files; excludes Eigen `test/`, `bench/`, `doc/`.
- [x] CI `kpm-build` matrix green on Linux, Windows, macOS.
- [x] CI `submodule-drift-check` green (SHA in `.gitmodules` tree matches `libraries.json` `commit` field).
- [x] Existing `benchmarks` CI job still green (unchanged; still uses `bootstrap.py` for the standalone C benchmark).
- [ ] After merge and release: verify docs.rs builds `ffi-backend` successfully.

## Reviewer notes

- No CHANGELOG edit in this PR (per project rule — CHANGELOG is updated at release time).
- Branched off `dev` per project rule of fresh branch per sub-issue.
- `benchmarks/c_benchmark/src/WebARKitLib/` (the old bootstrap path) is untouched — the C benchmark still works exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)