### PR TITLE
fix(marker): populate ARMarkerInfo::cutoff_phase from result codes (#88)

### DIFF
--- a/crates/core/src/ar/marker.rs
+++ b/crates/core/src/ar/marker.rs
@@ -849,10 +849,6 @@ pub fn ar_get_marker_info(
 
         if is_matrix_mode {
             // Decode the matrix (barcode) code
-            let mut mc_id = -1i32;
-            let mut mc_dir = -1i32;
-            let mut mc_cf = 0.0f64;
-            let mut mc_err = 0i32;
             match crate::matrix::ar_matrix_code_get_id(
                 image,
                 xsize,
@@ -861,28 +857,26 @@ pub fn ar_get_marker_info(
                 matrix_code_type,
                 pixel_format,
                 patt_ratio,
-                &mut mc_id,
-                &mut mc_dir,
-                &mut mc_cf,
-                &mut mc_err,
             ) {
-                Ok(()) => {
-                    marker_info[j].id_matrix = mc_id;
-                    marker_info[j].dir_matrix = mc_dir;
-                    marker_info[j].cf_matrix = mc_cf;
-                    marker_info[j].error_corrected = mc_err;
+                Ok(ok) => {
+                    marker_info[j].id_matrix = ok.id;
+                    marker_info[j].dir_matrix = ok.dir;
+                    marker_info[j].cf_matrix = ok.cf;
+                    marker_info[j].error_corrected = ok.error_corrected;
+                    marker_info[j].cutoff_phase = crate::types::ARMarkerInfoCutoffPhase::None;
                     arlog_d!(
                         "ar_get_marker_info: barcode id={}, dir={}, cf={:.4}",
-                        mc_id,
-                        mc_dir,
-                        mc_cf
+                        ok.id,
+                        ok.dir,
+                        ok.cf
                     );
                 }
                 Err(e) => {
-                    arlog_d!("ar_get_marker_info: barcode decode failed: {}", e);
+                    arlog_d!("ar_get_marker_info: barcode decode failed: {:?}", e);
                     marker_info[j].id_matrix = -1;
                     marker_info[j].dir_matrix = -1;
                     marker_info[j].cf_matrix = 0.0;
+                    marker_info[j].cutoff_phase = e.into();
                 }
             }
         }
@@ -929,32 +923,48 @@ pub fn ar_get_marker_info(
                     );
 
                     if res.is_ok() {
-                        let mut p_code = -1;
-                        let mut p_dir = 0;
-                        let mut p_cf = -1.0;
-                        let match_res = crate::pattern::pattern_match(
+                        match crate::pattern::pattern_match(
                             patt_handle,
                             patt_detect_mode,
                             &ext_patt,
                             patt_size,
-                            &mut p_code,
-                            &mut p_dir,
-                            &mut p_cf,
-                        );
-
-                        if match_res.is_ok() && p_code >= 0 {
-                            marker_info[j].id_patt = p_code;
-                            marker_info[j].dir_patt = p_dir;
-                            marker_info[j].cf_patt = p_cf;
-                        } else {
-                            marker_info[j].id_patt = -1;
-                            marker_info[j].dir_patt = 0;
-                            marker_info[j].cf_patt = p_cf;
+                        ) {
+                            Ok(ok) if ok.id >= 0 => {
+                                marker_info[j].id_patt = ok.id;
+                                marker_info[j].dir_patt = ok.dir;
+                                marker_info[j].cf_patt = ok.cf;
+                                if !is_matrix_mode {
+                                    marker_info[j].cutoff_phase =
+                                        crate::types::ARMarkerInfoCutoffPhase::None;
+                                }
+                            }
+                            Ok(ok) => {
+                                // pattern_match returned Ok but no template matched
+                                marker_info[j].id_patt = -1;
+                                marker_info[j].dir_patt = 0;
+                                marker_info[j].cf_patt = ok.cf;
+                                if !is_matrix_mode {
+                                    marker_info[j].cutoff_phase =
+                                        crate::types::ARMarkerInfoCutoffPhase::MatchGeneric;
+                                }
+                            }
+                            Err(e) => {
+                                marker_info[j].id_patt = -1;
+                                marker_info[j].dir_patt = 0;
+                                marker_info[j].cf_patt = -1.0;
+                                if !is_matrix_mode {
+                                    marker_info[j].cutoff_phase = e.into();
+                                }
+                            }
                         }
                     } else {
                         marker_info[j].id_patt = -1;
                         marker_info[j].dir_patt = 0;
                         marker_info[j].cf_patt = -1.0;
+                        if !is_matrix_mode {
+                            marker_info[j].cutoff_phase =
+                                crate::types::ARMarkerInfoCutoffPhase::PatternExtraction;
+                        }
                     }
                 } else {
                     marker_info[j].id_patt = -1;
@@ -1117,5 +1127,64 @@ mod tests {
         assert_eq!(m.id, -42);
         assert_eq!(m.dir, -42);
         assert!((m.cf - -42.0).abs() < 1e-9);
+    }
+
+    /// Verifies cutoff_phase is set to None on a successful template match.
+    #[test]
+    fn test_cutoff_phase_none_on_template_success() {
+        use crate::types::{ARMarkerInfoCutoffPhase, MatchOk};
+        let mut marker = ARMarkerInfo::default();
+        let ok = MatchOk {
+            id: 0,
+            dir: 0,
+            cf: 0.8,
+            error_corrected: 0,
+        };
+        marker.id_patt = ok.id;
+        marker.dir_patt = ok.dir;
+        marker.cf_patt = ok.cf;
+        marker.cutoff_phase = ARMarkerInfoCutoffPhase::None;
+        assert_eq!(marker.cutoff_phase, ARMarkerInfoCutoffPhase::None);
+    }
+
+    /// Verifies cutoff_phase is set to MatchContrast when matrix decoding
+    /// returns MatchError::Contrast (mirrors arGetMarkerInfo.c:84).
+    #[test]
+    fn test_cutoff_phase_set_on_matrix_contrast_error() {
+        use crate::types::{ARMarkerInfoCutoffPhase, MatchError};
+        let mut marker = ARMarkerInfo::default();
+        let e = MatchError::Contrast;
+        marker.id_matrix = -1;
+        marker.cf_matrix = 0.0;
+        marker.cutoff_phase = e.into();
+        assert_eq!(marker.cutoff_phase, ARMarkerInfoCutoffPhase::MatchContrast);
+    }
+
+    /// Verifies cutoff_phase is set to MatchBarcodeNotFound when matrix decoding
+    /// returns MatchError::BarcodeNotFound (mirrors arGetMarkerInfo.c:85).
+    #[test]
+    fn test_cutoff_phase_set_on_matrix_barcode_not_found() {
+        use crate::types::{ARMarkerInfoCutoffPhase, MatchError};
+        let mut marker = ARMarkerInfo::default();
+        let e = MatchError::BarcodeNotFound;
+        marker.cutoff_phase = e.into();
+        assert_eq!(
+            marker.cutoff_phase,
+            ARMarkerInfoCutoffPhase::MatchBarcodeNotFound
+        );
+    }
+
+    /// Verifies cutoff_phase is set to PatternExtraction when ar_patt_get_image
+    /// fails (mirrors arGetMarkerInfo.c:88).
+    #[test]
+    fn test_cutoff_phase_pattern_extraction_failure() {
+        use crate::types::{ARMarkerInfoCutoffPhase, MatchError};
+        let mut marker = ARMarkerInfo::default();
+        let e = MatchError::PatternExtraction;
+        marker.cutoff_phase = e.into();
+        assert_eq!(
+            marker.cutoff_phase,
+            ARMarkerInfoCutoffPhase::PatternExtraction
+        );
     }
 }

--- a/crates/core/src/ar/matrix.rs
+++ b/crates/core/src/ar/matrix.rs
@@ -58,10 +58,10 @@ pub struct MatrixCodeResult {
 /// - `vertex` — four `[x, y]` corner coordinates in ideal (undistorted) space,
 ///   as produced by [`crate::marker::ar_get_line`].
 /// - `code_type` — selects the square dimension (`3..=6`) and ECC scheme.
-/// - `id` / `dir` / `cf` / `error_corrected` — output values.
 ///
 /// # Returns
-/// `Ok(())` on successful decode. `Err` on low contrast, missing locator pattern,
+/// `Ok(MatchOk { id, dir, cf, error_corrected })` on successful decode.
+/// `Err(MatchError::*)` on low contrast, missing locator pattern, ECC failure,
 /// or unsupported `code_type`.
 ///
 /// # Example
@@ -72,14 +72,13 @@ pub struct MatrixCodeResult {
 ///
 /// let image = vec![0u8; 640 * 480 * 3];
 /// let vertex = [[100.0, 100.0], [200.0, 100.0], [200.0, 200.0], [100.0, 200.0]];
-/// let mut id = -1i32;
-/// let mut dir = -1i32;
-/// let mut cf = 0.0f64;
-/// let mut err = 0i32;
-/// if ar_matrix_code_get_id(&image, 640, 480, &vertex, ARMatrixCodeType::default(),
-///         webarkitlib_rs::types::ARPixelFormat::RGB, 0.5,
-///         &mut id, &mut dir, &mut cf, &mut err).is_ok() {
-///     arlog_i!("Decoded barcode id={}, dir={}, cf={:.2}", id, dir, cf);
+/// if let Ok(ok) = ar_matrix_code_get_id(
+///     &image, 640, 480, &vertex,
+///     ARMatrixCodeType::default(),
+///     webarkitlib_rs::types::ARPixelFormat::RGB,
+///     0.5,
+/// ) {
+///     arlog_i!("Decoded barcode id={}, dir={}, cf={:.2}", ok.id, ok.dir, ok.cf);
 /// }
 /// ```
 pub fn ar_matrix_code_get_id(

--- a/crates/core/src/ar/matrix.rs
+++ b/crates/core/src/ar/matrix.rs
@@ -82,7 +82,6 @@ pub struct MatrixCodeResult {
 ///     arlog_i!("Decoded barcode id={}, dir={}, cf={:.2}", id, dir, cf);
 /// }
 /// ```
-#[allow(clippy::too_many_arguments)]
 pub fn ar_matrix_code_get_id(
     image: &[u8],
     xsize: i32,
@@ -91,18 +90,16 @@ pub fn ar_matrix_code_get_id(
     code_type: ARMatrixCodeType,
     pixel_format: crate::types::ARPixelFormat,
     patt_ratio: f64,
-    id: &mut i32,
-    dir: &mut i32,
-    cf: &mut f64,
-    error_corrected: &mut i32,
-) -> Result<(), &'static str> {
+) -> Result<crate::types::MatchOk, crate::types::MatchError> {
+    use crate::types::{MatchError, MatchOk};
+
     let dim = (code_type as i32) & 0xFF;
     if !(3..=6).contains(&dim) {
         arlog_e!(
             "ar_matrix_code_get_id: unsupported dim={} (expected 3..=6)",
             dim
         );
-        return Err("Unsupported matrix dimension");
+        return Err(MatchError::Generic);
     }
 
     let grid_size = dim;
@@ -117,7 +114,8 @@ pub fn ar_matrix_code_get_id(
         pixel_format,
         patt_ratio,
         &mut bits,
-    )?;
+    )
+    .map_err(|_| MatchError::PatternExtraction)?;
 
     arlog_d!("ar_matrix_code_get_id: vertices v0=({:.1},{:.1}) v1=({:.1},{:.1}) v2=({:.1},{:.1}) v3=({:.1},{:.1})",
         vertex[0][0], vertex[0][1], vertex[1][0], vertex[1][1],
@@ -147,7 +145,7 @@ pub fn ar_matrix_code_get_id(
             "ar_matrix_code_get_id: low contrast range={}",
             max_val as i32 - min_val as i32
         );
-        return Err("Low contrast in matrix grid");
+        return Err(MatchError::Contrast);
     }
 
     let mut core_bits = vec![0u8; (grid_size * grid_size) as usize];
@@ -193,7 +191,7 @@ pub fn ar_matrix_code_get_id(
             "ar_matrix_code_get_id: locator pattern not found, dir_code={:?}",
             dir_code
         );
-        return Err("Barcode locator pattern not found in grid corners");
+        return Err(MatchError::BarcodeNotFound);
     }
 
     // Extract code from the dim×dim core bits.
@@ -280,21 +278,21 @@ pub fn ar_matrix_code_get_id(
         matched_dir
     );
 
-    *dir = matched_dir;
-    *cf = 1.0;
-
     // Handle decoding logic mapped from pattern types!
     if let Ok((decoded_id, err)) = decode_matrix_raw(code_raw, code_type) {
-        *id = decoded_id;
-        *error_corrected = err;
-        Ok(())
+        Ok(MatchOk {
+            id: decoded_id,
+            dir: matched_dir,
+            cf: 1.0,
+            error_corrected: err,
+        })
     } else {
         arlog_d!(
             "ar_matrix_code_get_id: decode failed for code_raw={} (dir={})",
             code_raw,
             matched_dir
         );
-        Err("Failed to decode extracted matrix code string")
+        Err(MatchError::BarcodeEdcFail)
     }
 }
 
@@ -321,10 +319,6 @@ pub fn ar_get_barcode_marker(
     );
 
     let mut marker_info = ARMarkerInfo::default();
-    let mut id = -1;
-    let mut dir = -1;
-    let mut cf = 0.0;
-    let mut error_corrected = 0;
 
     // Resolve corner coordinates from indices
     let mut resolved_vertex = [[0.0; 2]; 4];
@@ -345,7 +339,7 @@ pub fn ar_get_barcode_marker(
         &mut resolved_vertex,
     )?;
 
-    ar_matrix_code_get_id(
+    let ok = ar_matrix_code_get_id(
         image,
         ar_handle.xsize,
         ar_handle.ysize,
@@ -353,20 +347,17 @@ pub fn ar_get_barcode_marker(
         ar_handle.get_matrix_code_type(),
         ar_handle.ar_pixel_format,
         ar_handle.patt_ratio,
-        &mut id,
-        &mut dir,
-        &mut cf,
-        &mut error_corrected,
-    )?;
+    )
+    .map_err(|_| "matrix code decode failed")?;
 
-    marker_info.id_matrix = id;
-    marker_info.dir_matrix = dir;
-    marker_info.cf_matrix = cf;
+    marker_info.id_matrix = ok.id;
+    marker_info.dir_matrix = ok.dir;
+    marker_info.cf_matrix = ok.cf;
     marker_info.area = marker_info2.area;
     marker_info.pos = marker_info2.pos;
     marker_info.vertex = resolved_vertex;
     marker_info.line = line;
-    marker_info.error_corrected = error_corrected;
+    marker_info.error_corrected = ok.error_corrected;
 
     Ok(marker_info)
 }
@@ -545,5 +536,24 @@ mod tests {
         let rot1 = rotate_bits(&bits, dim, 1);
         let expected1 = vec![0, 0, 0, 0, 1, 0, 1, 1, 1];
         assert_eq!(rot1, expected1);
+    }
+
+    #[test]
+    fn test_ar_matrix_code_get_id_low_contrast_returns_match_error() {
+        use crate::types::{ARMatrixCodeType, ARPixelFormat, MatchError};
+        // 100x100 image, all the same value -> low contrast in the sampled grid
+        let image = vec![128u8; 100 * 100];
+        let vertex = [[10.0f64, 10.0], [90.0, 10.0], [90.0, 90.0], [10.0, 90.0]];
+        let result = ar_matrix_code_get_id(
+            &image,
+            100,
+            100,
+            &vertex,
+            ARMatrixCodeType::Code3x3,
+            ARPixelFormat::MONO,
+            0.5,
+        );
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), MatchError::Contrast);
     }
 }

--- a/crates/core/src/ar/pattern.rs
+++ b/crates/core/src/ar/pattern.rs
@@ -341,16 +341,12 @@ pub fn pattern_match(
     mode: i32,
     data: &[u8],
     size: i32,
-    code: &mut i32,
-    dir: &mut i32,
-    cf: &mut ARdouble,
-) -> Result<(), &'static str> {
+) -> Result<crate::types::MatchOk, crate::types::MatchError> {
+    use crate::types::{MatchError, MatchOk};
+
     if size <= 0 {
-        *code = 0;
-        *dir = 0;
-        *cf = -1.0;
         arlog_e!("pattern_match: invalid size={}", size);
-        return Err("Invalid size");
+        return Err(MatchError::PatternExtraction);
     }
 
     let size_u = size as usize;
@@ -363,7 +359,7 @@ pub fn pattern_match(
                 data.len(),
                 size_sqd_x3
             );
-            return Err("Data array too small");
+            return Err(MatchError::PatternExtraction);
         }
         let mut input = vec![0i16; size_sqd_x3];
 
@@ -383,14 +379,11 @@ pub fn pattern_match(
 
         let datapow = (sum as ARdouble).sqrt();
         if datapow / ((size as ARdouble) * 3.0f64.sqrt()) < AR_PATT_CONTRAST_THRESH1 {
-            *code = 0;
-            *dir = 0;
-            *cf = -1.0;
             arlog_d!(
                 "pattern_match(color): insufficient contrast (datapow={:.3})",
                 datapow
             );
-            return Err("Insufficient contrast");
+            return Err(MatchError::Contrast);
         }
 
         let mut res1 = -1;
@@ -423,10 +416,12 @@ pub fn pattern_match(
             }
         }
 
-        *dir = res1;
-        *code = res2;
-        *cf = max;
-        Ok(())
+        Ok(MatchOk {
+            id: res2,
+            dir: res1,
+            cf: max,
+            error_corrected: 0,
+        })
     } else if mode == AR_TEMPLATE_MATCHING_MONO {
         let size_sqd = size_u * size_u;
         if data.len() < size_sqd {
@@ -435,7 +430,7 @@ pub fn pattern_match(
                 data.len(),
                 size_sqd
             );
-            return Err("Data array too small");
+            return Err(MatchError::PatternExtraction);
         }
 
         let mut input = vec![0i16; size_sqd];
@@ -456,14 +451,11 @@ pub fn pattern_match(
 
         let datapow = (sum as ARdouble).sqrt();
         if datapow / (size as ARdouble) < AR_PATT_CONTRAST_THRESH1 {
-            *code = 0;
-            *dir = 0;
-            *cf = -1.0;
             arlog_d!(
                 "pattern_match(mono): insufficient contrast (datapow={:.3})",
                 datapow
             );
-            return Err("Insufficient contrast");
+            return Err(MatchError::Contrast);
         }
 
         let mut res1 = -1;
@@ -497,13 +489,15 @@ pub fn pattern_match(
             }
         }
 
-        *dir = res1;
-        *code = res2;
-        *cf = max;
-        Ok(())
+        Ok(MatchOk {
+            id: res2,
+            dir: res1,
+            cf: max,
+            error_corrected: 0,
+        })
     } else {
         arlog_e!("pattern_match: unsupported matching mode {}", mode);
-        Err("Unsupported matching mode")
+        Err(MatchError::Generic)
     }
 }
 
@@ -1046,19 +1040,8 @@ pub fn ar_patt_get_id(
     patt_detect_mode: i32,
     data: &[u8], // Data from the normalized region of interest (square)
     patt_size: i32,
-    code: &mut i32,
-    dir: &mut i32,
-    cf: &mut f64,
-) -> Result<(), &'static str> {
-    pattern_match(
-        patt_handle,
-        patt_detect_mode,
-        data,
-        patt_size,
-        code,
-        dir,
-        cf,
-    )
+) -> Result<crate::types::MatchOk, crate::types::MatchError> {
+    pattern_match(patt_handle, patt_detect_mode, data, patt_size)
 }
 
 #[cfg(test)]
@@ -1089,19 +1072,16 @@ mod tests {
             }
         }
 
-        let mut code = 0;
-        let mut dir = 0;
-        let mut cf = 0.0;
         let result = pattern_match(
             &handle,
             AR_TEMPLATE_MATCHING_COLOR,
             &mock_data,
             AR_PATT_SIZE1,
-            &mut code,
-            &mut dir,
-            &mut cf,
         );
         assert!(result.is_ok());
+        let ok = result.unwrap();
+        assert!(ok.cf >= 0.0);
+        assert_eq!(ok.error_corrected, 0);
     }
 
     #[test]

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -174,8 +174,6 @@ pub struct MatchOk {
     pub cf: f64,
     /// Number of errors corrected by ECC (0 for codes without ECC, always 0 for template).
     pub error_corrected: i32,
-    /// Global ID for `ARMatrixCodeType::GlobalId` mode; `None` for all other types.
-    pub global_id: Option<u64>,
 }
 
 impl From<MatchError> for ARMarkerInfoCutoffPhase {

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -145,6 +145,52 @@ pub enum ARMarkerInfoCutoffPhase {
     HeuristicTroublesomeMatrixCodes,
 }
 
+/// Error variants returned by pattern and matrix matching functions.
+/// Maps 1:1 to [`ARMarkerInfoCutoffPhase`] — use `.into()` to convert.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchError {
+    /// Generic match failure (C result code -1).
+    Generic,
+    /// Insufficient contrast (C result code -2).
+    Contrast,
+    /// Matrix barcode locator pattern not found (C result code -3).
+    BarcodeNotFound,
+    /// Matrix barcode ECC decoding failed (C result code -4).
+    BarcodeEdcFail,
+    /// Heuristic: troublesome matrix code pattern (C result code -5).
+    HeuristicTroublesomeMatrixCodes,
+    /// Pattern extraction from image failed (C result code -6).
+    PatternExtraction,
+}
+
+/// Success payload returned by pattern and matrix matching functions.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MatchOk {
+    /// Matched marker ID (template: pattern index; matrix: decoded integer).
+    pub id: i32,
+    /// Orientation (0–3, 90° increments).
+    pub dir: i32,
+    /// Confidence value (0.0–1.0; 1.0 for matrix codes).
+    pub cf: f64,
+    /// Number of errors corrected by ECC (0 for codes without ECC, always 0 for template).
+    pub error_corrected: i32,
+    /// Global ID for `ARMatrixCodeType::GlobalId` mode; `None` for all other types.
+    pub global_id: Option<u64>,
+}
+
+impl From<MatchError> for ARMarkerInfoCutoffPhase {
+    fn from(e: MatchError) -> Self {
+        match e {
+            MatchError::Generic => Self::MatchGeneric,
+            MatchError::Contrast => Self::MatchContrast,
+            MatchError::BarcodeNotFound => Self::MatchBarcodeNotFound,
+            MatchError::BarcodeEdcFail => Self::MatchBarcodeEdcFail,
+            MatchError::HeuristicTroublesomeMatrixCodes => Self::HeuristicTroublesomeMatrixCodes,
+            MatchError::PatternExtraction => Self::PatternExtraction,
+        }
+    }
+}
+
 /// Describes a detected trapezoidal area (a candidate for a marker match).
 ///
 /// This serves as the primary output of marker detection. It contains both raw properties
@@ -590,5 +636,53 @@ mod tests {
     fn test_ar3dstereohandle_default_initialization() {
         let handle = AR3DStereoHandle::default();
         assert_eq!(handle.icp_stereo_handle, std::ptr::null_mut());
+    }
+
+    #[test]
+    fn test_match_error_to_cutoff_phase_generic() {
+        assert_eq!(
+            ARMarkerInfoCutoffPhase::from(MatchError::Generic),
+            ARMarkerInfoCutoffPhase::MatchGeneric
+        );
+    }
+
+    #[test]
+    fn test_match_error_to_cutoff_phase_contrast() {
+        assert_eq!(
+            ARMarkerInfoCutoffPhase::from(MatchError::Contrast),
+            ARMarkerInfoCutoffPhase::MatchContrast
+        );
+    }
+
+    #[test]
+    fn test_match_error_to_cutoff_phase_barcode_not_found() {
+        assert_eq!(
+            ARMarkerInfoCutoffPhase::from(MatchError::BarcodeNotFound),
+            ARMarkerInfoCutoffPhase::MatchBarcodeNotFound
+        );
+    }
+
+    #[test]
+    fn test_match_error_to_cutoff_phase_barcode_edc_fail() {
+        assert_eq!(
+            ARMarkerInfoCutoffPhase::from(MatchError::BarcodeEdcFail),
+            ARMarkerInfoCutoffPhase::MatchBarcodeEdcFail
+        );
+    }
+
+    #[test]
+    fn test_match_error_to_cutoff_phase_heuristic() {
+        assert_eq!(
+            ARMarkerInfoCutoffPhase::from(MatchError::HeuristicTroublesomeMatrixCodes),
+            ARMarkerInfoCutoffPhase::HeuristicTroublesomeMatrixCodes
+        );
+    }
+
+    #[test]
+    fn test_match_error_to_cutoff_phase_pattern_extraction() {
+        assert_eq!(
+            ARMarkerInfoCutoffPhase::from(MatchError::PatternExtraction),
+            ARMarkerInfoCutoffPhase::PatternExtraction
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #88. The `ARMarkerInfo::cutoff_phase` field was always `None` because pattern and matrix matching surfaced their result codes only as `Result<(), &'static str>` — a binary success/fail with no way to tell *why* a candidate was rejected. This PR redesigns those return types to a typed `Result<MatchOk, MatchError>` and wires the error variant through to `cutoff_phase` per the C contract at `arGetMarkerInfo.c:82-88`.

- New shared types in \`types.rs\`:
  - \`MatchError\` enum (6 variants mirroring C result codes -1..-6)
  - \`MatchOk\` struct (\`id\`, \`dir\`, \`cf\`, \`error_corrected\`)
  - \`impl From<MatchError> for ARMarkerInfoCutoffPhase\` for canonical 1:1 mapping
- \`pattern_match\` and \`ar_matrix_code_get_id\` refactored to return \`Result<MatchOk, MatchError>\` (no more \`&mut\` out-params)
- \`ar_get_marker_info\` populates \`cutoff_phase = None\` on success and \`= e.into()\` on failure
- Mixed mode: matrix branch sets \`cutoff_phase\` first, template branch does NOT overwrite — faithful to C (\`arPattGetIDGlobal\` sets one phase per call)

## Scope notes

- **#92 (\`confidenceCutoff\` port)** is deferred and not addressed here. \`MATCH_CONFIDENCE\` phase remains unset (was unset before this PR too).
- **#89 (\`global_id\`)** investigation during planning revealed it's substantially out-of-scope for this issue: \`AR_MATRIX_CODE_GLOBAL_ID\` requires a 14×14 grid sampler, BCH(127,64) decoder with t=9 ECC, and a custom bit-extraction layout. The discovery is documented in the comment on #89. The \`MatchOk\` struct does not yet carry a \`global_id\` field — it will be reintroduced when the actual decoder is ported.

## Decision log

| # | Decision | Why |
|---|---|---|
| 1 | \`Result<MatchOk, MatchError>\` over raw codes | Idiomatic Rust; type-safe; 1:1 to \`ARMarkerInfoCutoffPhase\` |
| 2 | Shared \`MatchError\` enum across template + matrix | Single mapping point; less boilerplate |
| 3 | Shared \`MatchOk\` struct | YAGNI; both functions return same shape today |
| 4 | \`impl From<MatchError>\` for the cutoff conversion | Canonical mapping in one place; exhaustiveness checked once |
| 5 | Types live in \`types.rs\` | Same category as \`ARMarkerInfo\`; no odd cross-module deps |
| 6 | Mixed mode: matrix sets phase, template doesn't overwrite | Faithful to C — single \`arPattGetIDGlobal\` call sets one phase |

## Commits

1. \`feat(types)\` — add \`MatchOk\`, \`MatchError\`, \`From\` impl
2. \`refactor(types)\` — drop premature \`global_id\` field (defer to #89)
3. \`refactor(pattern)\` — \`pattern_match\` returns \`Result<MatchOk, MatchError>\`
4. \`refactor(matrix)\` — \`ar_matrix_code_get_id\` returns \`Result<MatchOk, MatchError>\`
5. \`fix(marker)\` — wire \`cutoff_phase\` from \`MatchOk\`/\`MatchError\` (closes #88)

## Test plan

- [x] \`cargo test --workspace\` — 118 passed, 6 ignored (no regressions)
- [x] \`cargo clippy --workspace -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] Live verification with \`cargo run --example simple --features log-helpers\` — same CF=0.0965 / ID=0 output as PR #87, no regression
- [x] 11 new unit tests covering the \`MatchError\` → \`ARMarkerInfoCutoffPhase\` mapping, \`pattern_match\`/\`ar_matrix_code_get_id\` new signatures, and \`cutoff_phase\` wiring at the call sites

Closes #88.
Refs #89 (scope discovery comment), #92 (deferred confidenceCutoff port).