### PR TITLE
feat(kpm): port FREAK math utilities + dual-mode validation (M6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ Cargo.lock
 # VSCode files
 .vscode/
 
+# IntelliJ IDEA / JetBrains files
+.idea/
+
 # Benchmarking and Example Artifacts
 benchmarks/c_benchmark/src/
 benchmarks/c_benchmark/build/

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -65,7 +65,9 @@ simd-wasm32 = []
 simd-x86-sse41 = []
 simd-x86-avx2 = []
 ffi-backend = []
-dual-mode = []
+# dual-mode validates pure-Rust implementations against the C++ baseline;
+# requires ffi-backend so the C++ comparison functions are compiled in.
+dual-mode = ["ffi-backend"]
 # Pulls env_logger (desktop) or console_log (wasm) for the `ar_log_init_*` helpers.
 log-helpers = ["dep:env_logger", "dep:console_log"]
 

--- a/crates/core/src/kpm/freak/math.rs
+++ b/crates/core/src/kpm/freak/math.rs
@@ -564,7 +564,10 @@ pub fn deg2rad_f64(deg: f64) -> f64 {
 /// Returns angle in radians in the range [-π, π].
 /// Uses polynomial approximation: angle += (0.1821*r² - 0.9675)*r
 ///
-/// C++ equivalent: `fastatan2`
+/// C++ equivalent: `fastatan2` — defined in `math_utils.h:93` but **never
+/// called** from anywhere in the upstream WebARKitLib FreakMatcher
+/// (verified at submodule rev 656436e). Ported here for completeness and
+/// future use; dual-mode validation against the C++ baseline still applies.
 #[inline(always)]
 pub fn fast_atan2(y: f32, x: f32) -> f32 {
     let abs_y = y.abs() + 1e-7;
@@ -594,7 +597,11 @@ pub fn fast_atan2(y: f32, x: f32) -> f32 {
 
 /// Fast atan2 returning degrees in [0, 360].
 ///
-/// C++ equivalent: `fastatan2_360` (note: incomplete in original C++)
+/// C++ equivalent: `fastatan2_360` — defined in `math_utils.h:116` but
+/// **never called** from anywhere in the upstream WebARKitLib FreakMatcher
+/// (verified at submodule rev 656436e). The original C++ also returns
+/// radians despite its `_360` suffix; our Rust version converts to degrees
+/// in [0, 360] to match the apparent intent.
 #[inline(always)]
 pub fn fast_atan2_360(y: f32, x: f32) -> f32 {
     let rad = fast_atan2(y, x);
@@ -609,10 +616,26 @@ pub fn fast_atan2_360(y: f32, x: f32) -> f32 {
 /// Fast square root using the Quake fast inverse square root algorithm.
 ///
 /// Computes √x with low precision but high speed. Uses bit manipulation
-/// to compute 1/√x via the magic constant 0x5f3759df, then applies Newton-Raphson refinement,
-/// and finally multiplies by x to get √x.
+/// to compute 1/√x via the magic constant 0x5f3759df, then applies
+/// Newton-Raphson refinement, and finally multiplies by x to get √x.
 ///
-/// C++ equivalent: `fastsqrt1`
+/// C++ equivalent: `fastsqrt1` — defined in `math_utils.h:142` but **never
+/// called** from anywhere in the upstream WebARKitLib FreakMatcher
+/// (verified at submodule rev 656436e).
+///
+/// # Upstream divergence
+///
+/// The C++ source contains an apparent bug: `u.x = (int)x;` casts the
+/// input float through `int` (truncating to the integer part) **before**
+/// applying the magic-constant trick. This means the Quake bit-manipulation
+/// operates on the bits of `(float)truncate(x)` rather than the bits of `x`,
+/// losing fractional-input precision. Our Rust port uses `x.to_bits()`
+/// directly — the canonical Quake algorithm — so it produces more accurate
+/// results. The dual-mode test in this module observes ~28% relative error
+/// at fractional inputs and asserts only a loose bound (0.5) to document
+/// rather than mask the divergence. If you ever wire this up against the
+/// C++ baseline in production, replicate the (int) cast in Rust to match
+/// upstream bit-for-bit; otherwise this Rust implementation is preferable.
 #[inline(always)]
 pub fn fast_sqrt_inv(x: f32) -> f32 {
     // SAFETY: uses transmute for float bit manipulation via to_bits/from_bits,
@@ -629,7 +652,12 @@ pub fn fast_sqrt_inv(x: f32) -> f32 {
 ///
 /// Coefficients: [720, 360, 120, 30, 6, 1] corresponding to x^5, x^4, ..., x^0 terms.
 ///
-/// C++ equivalent: `fastexp6<T>`
+/// C++ equivalent: `fastexp6<T>` — this is the **only** function in
+/// `math_utils.h` that is actually called from the upstream FreakMatcher
+/// algorithm (used at `detectors/orientation_assignment.cpp:186` for
+/// Gaussian weighting during keypoint orientation assignment). Dual-mode
+/// validation confirms agreement with the C++ baseline to ~8.5e-7 relative
+/// error across the input range.
 #[inline(always)]
 pub fn fast_exp6_f32(x: f32) -> f32 {
     1.0 + x
@@ -915,6 +943,130 @@ mod tests {
             "result={}, expected={}",
             result,
             expected
+        );
+    }
+}
+
+// ============================================================================
+// Dual-mode validation against the C++ baseline (Milestone 6, #63)
+// ============================================================================
+//
+// When the `dual-mode` feature is enabled (which transitively enables
+// `ffi-backend`), the C++ math functions in WebARKitLib are linked in via the
+// `webarkit_cpp_*` wrappers in `kpm_c_api.cpp`. The tests below sweep across
+// the input domain and assert that the pure-Rust ports produce results within
+// a small tolerance of the C++ baseline.
+
+#[cfg(feature = "dual-mode")]
+extern "C" {
+    fn webarkit_cpp_fast_atan2(y: f32, x: f32) -> f32;
+    fn webarkit_cpp_fast_sqrt1(x: f32) -> f32;
+    fn webarkit_cpp_fast_exp6_f32(x: f32) -> f32;
+}
+
+#[cfg(all(test, feature = "dual-mode"))]
+mod dual_mode_tests {
+    use super::*;
+    use crate::arlog_e;
+
+    /// Sweep `fast_atan2` over a 201×201 grid covering all four quadrants
+    /// and the axes; assert Rust and C++ outputs agree to 1e-6.
+    #[test]
+    fn fast_atan2_matches_cpp_across_quadrants() {
+        let mut max_diff = 0.0_f32;
+        let mut worst_inputs = (0.0_f32, 0.0_f32);
+        for y_q in -100..=100 {
+            for x_q in -100..=100 {
+                let y = y_q as f32 / 10.0;
+                let x = x_q as f32 / 10.0;
+                let rust = fast_atan2(y, x);
+                let cpp = unsafe { webarkit_cpp_fast_atan2(y, x) };
+                let diff = (rust - cpp).abs();
+                if diff > max_diff {
+                    max_diff = diff;
+                    worst_inputs = (y, x);
+                }
+                assert!(
+                    diff < 1e-6,
+                    "fast_atan2 diverged at y={}, x={}: rust={}, cpp={}, diff={}",
+                    y,
+                    x,
+                    rust,
+                    cpp,
+                    diff
+                );
+            }
+        }
+        arlog_e!(
+            "fast_atan2: max diff = {} over 40,401 inputs (worst at y={}, x={})",
+            max_diff,
+            worst_inputs.0,
+            worst_inputs.1
+        );
+    }
+
+    /// Sweep `fast_sqrt_inv` (which actually returns √x — see C++
+    /// `fastsqrt1`) over positive reals. The loose tolerance accommodates
+    /// the upstream `(int)x` truncation quirk documented on
+    /// [`fast_sqrt_inv`]. Function is unused in the upstream algorithm.
+    #[test]
+    fn fast_sqrt1_matches_cpp() {
+        let mut max_rel_err = 0.0_f32;
+        let mut worst_x = 0.0_f32;
+        for x_q in 1..=10000 {
+            let x = x_q as f32 / 100.0;
+            let rust = fast_sqrt_inv(x);
+            let cpp = unsafe { webarkit_cpp_fast_sqrt1(x) };
+            let denom = cpp.abs().max(1e-30);
+            let rel_err = ((rust - cpp).abs()) / denom;
+            if rel_err > max_rel_err {
+                max_rel_err = rel_err;
+                worst_x = x;
+            }
+        }
+        arlog_e!(
+            "fast_sqrt_inv: max relative err = {} over 10,000 inputs (worst at x={})",
+            max_rel_err,
+            worst_x
+        );
+        // Tolerance accommodates the upstream (int) cast in fastsqrt1.
+        assert!(
+            max_rel_err < 0.5,
+            "fast_sqrt_inv diverged from C++ baseline: max_rel_err={} at x={}",
+            max_rel_err,
+            worst_x
+        );
+    }
+
+    /// Sweep `fast_exp6_f32` over [-2.0, 2.0] in steps of 0.01 and assert
+    /// bit-near agreement with the C++ baseline.
+    #[test]
+    fn fast_exp6_matches_cpp() {
+        let mut max_rel_err = 0.0_f32;
+        let mut worst_x = 0.0_f32;
+        for x_q in -200..=200 {
+            let x = x_q as f32 / 100.0;
+            let rust = fast_exp6_f32(x);
+            let cpp = unsafe { webarkit_cpp_fast_exp6_f32(x) };
+            let denom = cpp.abs().max(1e-30);
+            let rel_err = ((rust - cpp).abs()) / denom;
+            if rel_err > max_rel_err {
+                max_rel_err = rel_err;
+                worst_x = x;
+            }
+            assert!(
+                rel_err < 1e-5,
+                "fast_exp6 diverged at x={}: rust={}, cpp={}, rel_err={}",
+                x,
+                rust,
+                cpp,
+                rel_err
+            );
+        }
+        arlog_e!(
+            "fast_exp6: max relative err = {} over 401 inputs (worst at x={})",
+            max_rel_err,
+            worst_x
         );
     }
 }

--- a/crates/core/src/kpm/freak/math.rs
+++ b/crates/core/src/kpm/freak/math.rs
@@ -1,0 +1,920 @@
+/*
+ *  freak/math.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Math utilities for the FREAK descriptor matcher.
+//!
+//! Ported from WebARKitLib C++ headers:
+//! - `KPM/FreakMatcher/math/indexing.h` (251 lines) — vector/array indexing and manipulation
+//! - `KPM/FreakMatcher/math/math_utils.h` (196 lines) — fast math approximations
+//!
+//! All functions are marked `#[inline(always)]` to match C++ `inline` keyword behavior
+//! and enable call-site specialization via monomorphization.
+
+use std::ops::AddAssign;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// π (pi) in f64 precision
+pub const PI: f64 = 3.1415926535897932384626433832795;
+
+/// π (pi) in f32 precision
+pub const PI_F: f32 = 3.1415926535897932384626433832795_f32;
+
+/// 1 / (2π)
+pub const ONE_OVER_2PI: f32 = 0.159154943091895_f32;
+
+/// √2 (square root of 2)
+pub const SQRT2: f32 = 1.41421356237309504880_f32;
+
+/// π / 180 — conversion factor from degrees to radians (f32)
+pub const DEG_TO_RAD_F: f32 = PI_F / 180.0;
+
+/// π / 180 — conversion factor from degrees to radians (f64)
+pub const DEG_TO_RAD: f64 = PI / 180.0;
+
+// ============================================================================
+// indexing.h Functions
+// ============================================================================
+
+/// Zero out a 3-element vector.
+///
+/// C++ equivalent: `ZeroVector3<T>`
+#[inline(always)]
+pub fn zero_vector_3<T: Default>(v: &mut [T; 3]) {
+    v[0] = T::default();
+    v[1] = T::default();
+    v[2] = T::default();
+}
+
+/// Zero out an n-element vector.
+///
+/// C++ equivalent: `ZeroVector<T>`
+#[inline(always)]
+pub fn zero_vector<T: Default>(v: &mut [T]) {
+    for elem in v.iter_mut() {
+        *elem = T::default();
+    }
+}
+
+/// Return the maximum of two values.
+///
+/// C++ equivalent: `max2<T>`
+#[inline(always)]
+pub fn max2<T: PartialOrd>(a: T, b: T) -> T {
+    if a > b {
+        a
+    } else {
+        b
+    }
+}
+
+/// Return the minimum of two values.
+///
+/// C++ equivalent: `min2<T>`
+#[inline(always)]
+pub fn min2<T: PartialOrd + Copy>(a: T, b: T) -> T {
+    if a < b {
+        a
+    } else {
+        b
+    }
+}
+
+/// Return the minimum of three values.
+///
+/// C++ equivalent: `min3<T>`
+#[inline(always)]
+pub fn min3<T: PartialOrd + Copy>(a: T, b: T, c: T) -> T {
+    min2(min2(a, b), c)
+}
+
+/// Return the minimum of four values.
+///
+/// C++ equivalent: `min4<T>`
+#[inline(always)]
+pub fn min4<T: PartialOrd + Copy>(a: T, b: T, c: T, d: T) -> T {
+    min2(min3(a, b, c), d)
+}
+
+/// Return the index of the maximum element in a 2-element array.
+///
+/// C++ equivalent: `MaxIndex2<T>`
+#[inline(always)]
+pub fn max_index_2<T: PartialOrd>(arr: &[T; 2]) -> usize {
+    if arr[0] > arr[1] {
+        0
+    } else {
+        1
+    }
+}
+
+/// Return the index of the maximum element in a 3-element array.
+///
+/// C++ equivalent: `MaxIndex3<T>`
+#[inline(always)]
+pub fn max_index_3<T: PartialOrd>(arr: &[T; 3]) -> usize {
+    let mut max_idx = 0;
+    if arr[1] > arr[max_idx] {
+        max_idx = 1;
+    }
+    if arr[2] > arr[max_idx] {
+        max_idx = 2;
+    }
+    max_idx
+}
+
+/// Return the index of the maximum element in a 4-element array.
+///
+/// C++ equivalent: `MaxIndex4<T>`
+#[inline(always)]
+pub fn max_index_4<T: PartialOrd>(arr: &[T; 4]) -> usize {
+    let mut max_idx = 0;
+    for i in 1..4 {
+        if arr[i] > arr[max_idx] {
+            max_idx = i;
+        }
+    }
+    max_idx
+}
+
+/// Return the index of the maximum element in a 5-element array.
+///
+/// C++ equivalent: `MaxIndex5<T>`
+#[inline(always)]
+pub fn max_index_5<T: PartialOrd>(arr: &[T; 5]) -> usize {
+    let mut max_idx = 0;
+    for i in 1..5 {
+        if arr[i] > arr[max_idx] {
+            max_idx = i;
+        }
+    }
+    max_idx
+}
+
+/// Return the index of the maximum element in a 6-element array.
+///
+/// C++ equivalent: `MaxIndex6<T>`
+#[inline(always)]
+pub fn max_index_6<T: PartialOrd>(arr: &[T; 6]) -> usize {
+    let mut max_idx = 0;
+    for i in 1..6 {
+        if arr[i] > arr[max_idx] {
+            max_idx = i;
+        }
+    }
+    max_idx
+}
+
+/// Return the index of the maximum element in a 7-element array.
+///
+/// C++ equivalent: `MaxIndex7<T>`
+#[inline(always)]
+pub fn max_index_7<T: PartialOrd>(arr: &[T; 7]) -> usize {
+    let mut max_idx = 0;
+    for i in 1..7 {
+        if arr[i] > arr[max_idx] {
+            max_idx = i;
+        }
+    }
+    max_idx
+}
+
+/// Return the index of the maximum element in an 8-element array.
+///
+/// C++ equivalent: `MaxIndex8<T>`
+#[inline(always)]
+pub fn max_index_8<T: PartialOrd>(arr: &[T; 8]) -> usize {
+    let mut max_idx = 0;
+    for i in 1..8 {
+        if arr[i] > arr[max_idx] {
+            max_idx = i;
+        }
+    }
+    max_idx
+}
+
+/// Return the index of the maximum element in a 9-element array.
+///
+/// C++ equivalent: `MaxIndex9<T>`
+#[inline(always)]
+pub fn max_index_9<T: PartialOrd>(arr: &[T; 9]) -> usize {
+    let mut max_idx = 0;
+    for i in 1..9 {
+        if arr[i] > arr[max_idx] {
+            max_idx = i;
+        }
+    }
+    max_idx
+}
+
+/// Copy a 2-element vector from source to destination.
+///
+/// C++ equivalent: `CopyVector2<T>`
+#[inline(always)]
+pub fn copy_vector_2<T: Copy>(dst: &mut [T; 2], src: &[T; 2]) {
+    dst[0] = src[0];
+    dst[1] = src[1];
+}
+
+/// Copy a 3-element vector from source to destination.
+///
+/// C++ equivalent: `CopyVector3<T>`
+#[inline(always)]
+pub fn copy_vector_3<T: Copy>(dst: &mut [T; 3], src: &[T; 3]) {
+    dst[0] = src[0];
+    dst[1] = src[1];
+    dst[2] = src[2];
+}
+
+/// Copy a 4-element vector from source to destination.
+///
+/// C++ equivalent: `CopyVector4<T>`
+#[inline(always)]
+pub fn copy_vector_4<T: Copy>(dst: &mut [T; 4], src: &[T; 4]) {
+    dst[0] = src[0];
+    dst[1] = src[1];
+    dst[2] = src[2];
+    dst[3] = src[3];
+}
+
+/// Copy a 5-element vector from source to destination.
+///
+/// C++ equivalent: `CopyVector5<T>`
+#[inline(always)]
+pub fn copy_vector_5<T: Copy>(dst: &mut [T; 5], src: &[T; 5]) {
+    dst[0] = src[0];
+    dst[1] = src[1];
+    dst[2] = src[2];
+    dst[3] = src[3];
+    dst[4] = src[4];
+}
+
+/// Copy a 6-element vector from source to destination.
+///
+/// C++ equivalent: `CopyVector6<T>`
+#[inline(always)]
+pub fn copy_vector_6<T: Copy>(dst: &mut [T; 6], src: &[T; 6]) {
+    dst[0] = src[0];
+    dst[1] = src[1];
+    dst[2] = src[2];
+    dst[3] = src[3];
+    dst[4] = src[4];
+    dst[5] = src[5];
+}
+
+/// Copy a 7-element vector from source to destination.
+///
+/// C++ equivalent: `CopyVector7<T>`
+#[inline(always)]
+pub fn copy_vector_7<T: Copy>(dst: &mut [T; 7], src: &[T; 7]) {
+    dst[0] = src[0];
+    dst[1] = src[1];
+    dst[2] = src[2];
+    dst[3] = src[3];
+    dst[4] = src[4];
+    dst[5] = src[5];
+    dst[6] = src[6];
+}
+
+/// Copy an 8-element vector from source to destination.
+///
+/// C++ equivalent: `CopyVector8<T>`
+#[inline(always)]
+pub fn copy_vector_8<T: Copy>(dst: &mut [T; 8], src: &[T; 8]) {
+    dst[0] = src[0];
+    dst[1] = src[1];
+    dst[2] = src[2];
+    dst[3] = src[3];
+    dst[4] = src[4];
+    dst[5] = src[5];
+    dst[6] = src[6];
+    dst[7] = src[7];
+}
+
+/// Copy a 9-element vector from source to destination.
+///
+/// C++ equivalent: `CopyVector9<T>`
+#[inline(always)]
+pub fn copy_vector_9<T: Copy>(dst: &mut [T; 9], src: &[T; 9]) {
+    dst[0] = src[0];
+    dst[1] = src[1];
+    dst[2] = src[2];
+    dst[3] = src[3];
+    dst[4] = src[4];
+    dst[5] = src[5];
+    dst[6] = src[6];
+    dst[7] = src[7];
+    dst[8] = src[8];
+}
+
+/// Copy an n-element vector from source to destination.
+///
+/// C++ equivalent: `CopyVector<T>`
+#[inline(always)]
+pub fn copy_vector<T: Copy>(dst: &mut [T], src: &[T]) {
+    dst.copy_from_slice(src);
+}
+
+/// Swap two 9-element arrays.
+///
+/// C++ equivalent: `Swap9<T>`
+#[inline(always)]
+pub fn swap_9<T: Copy>(a: &mut [T; 9], b: &mut [T; 9]) {
+    let temp = *a;
+    *a = *b;
+    *b = temp;
+}
+
+/// Set a specific bit in a bitstring (array of u8).
+///
+/// C++ equivalent: `bitstring_set_bit`
+#[inline(always)]
+pub fn bitstring_set_bit(bitstring: &mut [u8], pos: usize, bit: u8) {
+    let byte_idx = pos / 8;
+    let bit_idx = pos % 8;
+    if bit != 0 {
+        bitstring[byte_idx] |= 1 << bit_idx;
+    } else {
+        bitstring[byte_idx] &= !(1 << bit_idx);
+    }
+}
+
+/// Get a specific bit from a bitstring (array of u8).
+///
+/// C++ equivalent: `bitstring_get_bit`
+#[inline(always)]
+pub fn bitstring_get_bit(bitstring: &[u8], pos: usize) -> u8 {
+    let byte_idx = pos / 8;
+    let bit_idx = pos % 8;
+    (bitstring[byte_idx] >> bit_idx) & 1
+}
+
+/// Create a sequential vector [x0, x0+1, x0+2, ...].
+///
+/// C++ equivalent: `SequentialVector<T>`
+#[inline(always)]
+pub fn sequential_vector<T: Default + Copy + AddAssign>(v: &mut [T], x0: T) {
+    let mut val = x0;
+    for elem in v.iter_mut() {
+        *elem = val;
+        val += T::default(); // This won't work as intended; fixed below
+    }
+}
+
+// Fixed version of sequential_vector that requires numeric traits
+/// Create a sequential vector [x0, x0+1, x0+2, ...] for numeric types.
+///
+/// Works with types that support addition and zero initialization.
+#[inline(always)]
+pub fn sequential_vector_f32(v: &mut [f32], x0: f32) {
+    let mut val = x0;
+    for elem in v.iter_mut() {
+        *elem = val;
+        val += 1.0;
+    }
+}
+
+/// Create a sequential vector [x0, x0+1, x0+2, ...] for i32 types.
+#[inline(always)]
+pub fn sequential_vector_i32(v: &mut [i32], x0: i32) {
+    let mut val = x0;
+    for elem in v.iter_mut() {
+        *elem = val;
+        val += 1;
+    }
+}
+
+// ============================================================================
+// math_utils.h Functions
+// ============================================================================
+
+/// Return the square of a value: x * x.
+///
+/// C++ equivalent: `sqr<T>`
+#[inline(always)]
+pub fn sqr<T: std::ops::Mul<Output = T> + Copy>(x: T) -> T {
+    x * x
+}
+
+/// Round a floating-point value to the nearest integer.
+///
+/// Implements: floor(x + 0.5)
+///
+/// C++ equivalent: `round<T>`
+#[inline(always)]
+pub fn round_f32(x: f32) -> f32 {
+    (x + 0.5).floor()
+}
+
+/// Round a f64 value to the nearest integer.
+#[inline(always)]
+pub fn round_f64(x: f64) -> f64 {
+    (x + 0.5).floor()
+}
+
+/// Compute log base 2 of a value.
+///
+/// C++ equivalent: `log2<T>`
+#[inline(always)]
+pub fn log2_f32(x: f32) -> f32 {
+    x.log2()
+}
+
+/// Compute log base 2 of a f64 value.
+#[inline(always)]
+pub fn log2_f64(x: f64) -> f64 {
+    x.log2()
+}
+
+/// Compute log base b of a value.
+///
+/// C++ equivalent: `logb<T>`
+#[inline(always)]
+pub fn logb_f32(x: f32, b: f32) -> f32 {
+    x.ln() / b.ln()
+}
+
+/// Compute log base b of a f64 value.
+#[inline(always)]
+pub fn logb_f64(x: f64, b: f64) -> f64 {
+    x.ln() / b.ln()
+}
+
+/// Safe reciprocal: 1/x, returns 1 if x == 0.
+///
+/// C++ equivalent: `SafeReciprical<T>`
+#[inline(always)]
+pub fn safe_reciprocal_f32(x: f32) -> f32 {
+    if x == 0.0 {
+        1.0
+    } else {
+        1.0 / x
+    }
+}
+
+/// Safe reciprocal: 1/x, returns 1 if x == 0 (f64 version).
+#[inline(always)]
+pub fn safe_reciprocal_f64(x: f64) -> f64 {
+    if x == 0.0 {
+        1.0
+    } else {
+        1.0 / x
+    }
+}
+
+/// Safe division: x/y, returns x if y == 0.
+///
+/// C++ equivalent: `SafeDivision<T>`
+#[inline(always)]
+pub fn safe_division_f32(x: f32, y: f32) -> f32 {
+    if y == 0.0 {
+        x
+    } else {
+        x / y
+    }
+}
+
+/// Safe division: x/y, returns x if y == 0 (f64 version).
+#[inline(always)]
+pub fn safe_division_f64(x: f64, y: f64) -> f64 {
+    if y == 0.0 {
+        x
+    } else {
+        x / y
+    }
+}
+
+/// Clamp a scalar value to a range [min, max].
+///
+/// C++ equivalent: `ClipScalar<T>`
+#[inline(always)]
+pub fn clip_scalar_f32(x: f32, min: f32, max: f32) -> f32 {
+    if x < min {
+        min
+    } else if x > max {
+        max
+    } else {
+        x
+    }
+}
+
+/// Clamp a scalar value to a range [min, max] (f64 version).
+#[inline(always)]
+pub fn clip_scalar_f64(x: f64, min: f64, max: f64) -> f64 {
+    if x < min {
+        min
+    } else if x > max {
+        max
+    } else {
+        x
+    }
+}
+
+/// Convert degrees to radians.
+///
+/// C++ equivalent: `deg2rad<T>`
+#[inline(always)]
+pub fn deg2rad_f32(deg: f32) -> f32 {
+    deg * DEG_TO_RAD_F
+}
+
+/// Convert degrees to radians (f64 version).
+#[inline(always)]
+pub fn deg2rad_f64(deg: f64) -> f64 {
+    deg * DEG_TO_RAD
+}
+
+/// Fast atan2 approximation using polynomial coefficients.
+///
+/// Returns angle in radians in the range [-π, π].
+/// Uses polynomial approximation: angle += (0.1821*r² - 0.9675)*r
+///
+/// C++ equivalent: `fastatan2`
+#[inline(always)]
+pub fn fast_atan2(y: f32, x: f32) -> f32 {
+    let abs_y = y.abs() + 1e-7;
+
+    if x == 0.0 && y == 0.0 {
+        0.0
+    } else if x > 0.0 {
+        let r = (x - abs_y) / (x + abs_y);
+        let mut angle = PI_F / 4.0;
+        angle += (0.1821 * r * r - 0.9675) * r;
+        if y < 0.0 {
+            -angle
+        } else {
+            angle
+        }
+    } else {
+        let r = (x + abs_y) / (abs_y - x);
+        let mut angle = 3.0 * PI_F / 4.0;
+        angle += (0.1821 * r * r - 0.9675) * r;
+        if y < 0.0 {
+            -angle
+        } else {
+            angle
+        }
+    }
+}
+
+/// Fast atan2 returning degrees in [0, 360].
+///
+/// C++ equivalent: `fastatan2_360` (note: incomplete in original C++)
+#[inline(always)]
+pub fn fast_atan2_360(y: f32, x: f32) -> f32 {
+    let rad = fast_atan2(y, x);
+    let deg = rad / DEG_TO_RAD_F;
+    if deg < 0.0 {
+        deg + 360.0
+    } else {
+        deg
+    }
+}
+
+/// Fast square root using the Quake fast inverse square root algorithm.
+///
+/// Computes √x with low precision but high speed. Uses bit manipulation
+/// to compute 1/√x via the magic constant 0x5f3759df, then applies Newton-Raphson refinement,
+/// and finally multiplies by x to get √x.
+///
+/// C++ equivalent: `fastsqrt1`
+#[inline(always)]
+pub fn fast_sqrt_inv(x: f32) -> f32 {
+    // SAFETY: uses transmute for float bit manipulation via to_bits/from_bits,
+    // safe because input is finite positive f32 and we're just reinterpreting bits
+    let xhalf = 0.5 * x;
+    let i = x.to_bits();
+    let i = 0x5f3759df - (i >> 1);
+    let y = f32::from_bits(i);
+    let y = y * (1.5 - xhalf * y * y);
+    x * y
+}
+
+/// Fast 6-term Taylor series approximation of exp(x).
+///
+/// Coefficients: [720, 360, 120, 30, 6, 1] corresponding to x^5, x^4, ..., x^0 terms.
+///
+/// C++ equivalent: `fastexp6<T>`
+#[inline(always)]
+pub fn fast_exp6_f32(x: f32) -> f32 {
+    1.0 + x
+        * (1.0
+            + x * (0.5
+                + x * (1.0 / 6.0 + x * (1.0 / 24.0 + x * (1.0 / 120.0 + x * (1.0 / 720.0))))))
+}
+
+/// Fast 6-term Taylor series approximation of exp(x) (f64 version).
+#[inline(always)]
+pub fn fast_exp6_f64(x: f64) -> f64 {
+    1.0 + x
+        * (1.0
+            + x * (0.5
+                + x * (1.0 / 6.0 + x * (1.0 / 24.0 + x * (1.0 / 120.0 + x * (1.0 / 720.0))))))
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPSILON_F32: f32 = 1e-5;
+
+    // ========================================================================
+    // indexing.h Tests
+    // ========================================================================
+
+    #[test]
+    fn test_zero_vector_3() {
+        let mut v: [f32; 3] = [1.0, 2.0, 3.0];
+        zero_vector_3(&mut v);
+        assert_eq!(v, [0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn test_zero_vector() {
+        let mut v: [f32; 5] = [1.0, 2.0, 3.0, 4.0, 5.0];
+        zero_vector(&mut v);
+        for elem in &v {
+            assert_eq!(*elem, 0.0);
+        }
+    }
+
+    #[test]
+    fn test_max2() {
+        assert_eq!(max2(3, 7), 7);
+        assert_eq!(max2(7, 3), 7);
+        assert_eq!(max2(5, 5), 5);
+    }
+
+    #[test]
+    fn test_min2() {
+        assert_eq!(min2(3, 7), 3);
+        assert_eq!(min2(7, 3), 3);
+        assert_eq!(min2(5, 5), 5);
+    }
+
+    #[test]
+    fn test_min3() {
+        assert_eq!(min3(3, 1, 5), 1);
+        assert_eq!(min3(5, 3, 1), 1);
+    }
+
+    #[test]
+    fn test_min4() {
+        assert_eq!(min4(3, 1, 5, 2), 1);
+        assert_eq!(min4(5, 3, 1, 2), 1);
+    }
+
+    #[test]
+    fn test_max_index_2() {
+        assert_eq!(max_index_2(&[3.0, 7.0]), 1);
+        assert_eq!(max_index_2(&[7.0, 3.0]), 0);
+    }
+
+    #[test]
+    fn test_max_index_3() {
+        assert_eq!(max_index_3(&[3.0, 7.0, 2.0]), 1);
+        assert_eq!(max_index_3(&[7.0, 3.0, 2.0]), 0);
+        assert_eq!(max_index_3(&[3.0, 2.0, 7.0]), 2);
+    }
+
+    #[test]
+    fn test_max_index_9() {
+        let arr = [1.0, 2.0, 3.0, 9.0, 5.0, 6.0, 7.0, 8.0, 4.0];
+        assert_eq!(max_index_9(&arr), 3);
+    }
+
+    #[test]
+    fn test_copy_vector_3() {
+        let src = [1.0, 2.0, 3.0];
+        let mut dst = [0.0, 0.0, 0.0];
+        copy_vector_3(&mut dst, &src);
+        assert_eq!(dst, src);
+    }
+
+    #[test]
+    fn test_copy_vector_9() {
+        let src = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+        let mut dst = [0.0; 9];
+        copy_vector_9(&mut dst, &src);
+        assert_eq!(dst, src);
+    }
+
+    #[test]
+    fn test_swap_9() {
+        let mut a = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+        let mut b = [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0];
+        let a_orig = a;
+        let b_orig = b;
+        swap_9(&mut a, &mut b);
+        assert_eq!(a, b_orig);
+        assert_eq!(b, a_orig);
+    }
+
+    #[test]
+    fn test_bitstring_set_get() {
+        let mut bits = [0u8; 2];
+        bitstring_set_bit(&mut bits, 3, 1);
+        assert_eq!(bitstring_get_bit(&bits, 3), 1);
+        assert_eq!(bitstring_get_bit(&bits, 4), 0);
+
+        bitstring_set_bit(&mut bits, 3, 0);
+        assert_eq!(bitstring_get_bit(&bits, 3), 0);
+    }
+
+    #[test]
+    fn test_sequential_vector_f32() {
+        let mut v = [0.0; 5];
+        sequential_vector_f32(&mut v, 2.0);
+        assert_eq!(v, [2.0, 3.0, 4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn test_sequential_vector_i32() {
+        let mut v = [0; 5];
+        sequential_vector_i32(&mut v, 10);
+        assert_eq!(v, [10, 11, 12, 13, 14]);
+    }
+
+    // ========================================================================
+    // math_utils.h Tests
+    // ========================================================================
+
+    #[test]
+    fn test_sqr() {
+        assert_eq!(sqr(3.0_f32), 9.0);
+        assert_eq!(sqr(-5.0_f32), 25.0);
+        assert_eq!(sqr(0.0_f32), 0.0);
+    }
+
+    #[test]
+    fn test_round_f32() {
+        assert!((round_f32(2.3) - 2.0).abs() < EPSILON_F32);
+        assert!((round_f32(2.6) - 3.0).abs() < EPSILON_F32);
+        assert!((round_f32(2.5) - 3.0).abs() < EPSILON_F32);
+    }
+
+    #[test]
+    fn test_log2_f32() {
+        assert!((log2_f32(8.0) - 3.0).abs() < EPSILON_F32);
+        assert!((log2_f32(1.0) - 0.0).abs() < EPSILON_F32);
+        assert!((log2_f32(0.5) - (-1.0)).abs() < EPSILON_F32);
+    }
+
+    #[test]
+    fn test_logb_f32() {
+        assert!((logb_f32(100.0, 10.0) - 2.0).abs() < EPSILON_F32);
+        assert!((logb_f32(8.0, 2.0) - 3.0).abs() < EPSILON_F32);
+    }
+
+    #[test]
+    fn test_safe_reciprocal_f32() {
+        assert!((safe_reciprocal_f32(2.0) - 0.5).abs() < EPSILON_F32);
+        assert_eq!(safe_reciprocal_f32(0.0), 1.0);
+    }
+
+    #[test]
+    fn test_safe_division_f32() {
+        assert!((safe_division_f32(10.0, 2.0) - 5.0).abs() < EPSILON_F32);
+        assert_eq!(safe_division_f32(5.0, 0.0), 5.0);
+    }
+
+    #[test]
+    fn test_clip_scalar_f32() {
+        assert_eq!(clip_scalar_f32(5.0, 1.0, 10.0), 5.0);
+        assert_eq!(clip_scalar_f32(0.0, 1.0, 10.0), 1.0);
+        assert_eq!(clip_scalar_f32(15.0, 1.0, 10.0), 10.0);
+    }
+
+    #[test]
+    fn test_deg2rad_f32() {
+        assert!((deg2rad_f32(0.0) - 0.0).abs() < EPSILON_F32);
+        assert!((deg2rad_f32(180.0) - PI_F).abs() < EPSILON_F32);
+        assert!((deg2rad_f32(90.0) - PI_F / 2.0).abs() < EPSILON_F32);
+    }
+
+    #[test]
+    fn test_fast_atan2() {
+        let angles_deg: [f32; 16] = [
+            0.0, 22.5, 45.0, 67.5, 90.0, 112.5, 135.0, 157.5, 180.0, 202.5, 225.0, 247.5, 270.0,
+            292.5, 315.0, 337.5,
+        ];
+
+        for &angle_deg in &angles_deg {
+            let angle_rad = angle_deg.to_radians();
+            let (sin_a, cos_a) = angle_rad.sin_cos();
+            let approx = fast_atan2(sin_a, cos_a);
+            let expected = angle_rad;
+
+            // Normalize angles to [-π, π] for comparison
+            let mut normalized_approx = approx;
+            let mut normalized_expected = expected;
+            while normalized_approx > PI_F {
+                normalized_approx -= 2.0 * PI_F;
+            }
+            while normalized_approx < -PI_F {
+                normalized_approx += 2.0 * PI_F;
+            }
+            while normalized_expected > PI_F {
+                normalized_expected -= 2.0 * PI_F;
+            }
+            while normalized_expected < -PI_F {
+                normalized_expected += 2.0 * PI_F;
+            }
+
+            let error = (normalized_approx - normalized_expected).abs();
+            assert!(
+                error < 0.015,
+                "angle_deg={}, error={}, approx={}, expected={}",
+                angle_deg,
+                error,
+                normalized_approx,
+                normalized_expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_fast_atan2_360() {
+        let result = fast_atan2_360(0.0, 1.0);
+        assert!(result >= 0.0 && result <= 360.0);
+    }
+
+    #[test]
+    fn test_fast_sqrt_inv() {
+        let x = 4.0_f32;
+        let approx = fast_sqrt_inv(x);
+        let expected = x.sqrt();
+        assert!(
+            (approx - expected).abs() < 0.01,
+            "approx={}, expected={}",
+            approx,
+            expected
+        );
+
+        let x = 9.0_f32;
+        let approx = fast_sqrt_inv(x);
+        let expected = x.sqrt();
+        assert!(
+            (approx - expected).abs() < 0.01,
+            "approx={}, expected={}",
+            approx,
+            expected
+        );
+    }
+
+    #[test]
+    fn test_fast_exp6_f32() {
+        let x = 0.0_f32;
+        let result = fast_exp6_f32(x);
+        assert!((result - 1.0).abs() < EPSILON_F32);
+
+        let x = 1.0_f32;
+        let result = fast_exp6_f32(x);
+        let expected = std::f32::consts::E;
+        assert!(
+            (result - expected).abs() < 1e-3,
+            "result={}, expected={}",
+            result,
+            expected
+        );
+    }
+}

--- a/crates/core/src/kpm/freak/math.rs
+++ b/crates/core/src/kpm/freak/math.rs
@@ -43,23 +43,33 @@
 //! All functions are marked `#[inline(always)]` to match C++ `inline` keyword behavior
 //! and enable call-site specialization via monomorphization.
 
-use std::ops::AddAssign;
-
 // ============================================================================
 // Constants
 // ============================================================================
 
-/// π (pi) in f64 precision
-pub const PI: f64 = 3.1415926535897932384626433832795;
+/// π (pi) in f64 precision.
+///
+/// Re-exports `std::f64::consts::PI` to match the C++ `#define PI` from
+/// `math_utils.h:42`.
+pub const PI: f64 = std::f64::consts::PI;
 
-/// π (pi) in f32 precision
-pub const PI_F: f32 = 3.1415926535897932384626433832795_f32;
+/// π (pi) in f32 precision.
+///
+/// Re-exports `std::f32::consts::PI` to match the C++ `#define PI` from
+/// `math_utils.h:42`.
+pub const PI_F: f32 = std::f32::consts::PI;
 
-/// 1 / (2π)
-pub const ONE_OVER_2PI: f32 = 0.159154943091895_f32;
+/// 1 / (2π).
+///
+/// Computed from `PI_F` to retain full f32 precision. Matches the C++
+/// `#define ONE_OVER_2PI 0.159154943091895` from `math_utils.h:43`.
+pub const ONE_OVER_2PI: f32 = 1.0 / (2.0 * PI_F);
 
-/// √2 (square root of 2)
-pub const SQRT2: f32 = 1.41421356237309504880_f32;
+/// √2 (square root of 2).
+///
+/// Re-exports `std::f32::consts::SQRT_2` to match the C++
+/// `#define SQRT2 1.41421356237309504880` from `math_utils.h:44`.
+pub const SQRT2: f32 = std::f32::consts::SQRT_2;
 
 /// π / 180 — conversion factor from degrees to radians (f32)
 pub const DEG_TO_RAD_F: f32 = PI_F / 180.0;
@@ -354,10 +364,8 @@ pub fn copy_vector<T: Copy>(dst: &mut [T], src: &[T]) {
 ///
 /// C++ equivalent: `Swap9<T>`
 #[inline(always)]
-pub fn swap_9<T: Copy>(a: &mut [T; 9], b: &mut [T; 9]) {
-    let temp = *a;
-    *a = *b;
-    *b = temp;
+pub fn swap_9<T>(a: &mut [T; 9], b: &mut [T; 9]) {
+    std::mem::swap(a, b);
 }
 
 /// Set a specific bit in a bitstring (array of u8).
@@ -384,38 +392,23 @@ pub fn bitstring_get_bit(bitstring: &[u8], pos: usize) -> u8 {
     (bitstring[byte_idx] >> bit_idx) & 1
 }
 
-/// Create a sequential vector [x0, x0+1, x0+2, ...].
+/// Create a sequential vector [x0, x0+1, x0+2, ...] for f32 types.
 ///
-/// C++ equivalent: `SequentialVector<T>`
-#[inline(always)]
-pub fn sequential_vector<T: Default + Copy + AddAssign>(v: &mut [T], x0: T) {
-    let mut val = x0;
-    for elem in v.iter_mut() {
-        *elem = val;
-        val += T::default(); // This won't work as intended; fixed below
-    }
-}
-
-// Fixed version of sequential_vector that requires numeric traits
-/// Create a sequential vector [x0, x0+1, x0+2, ...] for numeric types.
-///
-/// Works with types that support addition and zero initialization.
+/// C++ equivalent: `SequentialVector<T>` for `T = float`.
 #[inline(always)]
 pub fn sequential_vector_f32(v: &mut [f32], x0: f32) {
-    let mut val = x0;
-    for elem in v.iter_mut() {
-        *elem = val;
-        val += 1.0;
+    for (i, elem) in v.iter_mut().enumerate() {
+        *elem = x0 + i as f32;
     }
 }
 
 /// Create a sequential vector [x0, x0+1, x0+2, ...] for i32 types.
+///
+/// C++ equivalent: `SequentialVector<T>` for `T = int`.
 #[inline(always)]
 pub fn sequential_vector_i32(v: &mut [i32], x0: i32) {
-    let mut val = x0;
-    for elem in v.iter_mut() {
+    for (val, elem) in (x0..).zip(v.iter_mut()) {
         *elem = val;
-        val += 1;
     }
 }
 

--- a/crates/core/src/kpm/freak/mod.rs
+++ b/crates/core/src/kpm/freak/mod.rs
@@ -1,0 +1,43 @@
+/*
+ *  freak/mod.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! FREAK (Fast Retina Keypoint) descriptor-based feature matching utilities.
+//!
+//! This module contains the core math and homography utilities used by the
+//! FreakMatcher feature detector. Functions are ported from the C++ WebARKitLib
+//! implementation and optimized for performance.
+
+pub mod math;

--- a/crates/core/src/kpm/kpm_c_api.cpp
+++ b/crates/core/src/kpm/kpm_c_api.cpp
@@ -38,6 +38,7 @@
 #include <facade/visual_database_facade.h>
 #include <matchers/feature_point.h>
 #include <matchers/matcher_types.h>
+#include <math/math_utils.h>
 #include <cstdlib>
 #include <cstring>
 #include <vector>
@@ -279,6 +280,20 @@ int kpm_extract_features(KpmOpaqueHandle* handle,
     }
 
     return n;
+}
+
+/* ---- Dual-mode validation: math function bridges (Milestone 6, #63) ---- */
+
+float webarkit_cpp_fast_atan2(float y, float x) {
+    return vision::fastatan2(y, x);
+}
+
+float webarkit_cpp_fast_sqrt1(float x) {
+    return vision::fastsqrt1(x);
+}
+
+float webarkit_cpp_fast_exp6_f32(float x) {
+    return vision::fastexp6<float>(x);
 }
 
 } // extern "C"

--- a/crates/core/src/kpm/kpm_c_api.h
+++ b/crates/core/src/kpm/kpm_c_api.h
@@ -117,6 +117,19 @@ int kpm_extract_features(KpmOpaqueHandle* handle,
                          unsigned char* desc_out,
                          int max_features);
 
+/* ---- Dual-mode validation: math function bridges (Milestone 6, #63) ---- */
+
+/* Thin wrappers around vision::fastatan2, vision::fastsqrt1, vision::fastexp6
+ * from FreakMatcher/math/math_utils.h. Used by Rust dual-mode tests to verify
+ * that the pure-Rust ports in crates/core/src/kpm/freak/math.rs produce the
+ * same outputs as the C++ baseline across a sweep of inputs.
+ *
+ * These are always exposed when ffi-backend is built; they are zero-cost when
+ * unused (link-time dead-code elimination removes them). */
+float webarkit_cpp_fast_atan2(float y, float x);
+float webarkit_cpp_fast_sqrt1(float x);
+float webarkit_cpp_fast_exp6_f32(float x);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crates/core/src/kpm/mod.rs
+++ b/crates/core/src/kpm/mod.rs
@@ -71,6 +71,7 @@
 //! | [`ref_data_set`] | [`RefDataSet`](ref_data_set::RefDataSet) collection |
 
 pub mod backend;
+pub mod freak;
 pub mod handle;
 pub mod kpm_ffi;
 pub mod matching;


### PR DESCRIPTION
## Summary

Milestone 6, Phase 1–3: ports the FREAK matcher math utilities from C++ to pure Rust and introduces the `dual-mode` feature for validating Rust implementations against the upstream C++ baseline.

Refs: #63

## What changed

**Commit 1 — `feat(kpm): port FREAK math utilities from C++`**
- New module `crates/core/src/kpm/freak/math.rs` (~640 LOC) porting all 40+ inline functions from upstream:
  - `indexing.h`: `zero_vector_*`, `copy_vector_*` (2-9), `swap_9`, `min2/3/4`, `max2`, `max_index_2..9`, `bitstring_set_bit`/`bitstring_get_bit`, `sequential_vector`
  - `math_utils.h`: `sqr`, `round`, `log2`, `logb`, `safe_reciprocal`, `safe_division`, `clip_scalar`, `deg2rad`, `fast_atan2`, `fast_atan2_360`, `fast_sqrt_inv`, `fast_exp6`
- All functions marked `#[inline(always)]` to match C++ `inline` semantics
- 27 unit tests covering exact equivalence (trivial functions) and tolerance-based comparison vs `std::f32` (fast approximations)

**Commit 2 — `test(kpm): add dual-mode validation for FREAK math fast-paths`**
- `Cargo.toml`: `dual-mode = ["ffi-backend"]` so the C++ comparison library is compiled when the feature is enabled
- `kpm_c_api.h/cpp`: thin `extern "C"` wrappers `webarkit_cpp_fast_atan2/fastsqrt1/fast_exp6_f32`
- 3 parametric tests gated on `#[cfg(feature = "dual-mode")]` that sweep across the input domain comparing Rust vs C++ output
- Test logging uses `arlog_e!` per `CLAUDE.md` (no `eprintln!`)
- `.idea/` added to `.gitignore`

## Validation results

Run with `cargo test -p webarkitlib-rs --features dual-mode`:

| Function | Inputs swept | Max divergence | Verdict |
|----------|--------------|----------------|---------|
| `fast_atan2` | 40,401 (201×201 grid covering 4 quadrants) | **0.0** | ✅ Bit-identical to C++ |
| `fast_exp6` | 401 over `x ∈ [-2, 2]` | 8.5e-7 relative | ✅ Essentially identical |
| `fast_sqrt_inv` | 10,000 over `x ∈ [0.01, 100]` | 28% relative | ⚠️ Documented divergence (see below) |

## Notes for reviewers

**Upstream usage status** (verified at submodule rev `656436e36b`):
- `fast_exp6` is the **only** function in `math_utils.h` actually called by the FreakMatcher algorithm — at `detectors/orientation_assignment.cpp:186` for Gaussian weighting in keypoint orientation assignment.
- `fast_atan2`, `fast_atan2_360`, and `fastsqrt1` are defined in `math_utils.h` but never called anywhere in upstream. They're ported anyway for completeness; doc comments on each note this.

**`fast_sqrt_inv` divergence** is real but **not a port bug**. The C++ source contains:

```cpp
inline float fastsqrt1(float x) {
    union { float x; int i; } u;
    float xhalf = 0.5f*x;
    u.x = (int)x;        // ← truncates float to int before bit manipulation
    u.i = 0x5f3759df - (u.i >> 1);
    ...
}
```

The `u.x = (int)x;` cast truncates the input through `int` **before** applying the magic-constant trick, losing fractional-input precision. The Rust port uses `x.to_bits()` directly (the canonical Quake algorithm), so it's more accurate. Since `fastsqrt1` is unused in upstream, this divergence has no algorithmic impact. Documented in detail on `fast_sqrt_inv`'s doc comment and the dual-mode test asserts only a loose bound to surface (not mask) the difference.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build -p webarkitlib-rs --all-features` succeeds
- [x] `cargo test -p webarkitlib-rs --lib kpm::freak::math` — 27/27 tests pass (default features)
- [x] `cargo test -p webarkitlib-rs --features dual-mode --lib kpm::freak::math` — 30/30 tests pass (dual-mode adds 3 FFI comparison tests)
- [x] No `println!`/`eprintln!` in library or test code (uses `arlog_e!`)
- [x] LGPL-3.0 headers on all new source files
- [x] CHANGELOG.md not touched (release-only per `CLAUDE.md`)

## Out of scope

- Homography porting (next phase of M6)
- SIMD optimization of math functions (deferred; scalar fallback first)
- Any algorithmic code that calls these utilities (this PR only ports the leaf functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)