### PR TITLE
Issue/detect marker orchestrator

### DIFF
--- a/crates/core/examples/simple.rs
+++ b/crates/core/examples/simple.rs
@@ -39,7 +39,7 @@ use std::fs::File;
 use webarkitlib_rs::{
     arlog_e, arlog_i,
     image_proc::ARImageProcInfo,
-    marker::{ar_detect_marker, confidence_cutoff, AR_CONFIDENCE_CUTOFF_DEFAULT},
+    marker::ar_detect_marker,
     pattern::ar_patt_load,
     pose::{ar_3d_create_handle, ar_3d_delete_handle, ar_get_trans_mat_square},
     types::{
@@ -235,13 +235,6 @@ fn main() {
     // Run the marker detection pipeline
     match ar_detect_marker(&mut ar_handle, &frame) {
         Ok(_) => {
-            confidence_cutoff(
-                &mut *ar_handle.marker_info,
-                ar_handle.marker_num,
-                ar_handle.ar_pattern_detection_mode,
-                AR_CONFIDENCE_CUTOFF_DEFAULT,
-            );
-
             arlog_i!("Detection pipeline finished successfully.");
             arlog_i!("Detected {} potential markers.", ar_handle.marker_num);
 

--- a/crates/core/src/ar/marker.rs
+++ b/crates/core/src/ar/marker.rs
@@ -1456,7 +1456,7 @@ mod tests {
     fn test_confidence_cutoff_mono_matrix_template_passes_matrix_fails() {
         let mut markers = vec![ARMarkerInfo::default()];
         markers[0].id_patt = 3;
-        markers[0].cf_patt = 0.8;   // passes
+        markers[0].cf_patt = 0.8; // passes
         markers[0].id_matrix = 9;
         markers[0].cf_matrix = 0.2; // fails
 
@@ -1467,7 +1467,7 @@ mod tests {
             0.5,
         );
 
-        assert_eq!(markers[0].id_patt, 3,    "template should survive");
+        assert_eq!(markers[0].id_patt, 3, "template should survive");
         assert_eq!(markers[0].id_matrix, -1, "matrix should be evicted");
         assert_eq!(
             markers[0].cutoff_phase,
@@ -1482,7 +1482,7 @@ mod tests {
     fn test_confidence_cutoff_mono_matrix_matrix_passes_template_fails() {
         let mut markers = vec![ARMarkerInfo::default()];
         markers[0].id_patt = 3;
-        markers[0].cf_patt = 0.1;   // fails
+        markers[0].cf_patt = 0.1; // fails
         markers[0].id_matrix = 9;
         markers[0].cf_matrix = 0.9; // passes
 
@@ -1494,7 +1494,7 @@ mod tests {
         );
 
         assert_eq!(markers[0].id_patt, -1, "template should be evicted");
-        assert_eq!(markers[0].id_matrix, 9,  "matrix should survive");
+        assert_eq!(markers[0].id_matrix, 9, "matrix should survive");
         assert_eq!(
             markers[0].cutoff_phase,
             crate::types::ARMarkerInfoCutoffPhase::None,
@@ -1522,7 +1522,7 @@ mod tests {
         );
 
         assert_eq!(markers[0].id, -1, "cf=0.75 should fail threshold=0.8");
-        assert_eq!(markers[1].id, 2,  "cf=0.85 should pass threshold=0.8");
+        assert_eq!(markers[1].id, 2, "cf=0.85 should pass threshold=0.8");
     }
 
     /// Verifies cf == cutoff exactly is KEPT (implementation uses strict <).
@@ -1540,7 +1540,10 @@ mod tests {
             0.5,
         );
 
-        assert_eq!(markers[0].id, 5, "cf exactly at cutoff should be kept (strict <)");
+        assert_eq!(
+            markers[0].id, 5,
+            "cf exactly at cutoff should be kept (strict <)"
+        );
         assert_eq!(
             markers[0].cutoff_phase,
             crate::types::ARMarkerInfoCutoffPhase::None
@@ -1567,18 +1570,27 @@ mod tests {
             crate::types::AR_TEMPLATE_MATCHING_MONO_AND_MATRIX_CODE_DETECTION,
         );
 
-        assert_eq!(m.id, -42,  "combined mode should not overwrite id");
+        assert_eq!(m.id, -42, "combined mode should not overwrite id");
         assert_eq!(m.dir, -42, "combined mode should not overwrite dir");
-        assert!((m.cf - -42.0).abs() < 1e-9, "combined mode should not overwrite cf");
+        assert!(
+            (m.cf - -42.0).abs() < 1e-9,
+            "combined mode should not overwrite cf"
+        );
     }
 
     /// Verifies markers beyond marker_num are not touched.
     #[test]
     fn test_confidence_cutoff_respects_marker_num_boundary() {
         let mut markers = vec![ARMarkerInfo::default(); 3];
-        markers[0].id = 1; markers[0].id_patt = 1; markers[0].cf = 0.1; // fails
-        markers[1].id = 2; markers[1].id_patt = 2; markers[1].cf = 0.9; // passes
-        markers[2].id = 3; markers[2].id_patt = 3; markers[2].cf = 0.1; // outside range
+        markers[0].id = 1;
+        markers[0].id_patt = 1;
+        markers[0].cf = 0.1; // fails
+        markers[1].id = 2;
+        markers[1].id_patt = 2;
+        markers[1].cf = 0.9; // passes
+        markers[2].id = 3;
+        markers[2].id_patt = 3;
+        markers[2].cf = 0.1; // outside range
 
         confidence_cutoff(
             &mut markers,
@@ -1588,15 +1600,23 @@ mod tests {
         );
 
         assert_eq!(markers[0].id, -1, "marker 0 should be evicted");
-        assert_eq!(markers[1].id, 2,  "marker 1 should be kept");
-        assert_eq!(markers[2].id, 3,  "marker 2 is outside marker_num and must not be touched");
+        assert_eq!(markers[1].id, 2, "marker 1 should be kept");
+        assert_eq!(
+            markers[2].id, 3,
+            "marker 2 is outside marker_num and must not be touched"
+        );
     }
 
     /// Verifies MatchOk carries correct fields for a successful template match.
     #[test]
     fn test_match_ok_fields() {
         use crate::types::MatchOk;
-        let ok = MatchOk { id: 5, dir: 3, cf: 0.91, error_corrected: 0 };
+        let ok = MatchOk {
+            id: 5,
+            dir: 3,
+            cf: 0.91,
+            error_corrected: 0,
+        };
         assert_eq!(ok.id, 5);
         assert_eq!(ok.dir, 3);
         assert!((ok.cf - 0.91).abs() < 1e-9);
@@ -1622,9 +1642,6 @@ mod tests {
         use crate::types::{ARMarkerInfoCutoffPhase, MatchError};
         let mut marker = ARMarkerInfo::default();
         marker.cutoff_phase = MatchError::Generic.into();
-        assert_eq!(
-            marker.cutoff_phase,
-            ARMarkerInfoCutoffPhase::MatchGeneric
-        );
+        assert_eq!(marker.cutoff_phase, ARMarkerInfoCutoffPhase::MatchGeneric);
     }
 }

--- a/crates/core/src/ar/marker.rs
+++ b/crates/core/src/ar/marker.rs
@@ -66,8 +66,12 @@ pub enum ImageProcMode {
 ///    template matching (via `ar_patt_get_image` + `pattern_match`) **or**
 ///    matrix-code reading (via [`crate::matrix::ar_matrix_code_get_id`]),
 ///    depending on `ar_handle.ar_pattern_detection_mode`.
+/// 5. **Confidence cutoff** — [`confidence_cutoff`] removes markers with
+///    confidence below `AR_CONFIDENCE_CUTOFF_DEFAULT` (0.5).
 ///
 /// Results are written into `ar_handle.marker_info` (up to `AR_SQUARE_MAX` markers).
+///
+/// Mirrors the C `arDetectMarker()` entry point from `arDetectMarker.c:80-300`.
 ///
 /// # Example
 /// ```rust,no_run
@@ -117,6 +121,7 @@ pub fn ar_detect_marker(
     };
 
     let thresh = ar_handle.ar_labeling_thresh as u8;
+    // TODO: port AR_LABELING_THRESH_MODE_*_AUTO variants (bracketing, median, etc.) from C
     let label_mode = if ar_handle.ar_labeling_mode == 0 {
         crate::labeling::LabelingMode::BlackRegion
     } else {
@@ -184,12 +189,14 @@ pub fn ar_detect_marker(
     };
 
     let param_ltf = unsafe { &(*ar_handle.ar_param_lt).param_ltf };
+    // SAFETY: ar_param_lt is checked for null above; ARHandle invariants ensure it's valid
 
     let patt_handle_opt = if !ar_handle.patt_handle.is_null() {
         Some(unsafe { &*ar_handle.patt_handle })
     } else {
         None
     };
+    // SAFETY: patt_handle is checked for null above; ARHandle invariants ensure it's valid
 
     ar_get_marker_info(
         color_buff,
@@ -215,6 +222,15 @@ pub fn ar_detect_marker(
         );
     }
 
+    confidence_cutoff(
+        &mut *ar_handle.marker_info,
+        ar_handle.marker_num,
+        ar_handle.ar_pattern_detection_mode,
+        AR_CONFIDENCE_CUTOFF_DEFAULT,
+    );
+// TODO: port arDetectMarker.c:300+ tracking history merge (out of scope for this issue)
+
+    
     Ok(())
 }
 
@@ -1015,7 +1031,7 @@ fn finalize_marker_id_cf_dir(marker: &mut ARMarkerInfo, patt_detect_mode: i32) {
 /// Cull low-confidence marker IDs after matching.
 ///
 /// Mirrors `confidenceCutoff()` from `arDetectMarker.c`.
-pub fn confidence_cutoff(
+pub(crate) fn confidence_cutoff(
     marker_info: &mut [ARMarkerInfo],
     marker_num: i32,
     patt_detect_mode: i32,
@@ -1287,6 +1303,94 @@ mod tests {
             markers[0].cutoff_phase,
             crate::types::ARMarkerInfoCutoffPhase::MatchConfidence
         )
+    }
+
+    /// Verifies zero markers detected (empty input) does not crash.
+    #[test]
+    fn test_confidence_cutoff_zero_markers_detected() {
+        let mut markers = vec![ARMarkerInfo::default(); 5];
+
+        // Call with marker_num=0 (no markers to process)
+        confidence_cutoff(
+            &mut markers,
+            0,
+            crate::pattern::AR_TEMPLATE_MATCHING_COLOR,
+            0.5,
+        );
+
+        // All markers should remain unchanged
+        for m in &markers {
+            assert_eq!(m.id, -1); // default value
+        }
+    }
+
+    /// Verifies matrix mode with all markers above cutoff (no eviction).
+    #[test]
+    fn test_confidence_cutoff_matrix_keeps_high_cf() {
+        let mut markers = vec![ARMarkerInfo::default()];
+        markers[0].id = 15;
+        markers[0].id_matrix = 15;
+        markers[0].cf = 0.88;
+
+        confidence_cutoff(&mut markers, 1, crate::types::AR_MATRIX_CODE_DETECTION, 0.5);
+
+        assert_eq!(markers[0].id, 15);
+        assert_eq!(markers[0].id_matrix, 15);
+        assert_eq!(
+            markers[0].cutoff_phase,
+            crate::types::ARMarkerInfoCutoffPhase::None
+        );
+    }
+
+    /// Verifies template mode with mixed pass/fail markers (some cleared, some kept).
+    #[test]
+    fn test_confidence_cutoff_template_mixed_pass_fail() {
+        let mut markers = vec![
+            ARMarkerInfo::default(),
+            ARMarkerInfo::default(),
+            ARMarkerInfo::default(),
+        ];
+        // Marker 0: low CF, should be cleared
+        markers[0].id = 3;
+        markers[0].id_patt = 3;
+        markers[0].cf = 0.2;
+        // Marker 1: high CF, should be kept
+        markers[1].id = 7;
+        markers[1].id_patt = 7;
+        markers[1].cf = 0.9;
+        // Marker 2: low CF, should be cleared
+        markers[2].id = 11;
+        markers[2].id_patt = 11;
+        markers[2].cf = 0.3;
+
+        confidence_cutoff(
+            &mut markers,
+            3,
+            crate::pattern::AR_TEMPLATE_MATCHING_MONO,
+            0.5,
+        );
+
+        // Marker 0: cleared
+        assert_eq!(markers[0].id, -1);
+        assert_eq!(markers[0].id_patt, -1);
+        assert_eq!(
+            markers[0].cutoff_phase,
+            crate::types::ARMarkerInfoCutoffPhase::MatchConfidence
+        );
+        // Marker 1: kept
+        assert_eq!(markers[1].id, 7);
+        assert_eq!(markers[1].id_patt, 7);
+        assert_eq!(
+            markers[1].cutoff_phase,
+            crate::types::ARMarkerInfoCutoffPhase::None
+        );
+        // Marker 2: cleared
+        assert_eq!(markers[2].id, -1);
+        assert_eq!(markers[2].id_patt, -1);
+        assert_eq!(
+            markers[2].cutoff_phase,
+            crate::types::ARMarkerInfoCutoffPhase::MatchConfidence
+        );
     }
     /// Verifies cutoff_phase is set to None on a successful template match.
     #[test]

--- a/crates/core/src/ar/marker.rs
+++ b/crates/core/src/ar/marker.rs
@@ -1449,4 +1449,182 @@ mod tests {
             ARMarkerInfoCutoffPhase::PatternExtraction
         );
     }
+
+    /// Verifies confidence_cutoff with mono+matrix combined mode,
+    /// where template passes but matrix fails.
+    #[test]
+    fn test_confidence_cutoff_mono_matrix_template_passes_matrix_fails() {
+        let mut markers = vec![ARMarkerInfo::default()];
+        markers[0].id_patt = 3;
+        markers[0].cf_patt = 0.8;   // passes
+        markers[0].id_matrix = 9;
+        markers[0].cf_matrix = 0.2; // fails
+
+        confidence_cutoff(
+            &mut markers,
+            1,
+            crate::types::AR_TEMPLATE_MATCHING_MONO_AND_MATRIX_CODE_DETECTION,
+            0.5,
+        );
+
+        assert_eq!(markers[0].id_patt, 3,    "template should survive");
+        assert_eq!(markers[0].id_matrix, -1, "matrix should be evicted");
+        assert_eq!(
+            markers[0].cutoff_phase,
+            crate::types::ARMarkerInfoCutoffPhase::None,
+            "phase should be None when at least one match survives"
+        );
+    }
+
+    /// Verifies confidence_cutoff with mono+matrix combined mode,
+    /// where matrix passes but template fails.
+    #[test]
+    fn test_confidence_cutoff_mono_matrix_matrix_passes_template_fails() {
+        let mut markers = vec![ARMarkerInfo::default()];
+        markers[0].id_patt = 3;
+        markers[0].cf_patt = 0.1;   // fails
+        markers[0].id_matrix = 9;
+        markers[0].cf_matrix = 0.9; // passes
+
+        confidence_cutoff(
+            &mut markers,
+            1,
+            crate::types::AR_TEMPLATE_MATCHING_MONO_AND_MATRIX_CODE_DETECTION,
+            0.5,
+        );
+
+        assert_eq!(markers[0].id_patt, -1, "template should be evicted");
+        assert_eq!(markers[0].id_matrix, 9,  "matrix should survive");
+        assert_eq!(
+            markers[0].cutoff_phase,
+            crate::types::ARMarkerInfoCutoffPhase::None,
+            "phase should be None when at least one match survives"
+        );
+    }
+
+    /// Verifies confidence_cutoff with a custom (non-0.5) threshold.
+    #[test]
+    fn test_confidence_cutoff_custom_threshold() {
+        let mut markers = vec![ARMarkerInfo::default(); 2];
+        markers[0].id = 1;
+        markers[0].id_patt = 1;
+        markers[0].cf = 0.75; // passes 0.7 but fails 0.8
+
+        markers[1].id = 2;
+        markers[1].id_patt = 2;
+        markers[1].cf = 0.85; // passes both
+
+        confidence_cutoff(
+            &mut markers,
+            2,
+            crate::pattern::AR_TEMPLATE_MATCHING_COLOR,
+            0.8,
+        );
+
+        assert_eq!(markers[0].id, -1, "cf=0.75 should fail threshold=0.8");
+        assert_eq!(markers[1].id, 2,  "cf=0.85 should pass threshold=0.8");
+    }
+
+    /// Verifies cf == cutoff exactly is KEPT (implementation uses strict <).
+    #[test]
+    fn test_confidence_cutoff_exactly_at_boundary() {
+        let mut markers = vec![ARMarkerInfo::default()];
+        markers[0].id = 5;
+        markers[0].id_patt = 5;
+        markers[0].cf = 0.5; // 0.5 < 0.5 is false, so survives
+
+        confidence_cutoff(
+            &mut markers,
+            1,
+            crate::pattern::AR_TEMPLATE_MATCHING_COLOR,
+            0.5,
+        );
+
+        assert_eq!(markers[0].id, 5, "cf exactly at cutoff should be kept (strict <)");
+        assert_eq!(
+            markers[0].cutoff_phase,
+            crate::types::ARMarkerInfoCutoffPhase::None
+        );
+    }
+
+    /// Verifies finalize_marker_id_cf_dir for mono+matrix combined mode
+    /// leaves finals untouched.
+    #[test]
+    fn test_finalize_marker_id_cf_dir_mono_matrix_leaves_finals_alone() {
+        let mut m = ARMarkerInfo::default();
+        m.id = -42;
+        m.dir = -42;
+        m.cf = -42.0;
+        m.id_patt = 1;
+        m.dir_patt = 1;
+        m.cf_patt = 0.6;
+        m.id_matrix = 2;
+        m.dir_matrix = 2;
+        m.cf_matrix = 0.7;
+
+        finalize_marker_id_cf_dir(
+            &mut m,
+            crate::types::AR_TEMPLATE_MATCHING_MONO_AND_MATRIX_CODE_DETECTION,
+        );
+
+        assert_eq!(m.id, -42,  "combined mode should not overwrite id");
+        assert_eq!(m.dir, -42, "combined mode should not overwrite dir");
+        assert!((m.cf - -42.0).abs() < 1e-9, "combined mode should not overwrite cf");
+    }
+
+    /// Verifies markers beyond marker_num are not touched.
+    #[test]
+    fn test_confidence_cutoff_respects_marker_num_boundary() {
+        let mut markers = vec![ARMarkerInfo::default(); 3];
+        markers[0].id = 1; markers[0].id_patt = 1; markers[0].cf = 0.1; // fails
+        markers[1].id = 2; markers[1].id_patt = 2; markers[1].cf = 0.9; // passes
+        markers[2].id = 3; markers[2].id_patt = 3; markers[2].cf = 0.1; // outside range
+
+        confidence_cutoff(
+            &mut markers,
+            2,
+            crate::pattern::AR_TEMPLATE_MATCHING_COLOR,
+            0.5,
+        );
+
+        assert_eq!(markers[0].id, -1, "marker 0 should be evicted");
+        assert_eq!(markers[1].id, 2,  "marker 1 should be kept");
+        assert_eq!(markers[2].id, 3,  "marker 2 is outside marker_num and must not be touched");
+    }
+
+    /// Verifies MatchOk carries correct fields for a successful template match.
+    #[test]
+    fn test_match_ok_fields() {
+        use crate::types::MatchOk;
+        let ok = MatchOk { id: 5, dir: 3, cf: 0.91, error_corrected: 0 };
+        assert_eq!(ok.id, 5);
+        assert_eq!(ok.dir, 3);
+        assert!((ok.cf - 0.91).abs() < 1e-9);
+        assert_eq!(ok.error_corrected, 0);
+    }
+
+    /// Verifies cutoff_phase is set to MatchBarcodeEdcFail when matrix decoding
+    /// returns MatchError::BarcodeEdcFail.
+    #[test]
+    fn test_cutoff_phase_set_on_barcode_edc_fail() {
+        use crate::types::{ARMarkerInfoCutoffPhase, MatchError};
+        let mut marker = ARMarkerInfo::default();
+        marker.cutoff_phase = MatchError::BarcodeEdcFail.into();
+        assert_eq!(
+            marker.cutoff_phase,
+            ARMarkerInfoCutoffPhase::MatchBarcodeEdcFail
+        );
+    }
+
+    /// Verifies cutoff_phase is set to MatchGeneric for a generic match failure.
+    #[test]
+    fn test_cutoff_phase_set_on_match_generic() {
+        use crate::types::{ARMarkerInfoCutoffPhase, MatchError};
+        let mut marker = ARMarkerInfo::default();
+        marker.cutoff_phase = MatchError::Generic.into();
+        assert_eq!(
+            marker.cutoff_phase,
+            ARMarkerInfoCutoffPhase::MatchGeneric
+        );
+    }
 }

--- a/crates/core/src/ar/marker.rs
+++ b/crates/core/src/ar/marker.rs
@@ -228,9 +228,8 @@ pub fn ar_detect_marker(
         ar_handle.ar_pattern_detection_mode,
         AR_CONFIDENCE_CUTOFF_DEFAULT,
     );
-// TODO: port arDetectMarker.c:300+ tracking history merge (out of scope for this issue)
+    // TODO: port arDetectMarker.c:300+ tracking history merge (out of scope for this issue)
 
-    
     Ok(())
 }
 


### PR DESCRIPTION
 https://github.com/webarkit/WebARKitLib-rs/issues/96. Maintainer @kalwalt - confirmed plan in the issue thread.
This PR introduces a top-level `ar_detect_marker()` orchestrator in `marker.rs`, mirroring the public entry point from the C library (`arDetectMarker.c`).  
It consolidates the full four-stage detection pipeline into a single function call, ensuring the pipeline is executed correctly by default.
### The Problem
Previously, the Rust port required manual chaining of four stages:

1. `ar_label` (labeling)  
2. `ar_detect_marker2` (square detection)  
3. `ar_get_marker_info` (matching)  
4. `confidence_cutoff` (culling)  

Forgetting the final stage caused **"ghost markers"**—low-confidence detections that still appeared with valid IDs.
### What changed
A new public function ar_detect_marker(...) was added as the main entry point for marker detection. This function internally runs the full pipeline in order: ar_labeling, ar_detect_marker2, ar_get_marker_info, and confidence_cutoff. The visibility of confidence_cutoff was reduced to pub(crate) so external callers can no longer bypass low-confidence filtering. The simple.rs example was updated to use this new single-call API, reducing boilerplate and improving correctness. Safety comments were added for all raw ARHandle pointer dereferences, and TODO notes were included for future work such as auto-threshold mode porting and tracking history merge based on arDetectMarker.c

### Why
This change fixes a recurring issue where callers could manually run only the first three stages of the pipeline and forget to apply confidence_cutoff, resulting in silently incorrect outputs with low-confidence marker IDs. By enforcing a single orchestrated entry point, the API becomes safer and “correct by default.”

### Tests
cargo fmt --all -- --check ✓
cargo clippy -- -D warnings ✓
cargo test ✓ (all suites pass)
