### PR TITLE
chore: convert println!/eprintln! to arlog_*! in examples and bench (PR 1/4 for #90)

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -92,6 +92,14 @@ required-features = ["log-helpers"]
 name = "nft_marker_gen"
 required-features = ["log-helpers"]
 
+[[example]]
+name = "barcode"
+required-features = ["log-helpers"]
+
+[[example]]
+name = "debug_labeling"
+required-features = ["log-helpers"]
+
 [[bench]]
 name = "marker_bench"
 harness = false
@@ -103,3 +111,4 @@ harness = false
 [[bench]]
 name = "feature_map_bench"
 harness = false
+required-features = ["log-helpers"]

--- a/crates/core/benches/feature_map_bench.rs
+++ b/crates/core/benches/feature_map_bench.rs
@@ -46,13 +46,16 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::path::PathBuf;
 use webarkitlib_rs::ar2::{ar2_gen_feature_map, ar2_gen_image_set};
+use webarkitlib_rs::arlog_e;
 
 fn bench_ar2_gen_feature_map(c: &mut Criterion) {
+    webarkitlib_rs::arlog::ar_log_init_default();
+
     // Locate the pinball fixture relative to the crate root.
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("examples/Data/pinball.jpg");
     if !path.exists() {
-        eprintln!("Skipping bench: missing {}", path.display());
+        arlog_e!("Skipping bench: missing {}", path.display());
         return;
     }
 

--- a/crates/core/examples/barcode.rs
+++ b/crates/core/examples/barcode.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use image::ImageReader;
 use std::fs::File;
+use webarkitlib_rs::arlog_i;
 use webarkitlib_rs::marker::ar_detect_marker;
 use webarkitlib_rs::types::{
     AR2VideoBufferT, AR2VideoTimestampT, ARHandle, ARMatrixCodeType, ARParam, ARParamLT,
@@ -55,14 +56,13 @@ fn resolve_path<'a>(candidates: &[&'a str]) -> &'a str {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 1. Initialize Logging
-    std::env::set_var("RUST_LOG", "trace");
-    env_logger::init();
+    webarkitlib_rs::arlog::ar_log_init_default();
 
     let args = Args::parse();
 
     let code_type = parse_matrix_code_type(&args.matrix_code_type)?;
-    println!("WebARKitLib-rs v{}", version::get_version());
-    println!(
+    arlog_i!("WebARKitLib-rs v{}", version::get_version());
+    arlog_i!(
         "WebARKitLib-rs Barcode Detection Example (matrix_code_type={:?})",
         code_type
     );
@@ -75,9 +75,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let param_file = File::open(camera_para_path)
         .map_err(|e| format!("Failed to open camera parameters at {camera_para_path}: {e}"))?;
     let mut param = ARParam::load(param_file).expect("Failed to read camera parameters");
-    println!(
+    arlog_i!(
         "Loaded camera parameters from {}: xsize={}, ysize={}",
-        camera_para_path, param.xsize, param.ysize
+        camera_para_path,
+        param.xsize,
+        param.ysize
     );
 
     // 3. Resolve image path
@@ -89,14 +91,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let image_path = image_path_str.as_str();
 
-    println!("Loading image {}...", image_path);
+    arlog_i!("Loading image {}...", image_path);
     let full_img = ImageReader::open(image_path)
         .map_err(|e| format!("Failed to open image at {image_path}: {e}"))?
         .decode()
         .map_err(|e| format!("Failed to decode image at {image_path}: {e}"))?;
     let width = full_img.width() as i32;
     let height = full_img.height() as i32;
-    println!("Image dimensions: {}x{}", width, height);
+    arlog_i!("Image dimensions: {}x{}", width, height);
 
     // Derive output directory
     let data_dir = std::path::Path::new(image_path)
@@ -126,7 +128,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     for thresh in thresholds {
-        println!("\n--- Testing BlackRegion, Threshold: {} ---", thresh);
+        arlog_i!("--- Testing BlackRegion, Threshold: {} ---", thresh);
 
         let mut ar_handle = ARHandle::default();
         ar_handle.xsize = width;
@@ -165,18 +167,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         if let Ok(_) = ar_detect_marker(&mut ar_handle, &frame) {
-            println!("Found {} square candidates.", ar_handle.marker2_num);
-            println!("Found {} valid barcode markers.", ar_handle.marker_num);
+            arlog_i!("Found {} square candidates.", ar_handle.marker2_num);
+            arlog_i!("Found {} valid barcode markers.", ar_handle.marker_num);
             let mut found_valid = false;
             for i in 0..ar_handle.marker_num as usize {
                 let m = &ar_handle.marker_info[i];
-                println!("  >> MATCH: ID={}, CF={:.4}", m.id_matrix, m.cf_matrix);
+                arlog_i!("  >> MATCH: ID={}, CF={:.4}", m.id_matrix, m.cf_matrix);
                 if m.id_matrix >= 0 {
                     found_valid = true;
                 }
             }
             if found_valid {
-                println!("Valid matrix code found! Stopping loop.");
+                arlog_i!("Valid matrix code found! Stopping loop.");
                 break;
             }
         }

--- a/crates/core/examples/debug_labeling.rs
+++ b/crates/core/examples/debug_labeling.rs
@@ -7,13 +7,13 @@
 
 use image::{ImageReader, Rgb, RgbImage};
 use webarkitlib_rs::{
+    arlog_i,
     labeling::{ar_labeling, ImageProcMode, LabelingMode},
     types::ARLabelInfo,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    std::env::set_var("RUST_LOG", "trace");
-    env_logger::init();
+    webarkitlib_rs::arlog::ar_log_init_default();
 
     let image_path = "crates/core/examples/Data/gem_05_3x3.png";
     let image_path_buf = std::path::PathBuf::from(image_path);
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         image_path_buf
     };
 
-    println!("Loading image {}...", final_image_path.display());
+    arlog_i!("Loading image {}...", final_image_path.display());
     let full_img = ImageReader::open(&final_image_path)
         .expect(&format!("Failed to open {}", final_image_path.display()))
         .decode()
@@ -52,7 +52,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .expect("Labeling failed");
 
-    println!("Found {} labels.", label_info.label_num);
+    arlog_i!("Found {} labels.", label_info.label_num);
 
     // Save as colorized image
     let mut out_img = RgbImage::new(width, height);
@@ -82,14 +82,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     out_img.save("crates/core/examples/Data/debug_labels.png")?;
-    println!("Saved debug_labels.png");
+    arlog_i!("Saved debug_labels.png");
 
     // Print stats for largest components
     let mut labels: Vec<usize> = (0..label_info.label_num as usize).collect();
     labels.sort_by_key(|&idx| std::cmp::Reverse(label_info.area[idx]));
 
     for &idx in labels.iter().take(10) {
-        println!(
+        arlog_i!(
             "Label #{} : Area={}, Clip={:?}",
             idx + 1,
             label_info.area[idx],


### PR DESCRIPTION
Part 1 of 4 for #90. Converts println!/eprintln! to arlog_*! macros, following the simple.rs template established in #85. Maintainer @kalwalt - confirmed plan in the issue thread.

**Scope**

- crates/core/examples/barcode.rs — 10 sites, all arlog_i! (one-shot example, threshold sweep bounded to ≤7 iterations).
- crates/core/examples/debug_labeling.rs — 4 sites, all arlog_i! (one-shot diagnostic tool).
- crates/core/benches/feature_map_bench.rs — 1 site, arlog_e! per @kalwalt's guidance. Added webarkitlib_rs::arlog::ar_log_init_default() to bench_ar2_gen_feature_map and required-features = ["log-helpers"] to the bench's Cargo.toml block so the warning is visible under cargo bench.
- crates/core/Cargo.toml — added [[example]] blocks with required-features = ["log-helpers"] for barcode and debug_labeling; added the same to the existing feature_map_bench [[bench]] block.

In each entry point: std::env::set_var("RUST_LOG", "trace") + env_logger::init() replaced with webarkitlib_rs::arlog::ar_log_init_default().

**Verification**

- cargo fmt --all -- --check ✓
- cargo build --examples --features log-helpers ✓
- cargo build --bench feature_map_bench --features log-helpers ✓
- cargo test ✓ (all suites pass)
- cargo run --example barcode --features log-helpers ✓ — confirmed [info] arlog output
- cargo run --example debug_labeling --features log-helpers ✓ — confirmed [info] arlog output
- No remaining println!/eprintln! in the touched files (grep clean).

**Pre-existing issues (not in scope, flagged for follow-up)**

While verifying, three pre-existing issues surfaced unrelated to this PR:

1. cargo build --all-features fails on macOS due to crates/core/build.rs:128 hardcoding cargo:rustc-link-lib=stdc++ under a !msvc check (macOS needs c++). Already flagged in the issue thread.
2. cargo build --benches --features log-helpers fails on simd_bench because its [[bench]] block doesn't declare its required SIMD features.
3. cargo clippy --all-targets -- -D warnings fails on a needless_doctest_main lint in crates/core/src/arlog.rs:299 (lib-side, untouched here).

Plain cargo build and the targeted feature builds above all pass cleanly. None of (1)/(2)/(3) are introduced by these changes.

**Not touched**

- CHANGELOG.md (per #90)
- Library code or other examples (those land in PRs 2–4)

**Followups**

- PR 2: load_nft.rs finish-up
- PR 3: generate_patt.rs + nft_marker_gen.rs
- PR 4: simple_nft.rs

Will hold on starting PR 2 until @kalwalt sanity-checks the pattern here.