### PR TITLE
docs: add CLAUDE.md with project conventions

### DIFF
--- a/.claude/HEADER.txt
+++ b/.claude/HEADER.txt
@@ -1,0 +1,35 @@
+/*
+ *  <FILENAME>.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright <YEAR> WebARKit.
+ *
+ *  Author(s): <AUTHOR> <@HANDLE> <URL>
+ *
+ */

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,160 @@
+# CLAUDE.md — Project Conventions for WebARKitLib-rs
+
+This file documents conventions for contributors (human and AI) working on
+WebARKitLib-rs, a Rust port of ARToolKit. Keep it short, actionable, and
+update it when a convention changes.
+
+---
+
+## 1. Idiomatic Rust
+
+Prefer idiomatic Rust over a mechanical C-to-Rust transliteration, even
+though this is a port.
+
+- **Errors, not panics.** Library code returns `Result<T, E>`; reserve
+  `panic!` / `unwrap()` / `expect()` for truly unrecoverable invariants
+  (and prefer `debug_assert!` where possible). Use `?` to propagate.
+- **Borrow, don't clone.** Take `&[T]` / `&str` in APIs; clone only when
+  ownership is genuinely required. Use `Cow<'_, T>` when the choice is
+  conditional.
+- **Iterators over index loops** where it doesn't hurt clarity or perf.
+- **Exhaustive `match`** on enums; avoid catch-all `_ =>` unless the
+  intent is forward-compatibility.
+- **`#[must_use]`** on constructors and fallible helpers whose result
+  callers should not silently drop.
+- **No `unsafe` without a `// SAFETY:` comment** explaining the invariant.
+- **Newtypes** for units / IDs that C used as bare `int` (e.g. marker IDs,
+  pattern handles) when it prevents real bugs.
+- **Naming**: `snake_case` for fns/locals, `CamelCase` for types,
+  `SCREAMING_SNAKE_CASE` for consts. Keep the C name in a doc comment
+  (`/// C equivalent: arParamLT`) when porting, so the mapping stays
+  discoverable — but the Rust name should be idiomatic.
+
+Run `cargo clippy --all-targets --all-features` and keep it clean.
+
+---
+
+## 2. Logging — use the `arlog` system
+
+**Do not use `println!` / `eprintln!` / bare `log::*` in library code.**
+Use the project's `arlog_*` macros from `crates/core/src/arlog.rs`:
+
+| Macro       | ARToolKit C equivalent | Use for                              |
+|-------------|------------------------|--------------------------------------|
+| `arlog_d!`  | `ARLOGd` / `ARLOGi`    | Per-frame rejections, trace details  |
+| `arlog_i!`  | `ARLOGi`               | One-shot informational events        |
+| `arlog_w!`  | `ARLOGw`               | Recoverable anomalies                |
+| `arlog_e!`  | `ARLOGe`               | Misconfiguration / wiring errors     |
+
+### "Log + return Err" pattern
+
+Every error-returning site gets a matching `arlog_*!` immediately before
+the `return Err(...)`:
+
+```rust
+if scales == 0 {
+    arlog_e!("ar2_gen_feature_map: image set has no scales");
+    return Err(Ar2Error::InvalidImageSet);
+}
+```
+
+- **`arlog_e!`** for misconfiguration, null/invalid inputs, bad wiring —
+  things a caller should fix.
+- **`arlog_d!`** for per-frame rejections (low contrast, decode failure,
+  EDC fail) — expected at runtime, noisy, debug-level only.
+
+Canonical examples: PR #76 (matrix.rs, bch.rs) and PR #77 (marker.rs,
+pattern.rs, image_set.rs, labeling.rs, ar2/feature_map.rs).
+
+### Enabling output
+
+The macros compile unconditionally. For output to appear, a logger must
+be installed:
+
+- **Desktop examples/tests**: enable the `log-helpers` feature and call
+  `ar_log_init_default()` (installs `env_logger`).
+- **Wasm**: enable `log-helpers` and call `ar_log_init_wasm()` (installs
+  `console_log`).
+- **Library consumers**: install any `log`-compatible backend themselves;
+  our macros will route through it.
+
+Examples that need log output must declare
+`required-features = ["log-helpers"]` in `Cargo.toml`. See the
+`load_nft` example as the canonical pattern.
+
+---
+
+## 3. SIMD and multithreading
+
+When porting hot paths, reach for SIMD and parallelism where it is
+measurable and the scalar fallback stays correct.
+
+### SIMD
+
+Feature flags already defined:
+
+- `simd-x86-avx2`
+- `simd-x86-sse41`
+- `simd-wasm32`
+
+Use runtime detection so binaries stay portable:
+
+```rust
+#[cfg(all(target_arch = "x86_64", feature = "simd-x86-avx2"))]
+if is_x86_feature_detected!("avx2") {
+    return unsafe { avx2_impl(input) };
+}
+// scalar fallback
+scalar_impl(input)
+```
+
+Rules of thumb:
+- Always keep a scalar fallback; SIMD is an optimization, not a
+  requirement.
+- Gate `unsafe` SIMD intrinsics behind both the `cfg(target_arch)` and
+  the feature flag.
+- Add a benchmark (in `benchmarks/`) alongside any new SIMD path.
+
+### Multithreading
+
+Use `rayon` for data-parallel loops when the workload is large enough to
+amortize thread-pool overhead. Canonical example: `ar2_gen_feature_map`
+Stage 3 in `crates/core/src/ar2/feature_map.rs`.
+
+- Prefer `par_iter` / `par_iter_mut` over hand-rolled threads.
+- Don't parallelize small loops — measure first.
+- Keep wasm builds single-threaded unless explicitly targeting
+  `wasm32-unknown-unknown` with threads.
+
+---
+
+## 4. Housekeeping
+
+- **License header**: every new source file starts with the LGPL-3.0
+  header. Canonical template: [`.claude/HEADER.txt`](.claude/HEADER.txt)
+  — copy verbatim and substitute `<FILENAME>`, `<YEAR>`, `<AUTHOR>`,
+  `<@HANDLE>`, `<URL>`.
+- **Fresh branch per issue/sub-issue**: branch from `dev`, never stack
+  unrelated work on the same branch — avoids merge conflicts and keeps
+  PR review focused.
+- **CHANGELOG.md is release-only**: never edit it in feature PRs. It is
+  rewritten at release time from the merged PR history.
+- **Examples**: put runnable examples under `crates/<crate>/examples/`
+  with a short header comment explaining what they demonstrate and any
+  required assets.
+- **Tests**: unit tests live next to the code (`#[cfg(test)] mod tests`);
+  integration tests in `tests/`.
+
+---
+
+## 5. Quick checklist before opening a PR
+
+- [ ] `cargo fmt --all -- --check` clean (run `cargo fmt --all` to fix)
+- [ ] `cargo build --all-features` clean
+- [ ] `cargo clippy --all-targets --all-features` clean
+- [ ] `cargo test --all-features` green
+- [ ] New source files carry the LGPL-3.0 header
+- [ ] Error sites use `arlog_*!` + `return Err`
+- [ ] No `println!` / `eprintln!` added in library code
+- [ ] CHANGELOG.md **not** touched
+- [ ] Branch is off current `dev`


### PR DESCRIPTION
## Summary
Adds a root-level `CLAUDE.md` documenting project conventions for contributors (human and AI), plus a canonical LGPL-3.0 header template at `.claude/HEADER.txt`.

Three conventions covered:
1. **Idiomatic Rust** — `Result`/`?`, borrows over clones, exhaustive match, no `unsafe` without `// SAFETY:`.
2. **arlog system** — use `arlog_*!` macros (not `println!`/`log::*`); "log + return Err" pattern; level convention (`arlog_e!` misconfig, `arlog_d!` per-frame). References PR #76 / #77 as canonical examples.
3. **SIMD + multithreading** — `simd-x86-avx2` / `simd-x86-sse41` / `simd-wasm32` feature gates with `is_x86_feature_detected!`; rayon for data-parallel loops (e.g. `ar2_gen_feature_map`).

Housekeeping section covers: LGPL header (points to `.claude/HEADER.txt`), fresh branch per sub-issue, `CHANGELOG.md` is release-only, pre-PR checklist starting with `cargo fmt --all -- --check`.

## Test plan
- [x] Render `CLAUDE.md` on GitHub — verify links to `.claude/HEADER.txt` and PRs #76/#77 resolve
- [x] Confirm `.claude/HEADER.txt` placeholders (`<FILENAME>`, `<YEAR>`, `<AUTHOR>`, `<@HANDLE>`, `<URL>`) are clear to contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)