### PR TITLE
feat(log): log + return Err retrofit across 5 modules (Pass B3)

### DIFF
--- a/crates/core/src/ar2/feature_map.rs
+++ b/crates/core/src/ar2/feature_map.rs
@@ -43,7 +43,7 @@
 use super::feature_set::{AR2FeatureCoordT, AR2FeaturePointsT, AR2FeatureSetT};
 use super::image_set::AR2ImageSetT;
 use super::Ar2Error;
-use crate::arlog_i;
+use crate::{arlog_e, arlog_i};
 use rayon::prelude::*;
 
 // ---------------------------------------------------------------------------
@@ -801,6 +801,7 @@ pub fn ar2_gen_feature_map(
     level: u8,
 ) -> Result<AR2FeatureSetT, Ar2Error> {
     if image_set.scale.is_empty() {
+        arlog_e!("ar2_gen_feature_map: image set has no scales");
         return Err(Ar2Error::InvalidInput("image set has no scales"));
     }
 

--- a/crates/core/src/ar2/image_set.rs
+++ b/crates/core/src/ar2/image_set.rs
@@ -64,7 +64,7 @@
 //! ```
 
 use super::Ar2Error;
-use crate::arlog_d;
+use crate::{arlog_d, arlog_e};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use rayon::prelude::*;
 use std::io::{self, BufWriter, Cursor, Read, Write};
@@ -124,6 +124,7 @@ impl AR2ImageSetT {
         // Read number of scales.
         let num = cursor.read_i32::<LittleEndian>()?;
         if num <= 0 {
+            arlog_e!("AR2ImageSetT::from_bytes: invalid scale count: {}", num);
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("invalid scale count: {}", num),
@@ -475,22 +476,35 @@ pub fn ar2_gen_image_set(
     dpi: f32,
 ) -> Result<AR2ImageSetT, Ar2Error> {
     if image.is_empty() || xsize <= 0 || ysize <= 0 {
+        arlog_e!(
+            "ar2_gen_image_set: image empty or zero-sized (len={}, xsize={}, ysize={})",
+            image.len(),
+            xsize,
+            ysize
+        );
         return Err(Ar2Error::InvalidInput(
             "image is empty or has zero dimensions",
         ));
     }
     let expected = (xsize as usize) * (ysize as usize) * (nc as usize);
     if image.len() != expected {
+        arlog_e!(
+            "ar2_gen_image_set: image length mismatch (got={}, expected={})",
+            image.len(),
+            expected
+        );
         return Err(Ar2Error::InvalidInput(
             "image buffer length does not match xsize * ysize * nc",
         ));
     }
     if nc != 1 && nc != 3 {
+        arlog_e!("ar2_gen_image_set: unsupported channel count nc={}", nc);
         return Err(Ar2Error::InvalidInput(
             "nc must be 1 (grayscale) or 3 (RGB)",
         ));
     }
     if dpi <= 0.0 {
+        arlog_e!("ar2_gen_image_set: non-positive dpi={}", dpi);
         return Err(Ar2Error::InvalidInput("dpi must be positive"));
     }
 

--- a/crates/core/src/labeling.rs
+++ b/crates/core/src/labeling.rs
@@ -37,6 +37,7 @@
 //! Connected Component Labeling Utilities
 //! Translated from ARToolKit C headers (arLabeling.c, arLabelingSub.h)
 
+use crate::arlog_e;
 use crate::types::{ARLabelInfo, ARdouble};
 use log::trace;
 
@@ -137,6 +138,11 @@ pub fn ar_labeling(
     }
 
     if image.len() < (ysize as usize * xsize as usize) {
+        arlog_e!(
+            "ar_labeling: image buffer too small (len={}, expected>={})",
+            image.len(),
+            ysize as usize * xsize as usize
+        );
         return Err("Image buffer is too small for given dimensions.");
     }
 
@@ -321,6 +327,11 @@ pub fn ar_labeling(
                 } else {
                     wk_max += 1;
                     if wk_max > AR_LABELING_WORK_SIZE {
+                        arlog_e!(
+                            "ar_labeling: work array overflow (wk_max={}, limit={})",
+                            wk_max,
+                            AR_LABELING_WORK_SIZE
+                        );
                         return Err("Labeling work array overflow");
                     }
                     work[wk_max - 1] = wk_max as i32;

--- a/crates/core/src/marker.rs
+++ b/crates/core/src/marker.rs
@@ -37,8 +37,8 @@
 //! Marker Detection Pipeline
 //! Ported from arDetectMarker.c, arDetectMarker2.c, and arGetMarkerInfo.c
 
-use crate::arlog_d;
 use crate::types::{ARLabelInfo, ARMarkerInfo2, ARdouble};
+use crate::{arlog_d, arlog_e};
 
 pub const AR_AREA_MAX: i32 = 100000;
 pub const AR_AREA_MIN: i32 = 70;
@@ -92,12 +92,18 @@ pub fn ar_detect_marker(
 
     let luma_buff = match &frame.buff_luma {
         Some(b) => b.as_slice(),
-        None => return Err("AR2VideoBufferT requires buff_luma to be available"),
+        None => {
+            arlog_e!("ar_detect_marker: AR2VideoBufferT.buff_luma is None");
+            return Err("AR2VideoBufferT requires buff_luma to be available");
+        }
     };
 
     let color_buff = match &frame.buff {
         Some(b) => b.as_slice(),
-        None => return Err("AR2VideoBufferT requires buff to be available"),
+        None => {
+            arlog_e!("ar_detect_marker: AR2VideoBufferT.buff is None");
+            return Err("AR2VideoBufferT requires buff to be available");
+        }
     };
 
     let thresh = ar_handle.ar_labeling_thresh as u8;
@@ -157,6 +163,7 @@ pub fn ar_detect_marker(
     }
 
     if ar_handle.ar_param_lt.is_null() {
+        arlog_e!("ar_detect_marker: ARHandle.ar_param_lt is null");
         return Err("ARParamLT is null in ARHandle");
     }
 

--- a/crates/core/src/pattern.rs
+++ b/crates/core/src/pattern.rs
@@ -38,6 +38,7 @@
 //! Ported natively to safe Rust from arPattLoad.c and arPattGetID.c
 
 use crate::types::*;
+use crate::{arlog_d, arlog_e};
 use std::fs::File;
 use std::io::{BufWriter, Error, ErrorKind, Result as IoResult, Write};
 use std::path::Path;
@@ -91,6 +92,7 @@ pub fn ar_patt_load_from_buffer(
     }
 
     if patno == -1 {
+        arlog_e!("ar_patt_load_from_buffer: maximum pattern limit reached");
         return Err("Maximum pattern limit reached");
     }
 
@@ -108,9 +110,11 @@ pub fn ar_patt_load_from_buffer(
                 if let Ok(val) = t.parse::<i32>() {
                     read_tokens.push(val);
                 } else {
+                    arlog_e!("ar_patt_load_from_buffer: failed to parse pattern number");
                     return Err("Failed to parse pattern number");
                 }
             } else {
+                arlog_e!("ar_patt_load_from_buffer: unexpected EOF while reading pattern data");
                 return Err("Pattern data read error (unexpected EOF)");
             }
         }
@@ -267,9 +271,15 @@ pub fn ar_patt_save(
 /// Activates a pattern for detection.
 pub fn ar_patt_activate(patt_handle: &mut ARPattHandle, patno: i32) -> Result<(), &'static str> {
     if patno < 0 || patno as usize >= patt_handle.pattf.len() {
+        arlog_e!(
+            "ar_patt_activate: invalid pattern index {} (len={})",
+            patno,
+            patt_handle.pattf.len()
+        );
         return Err("Invalid pattern index");
     }
     if patt_handle.pattf[patno as usize] == 0 {
+        arlog_e!("ar_patt_activate: pattern {} not loaded", patno);
         return Err("Pattern not loaded");
     }
     patt_handle.active[patno as usize] = true;
@@ -279,9 +289,15 @@ pub fn ar_patt_activate(patt_handle: &mut ARPattHandle, patno: i32) -> Result<()
 /// Deactivates a pattern from detection.
 pub fn ar_patt_deactivate(patt_handle: &mut ARPattHandle, patno: i32) -> Result<(), &'static str> {
     if patno < 0 || patno as usize >= patt_handle.pattf.len() {
+        arlog_e!(
+            "ar_patt_deactivate: invalid pattern index {} (len={})",
+            patno,
+            patt_handle.pattf.len()
+        );
         return Err("Invalid pattern index");
     }
     if patt_handle.pattf[patno as usize] == 0 {
+        arlog_e!("ar_patt_deactivate: pattern {} not loaded", patno);
         return Err("Pattern not loaded");
     }
     patt_handle.active[patno as usize] = false;
@@ -291,6 +307,11 @@ pub fn ar_patt_deactivate(patt_handle: &mut ARPattHandle, patno: i32) -> Result<
 /// Frees a pattern slot, making it available for a new pattern.
 pub fn ar_patt_free(patt_handle: &mut ARPattHandle, patno: i32) -> Result<(), &'static str> {
     if patno < 0 || patno as usize >= patt_handle.pattf.len() {
+        arlog_e!(
+            "ar_patt_free: invalid pattern index {} (len={})",
+            patno,
+            patt_handle.pattf.len()
+        );
         return Err("Invalid pattern index");
     }
     if patt_handle.pattf[patno as usize] != 0 {
@@ -326,6 +347,7 @@ pub fn pattern_match(
         *code = 0;
         *dir = 0;
         *cf = -1.0;
+        arlog_e!("pattern_match: invalid size={}", size);
         return Err("Invalid size");
     }
 
@@ -334,6 +356,11 @@ pub fn pattern_match(
     if mode == AR_TEMPLATE_MATCHING_COLOR {
         let size_sqd_x3 = size_u * size_u * 3;
         if data.len() < size_sqd_x3 {
+            arlog_e!(
+                "pattern_match(color): data too small (len={}, need={})",
+                data.len(),
+                size_sqd_x3
+            );
             return Err("Data array too small");
         }
         let mut input = vec![0i16; size_sqd_x3];
@@ -357,6 +384,10 @@ pub fn pattern_match(
             *code = 0;
             *dir = 0;
             *cf = -1.0;
+            arlog_d!(
+                "pattern_match(color): insufficient contrast (datapow={:.3})",
+                datapow
+            );
             return Err("Insufficient contrast");
         }
 
@@ -397,6 +428,11 @@ pub fn pattern_match(
     } else if mode == AR_TEMPLATE_MATCHING_MONO {
         let size_sqd = size_u * size_u;
         if data.len() < size_sqd {
+            arlog_e!(
+                "pattern_match(mono): data too small (len={}, need={})",
+                data.len(),
+                size_sqd
+            );
             return Err("Data array too small");
         }
 
@@ -421,6 +457,10 @@ pub fn pattern_match(
             *code = 0;
             *dir = 0;
             *cf = -1.0;
+            arlog_d!(
+                "pattern_match(mono): insufficient contrast (datapow={:.3})",
+                datapow
+            );
             return Err("Insufficient contrast");
         }
 
@@ -460,6 +500,7 @@ pub fn pattern_match(
         *cf = max;
         Ok(())
     } else {
+        arlog_e!("pattern_match: unsupported matching mode {}", mode);
         Err("Unsupported matching mode")
     }
 }
@@ -630,6 +671,11 @@ pub fn ar_patt_get_image(
             let d = para[2][0] * xw + para[2][1] * yw + para[2][2];
 
             if d == 0.0 {
+                arlog_d!(
+                    "ar_patt_get_image: matrix denominator is zero (xw={:.3}, yw={:.3})",
+                    xw,
+                    yw
+                );
                 return Err("Matrix denominator is zero");
             }
 
@@ -675,7 +721,13 @@ pub fn ar_patt_get_image(
                             ext_patt2[dest_idx + 2] += val;
                         }
                         // Note: BGR, BGRA, 2vuy, yuvs, rgb565, etc. can be expanded here.
-                        _ => return Err("Unsupported pixel format for color matching"),
+                        _ => {
+                            arlog_e!(
+                                "ar_patt_get_image: unsupported pixel format {:?} for color matching",
+                                pixel_format
+                            );
+                            return Err("Unsupported pixel format for color matching");
+                        }
                     }
                 } else {
                     match pixel_format {
@@ -703,7 +755,13 @@ pub fn ar_patt_get_image(
                             ext_patt2[idx_patt] += image[src_idx] as u32;
                         }
                         // Note: Other specific mono format decodings can be added here.
-                        _ => return Err("Unsupported pixel format for mono matching"),
+                        _ => {
+                            arlog_e!(
+                                "ar_patt_get_image: unsupported pixel format {:?} for mono matching",
+                                pixel_format
+                            );
+                            return Err("Unsupported pixel format for mono matching");
+                        }
                     }
                 }
             }
@@ -834,6 +892,11 @@ pub fn ar_patt_get_image2(
             let d = para[2][0] * xw + para[2][1] * yw + para[2][2];
 
             if d == 0.0 {
+                arlog_d!(
+                    "ar_patt_get_image2: matrix denominator is zero (xw={:.3}, yw={:.3})",
+                    xw,
+                    yw
+                );
                 return Err("Matrix denominator is zero");
             }
 
@@ -889,7 +952,13 @@ pub fn ar_patt_get_image2(
                             ext_patt2[dest_idx + 2] += val;
                         }
                         // Note: Add other specific color format decodings (e.g., RGB_565, YUVS) here as needed.
-                        _ => return Err("Unsupported pixel format for color matching"),
+                        _ => {
+                            arlog_e!(
+                                "ar_patt_get_image2: unsupported pixel format {:?} for color matching",
+                                pixel_format
+                            );
+                            return Err("Unsupported pixel format for color matching");
+                        }
                     }
                 } else {
                     match pixel_format {
@@ -917,7 +986,13 @@ pub fn ar_patt_get_image2(
                             ext_patt2[idx_patt] += image[src_idx] as u32;
                         }
                         // Note: Add other specific mono format decodings here as needed.
-                        _ => return Err("Unsupported pixel format for mono matching"),
+                        _ => {
+                            arlog_e!(
+                                "ar_patt_get_image2: unsupported pixel format {:?} for mono matching",
+                                pixel_format
+                            );
+                            return Err("Unsupported pixel format for mono matching");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Finishes the issue #57 log-sweep by retrofitting the **log + return Err** pattern (adopted in PR #76) across modules whose earlier passes predated the convention.

Every `return Err(...)` site in the touched files now has a preceding `arlog_*!` line, so diagnostics surface even when callers discard the `Err` string (common pattern in marker filter loops and pyramid construction).

### Changes

| File | Sites | Mix |
|---|---|---|
| `marker.rs` | 3 | 3 × `arlog_e!` (null buffers / null ar_param_lt) |
| `ar2/feature_map.rs` | 1 | 1 × `arlog_e!` (empty image set) |
| `ar2/image_set.rs` | 5 | 5 × `arlog_e!` (invalid scale count, bad image dims, length mismatch, bad nc, non-positive dpi) |
| `labeling.rs` | 2 | 2 × `arlog_e!` (image too small, work-array overflow) |
| `pattern.rs` | 17 | 14 × `arlog_e!` (load/activate/deactivate/free index errors, pattern_match bad size/data/mode, unsupported pixel formats in ar_patt_get_image/ar_patt_get_image2) + 3 × `arlog_d!` (insufficient contrast in color + mono modes, degenerate homography) |

**Total:** 28 new `arlog_*!` sites across 5 files.

### Level convention (same as PR #76)

- `arlog_e!` — misconfiguration / wiring errors that should never fire in a correct build (null pointers, unsupported enum variants, index out of range)
- `arlog_d!` — per-frame / per-candidate rejections that would spam at `info` but are valuable under `RUST_LOG=debug` (insufficient contrast during pattern matching, degenerate homography per sample)

### Clean files (no retrofit needed)

- `ar2/tracking.rs` — already compliant (PR #73)
- `icp.rs` — already compliant
- `version.rs` — no `return Err` sites

### Test plan

- [x] `cargo fmt` clean
- [x] `cargo check` — clean (2 pre-existing `arlog.rs` dead-code warnings, unrelated)
- [x] `cargo test --lib` — 87 passed, 2 ignored
- [x] Happy-path regression: `barcode` example still decodes `marker_05_3x3.jpg` cleanly with no new error-path logs firing

Refs #57. Closes the "log + return Err retrofit" punch list from https://github.com/webarkit/WebARKitLib-rs/issues/57#issuecomment-4302467336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)