### PR TITLE
feat(log): log + return Err at matrix.rs + bch.rs (Pass B2)

### DIFF
--- a/crates/core/src/bch.rs
+++ b/crates/core/src/bch.rs
@@ -35,6 +35,7 @@
  */
 //! # BCH Code Decoding - used for error correction in AR marker detection.
 use crate::types::ARMatrixCodeType;
+use crate::{arlog_d, arlog_e};
 
 pub fn decode_parity65(code_raw: u64) -> Result<u64, &'static str> {
     const PARITY65_DECODER_TABLE: [i8; 64] = [
@@ -43,10 +44,15 @@ pub fn decode_parity65(code_raw: u64) -> Result<u64, &'static str> {
         16, -1, -1, 19, -1, 21, 22, -1, -1, 25, 26, -1, 28, -1, -1, 31,
     ];
     if code_raw >= 64 {
+        arlog_d!("decode_parity65: EDC fail (code_raw={:#x} >= 64)", code_raw);
         return Err("EDC fail");
     }
     let val = PARITY65_DECODER_TABLE[code_raw as usize];
     if val < 0 {
+        arlog_d!(
+            "decode_parity65: EDC fail (table miss for code_raw={:#x})",
+            code_raw
+        );
         Err("EDC fail")
     } else {
         Ok(val as u64)
@@ -67,10 +73,18 @@ pub fn decode_hamming63(code_raw: u64) -> Result<(u64, i32), &'static str> {
         false, true, true, true, true, true, true, false,
     ];
     if code_raw >= 64 {
+        arlog_d!(
+            "decode_hamming63: EDC fail (code_raw={:#x} >= 64)",
+            code_raw
+        );
         return Err("EDC fail");
     }
     let val = HAMMING63_DECODER_TABLE[code_raw as usize];
     if val < 0 {
+        arlog_d!(
+            "decode_hamming63: EDC fail (table miss for code_raw={:#x})",
+            code_raw
+        );
         Err("EDC fail")
     } else {
         let corrected = if ERROR_CORRECTED[code_raw as usize] {
@@ -133,7 +147,13 @@ pub fn decode_bch(
             alpha_to = &BCH_31_ALPHA_TO;
             index_of = &BCH_31_INDEX_OF;
         }
-        _ => return Err("Unsupported BCH code type"),
+        _ => {
+            arlog_e!(
+                "decode_bch: unsupported matrix code type {:?}",
+                matrix_code_type
+            );
+            return Err("Unsupported BCH code type");
+        }
     }
 
     let mut in_bitwise = in_val;
@@ -287,9 +307,11 @@ pub fn decode_bch(
                     recd[loc[i]] ^= 1;
                 }
             } else {
+                arlog_d!("decode_bch: count != l[u] (in_val={:#x})", in_val);
                 return Err("BCH correction failed (count != l)");
             }
         } else {
+            arlog_d!("decode_bch: l[u] > t (in_val={:#x})", in_val);
             return Err("BCH correction failed (l > t)");
         }
     }

--- a/crates/core/src/matrix.rs
+++ b/crates/core/src/matrix.rs
@@ -26,9 +26,9 @@
 //! Matrix Code (Barcode) Marker Decoding
 //! Ported from arGetMatrixCode.c and associated ECC logic.
 
-use crate::arlog_d;
 use crate::marker::ar_get_line;
 use crate::types::{ARHandle, ARMarkerInfo, ARMarkerInfo2, ARMatrixCodeType, ARdouble};
+use crate::{arlog_d, arlog_e};
 use log::trace;
 
 /// Results of a matrix code decoding attempt.
@@ -97,6 +97,10 @@ pub fn ar_matrix_code_get_id(
 ) -> Result<(), &'static str> {
     let dim = (code_type as i32) & 0xFF;
     if dim < 3 || dim > 6 {
+        arlog_e!(
+            "ar_matrix_code_get_id: unsupported dim={} (expected 3..=6)",
+            dim
+        );
         return Err("Unsupported matrix dimension");
     }
 
@@ -138,6 +142,10 @@ pub fn ar_matrix_code_get_id(
     );
 
     if (max_val as i32 - min_val as i32) < 30 {
+        arlog_d!(
+            "ar_matrix_code_get_id: low contrast range={}",
+            max_val as i32 - min_val as i32
+        );
         return Err("Low contrast in matrix grid");
     }
 
@@ -180,6 +188,10 @@ pub fn ar_matrix_code_get_id(
     }
 
     if matched_dir == -1 {
+        arlog_d!(
+            "ar_matrix_code_get_id: locator pattern not found, dir_code={:?}",
+            dir_code
+        );
         return Err("Barcode locator pattern not found in grid corners");
     }
 
@@ -276,6 +288,11 @@ pub fn ar_matrix_code_get_id(
         *error_corrected = err;
         Ok(())
     } else {
+        arlog_d!(
+            "ar_matrix_code_get_id: decode failed for code_raw={} (dir={})",
+            code_raw,
+            matched_dir
+        );
         Err("Failed to decode extracted matrix code string")
     }
 }
@@ -385,7 +402,10 @@ fn sample_grid(
         crate::types::ARPixelFormat::RGBA
         | crate::types::ARPixelFormat::BGRA
         | crate::types::ARPixelFormat::ARGB => 4,
-        _ => return Err("Unsupported pixel format in sample_grid"),
+        _ => {
+            arlog_e!("sample_grid: unsupported pixel format {:?}", pixel_format);
+            return Err("Unsupported pixel format in sample_grid");
+        }
     };
 
     let mut world = [[0.0; 2]; 4];


### PR DESCRIPTION
## Summary

Pass B2 continues the issue #57 log sweep, targeting the barcode decoder path.

Adopts a new **log + return Err** pattern at every error-return site:
- diagnostics surface even when callers discard the `Err` string (e.g. marker filter loops that skip bad candidates silently)
- mirrors C's `ARLOGe(...); return -1;` idiom

### Changes
- **matrix.rs**: 5 new arlog sites (1 x arlog_e! misconfig + 4 x arlog_d! per-candidate rejection)
- **bch.rs**: 6 new arlog sites (1 x arlog_e! unsupported code type + 5 x arlog_d! EDC / BCH correction failures)

Level choice rationale:
- arlog_e! — wiring/config errors (unsupported X) that should never fire in a correct build
- arlog_d! — per-frame rejections that would spam at info but are valuable diagnostics under RUST_LOG=debug

### C parity
- decode_bch unsupported BCH code matches C ARLOGe at arPattGetID.c:1873
- BCH correction failures (count != l, l > t) match C DEBUG_BCH gating at arPattGetID.c:2031/2037

### Non-goal
Rust ar_matrix_code_get_id still hardcodes *cf = 1.0 instead of computing contrastMin like C (arPattGetID.c:2247). Behavior gap, not a logging issue — flagged for separate follow-up.

## Test plan
- [x] cargo fmt
- [x] cargo check — clean (2 pre-existing arlog.rs dead-code warnings unrelated)
- [x] cargo test --lib — 87 passed, 2 ignored

Refs #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)