### PR TITLE
fix(simple,marker): honour the buff/pixel_format contract (#103)

### DIFF
--- a/crates/core/examples/simple.rs
+++ b/crates/core/examples/simple.rs
@@ -218,12 +218,15 @@ fn main() {
 
     let luma_buffer_vec = luma_img.into_raw();
     let mut out_img = color_img.clone();
-    let color_buffer_vec = color_img.into_raw();
 
-    // Construct the AR2VideoBufferT pointing to our image data
+    // ARToolKit5's contract (cf. artoolkit5/video2.c:682): `buff` MUST hold
+    // data in the format declared by ar_pixel_format. When pixel_format is
+    // MONO, that means buff IS the luma data — buffLuma is just an alias.
+    // Feeding RGBA into buff while declaring MONO produces silent low-cf
+    // detections (see issue #103).
     let frame = AR2VideoBufferT {
-        buff: Some(color_buffer_vec),     // Color data
-        buff_luma: Some(luma_buffer_vec), // Gray data used for binarization
+        buff: Some(luma_buffer_vec.clone()), // pixfmt=MONO → buff IS luma
+        buff_luma: Some(luma_buffer_vec.clone()),
         buf_planes: None,
         buf_plane_count: 0,
         fill_flag: true,

--- a/crates/core/src/ar/marker.rs
+++ b/crates/core/src/ar/marker.rs
@@ -82,6 +82,19 @@ pub enum ImageProcMode {
 ///
 /// Results are written into `ar_handle.marker_info` (up to `AR_SQUARE_MAX` markers).
 ///
+/// # Frame buffer contract
+///
+/// `frame.buff` MUST hold data in the format declared by
+/// `ar_handle.ar_pixel_format`. ARToolKit5's `video2.c:682` documents this
+/// contract: when `ar_pixel_format == MONO`, `buff` IS the luma data
+/// (and `buff_luma` is just an alias to it); otherwise `buff` holds the
+/// declared format and `buff_luma` is a separately-converted greyscale view.
+///
+/// Mismatching the buffer layout against the declared format used to
+/// produce silent low-confidence matches (see
+/// [issue #103](https://github.com/webarkit/WebARKitLib-rs/issues/103));
+/// `ar_detect_marker` now rejects such mismatches up front.
+///
 /// Mirrors the C `arDetectMarker()` entry point from `arDetectMarker.c:80-322`.
 ///
 /// # Example
@@ -130,6 +143,43 @@ pub fn ar_detect_marker(
             return Err("AR2VideoBufferT requires buff to be available");
         }
     };
+
+    // Frame-buffer contract (artoolkit5/video2.c:682, issue #103): when
+    // ar_pixel_size > 0 (i.e. a known fixed bytes-per-pixel format), `buff`
+    // length must equal xsize * ysize * pixel_size. Sub-sampled formats
+    // (NV21, 420v, 420f) have pixel_size == 0 and are skipped.
+    let pixel_size = ar_handle.ar_pixel_size as usize;
+    if pixel_size > 0 {
+        let expected = (ar_handle.xsize as usize) * (ar_handle.ysize as usize) * pixel_size;
+        if color_buff.len() != expected {
+            arlog_e!(
+                "ar_detect_marker: AR2VideoBufferT.buff length {} does not match \
+                 expected {} for {}x{} {:?} (pixel_size={}). \
+                 buff must hold data in the format declared by ar_pixel_format \
+                 (cf. artoolkit5 video2.c:682).",
+                color_buff.len(),
+                expected,
+                ar_handle.xsize,
+                ar_handle.ysize,
+                ar_handle.ar_pixel_format,
+                pixel_size
+            );
+            return Err("AR2VideoBufferT.buff length mismatches ar_pixel_format");
+        }
+    }
+    // Buff_luma is always 1 byte per pixel.
+    let expected_luma = (ar_handle.xsize as usize) * (ar_handle.ysize as usize);
+    if luma_buff.len() != expected_luma {
+        arlog_e!(
+            "ar_detect_marker: AR2VideoBufferT.buff_luma length {} does not match \
+             expected {} for {}x{} (1 byte/pixel)",
+            luma_buff.len(),
+            expected_luma,
+            ar_handle.xsize,
+            ar_handle.ysize
+        );
+        return Err("AR2VideoBufferT.buff_luma length mismatches xsize*ysize");
+    }
 
     let thresh = ar_handle.ar_labeling_thresh as u8;
     // TODO: port AR_LABELING_THRESH_MODE_*_AUTO variants (bracketing, median, etc.) from C


### PR DESCRIPTION
## Summary

Closes the symptom from [issue #103](https://github.com/webarkit/WebARKitLib-rs/issues/103) — `simple.rs` reporting `cf ≈ 0.0965` and `Matched ID = -1` on the standard hiro pattern. After this PR the same example reports `cf = 0.8925` and `Matched ID = 0`, well above the 0.5 cutoff.

The PR-A diagnostic harness ([#104](https://github.com/webarkit/WebARKitLib-rs/pull/104)) already established that the library extraction is correct on this code path (`cf ≈ 0.89` in `dump_patt`). The remaining symptom in `simple.rs` was a frame-setup bug, not a port bug.

## Root cause

`simple.rs` declared `ar_pixel_format = MONO` but fed an RGBA buffer into `AR2VideoBufferT.buff`, violating the contract documented at upstream [`artoolkit5/video2.c:682`](https://github.com/webarkit/artoolkit5/blob/66aa1cc12e1bdeb12ee6af5746dc4ff6f3ba34cb/lib/SRC/Video/video2.c#L682):

```c
if (pixFormat == AR_PIXEL_FORMAT_MONO || /* ... */) {
    ret->buffLuma = ret->buff;   // when MONO, buff IS the luma data
} else {
    /* otherwise compute buffLuma from buff via arVideoLuma() */
}
```

The MONO branch of `ar_patt_get_image` indexes `buff` as one byte per pixel; with RGBA passed instead, the sampler reads the wrong bytes and produces nonsense correlation. The `cf` was non-zero because the staggered byte stride of an RGBA hiro thumbnail still carries some accidental signal — but nowhere near the real correlation.

## Changes

1. **`crates/core/examples/simple.rs`** — feeds the luma buffer into both `buff` and `buff_luma` (matching `pixfmt = MONO`), with a comment pointing at the upstream contract.
2. **`crates/core/src/ar/marker.rs`** — `ar_detect_marker` now validates:
   - `frame.buff.len() == xsize * ysize * pixel_size` (when `pixel_size > 0`; sub-sampled formats like NV21 / 420v / 420f have `pixel_size == 0` and skip the check),
   - `frame.buff_luma.len() == xsize * ysize` (always).
   On mismatch, emits `arlog_e!` and returns `Err(\"AR2VideoBufferT.buff length mismatches ar_pixel_format\")`. Turns silent contract violations into loud, immediate failures.
3. **`ar_detect_marker` doc comment** grew a *Frame buffer contract* section documenting the rule and linking issue #103.

## Verification

| Check | Before | After |
|---|---|---|
| `cargo run --example simple` cf | `0.0965` | **`0.8925`** ✅ |
| `cargo run --example simple` id | `-1` | **`0`** ✅ |
| `cargo fmt --all -- --check` | clean | clean |
| `cargo clippy --lib -- -D warnings` | clean | clean |
| `cargo test --lib` | 132 passed | **132 passed** |

## Test plan

- [x] Build: `cargo build --example simple --features log-helpers`
- [x] Run: `cargo run --release --example simple --features log-helpers` → `cf=0.8925, id=0`
- [x] Library tests: `cargo test --lib` → 132 passed, 2 ignored (pre-existing)
- [x] fmt + clippy: both clean

## Out of scope

- The residual *byte-equality* drift between Rust and C `ext_patt` (`cf ≈ 0.89` vs `cf ≈ 0.85` in PR-A's diagnostic) — captured as a follow-up in `docs/issue-103-fix-plan.md` §10. The Rust path is functionally correct; bit-exact parity is a separate, lower-priority refinement.
- Issue #103 points 3 (`patt_ratio`) and 4 (`ar_patt_load`) — separate brainstorms.
- Full pixel-format coverage in `ar_patt_get_image` (BGR, BGRA, ABGR, ARGB, RGB565, 2vuy, yuvs).