### PR TITLE
feat(matrix): implement AR_MATRIX_CODE_GLOBAL_ID decoding

### DIFF
--- a/crates/core/examples/barcode.rs
+++ b/crates/core/examples/barcode.rs
@@ -15,7 +15,8 @@ use webarkitlib_rs::version;
 struct Args {
     /// Matrix code type to use for detection.
     /// Accepted values: 3x3, 3x3parity65, 3x3hamming63, 4x4, 4x4bch1393,
-    ///                  4x4bch1355, 5x5, 5x5bch22125, 5x5bch2277, 6x6
+    ///                  4x4bch1355, 5x5, 5x5bch22125, 5x5bch2277, 6x6,
+    ///                  globalid (14x14 BCH(127,64,22), 64-bit IDs)
     #[arg(short = 'm', long, default_value = "3x3")]
     matrix_code_type: String,
 
@@ -41,6 +42,7 @@ fn parse_matrix_code_type(s: &str) -> Result<ARMatrixCodeType, String> {
         "5x5bch22125" => Ok(ARMatrixCodeType::Code5x5BCH22125),
         "5x5bch2277" => Ok(ARMatrixCodeType::Code5x5BCH2277),
         "6x6" => Ok(ARMatrixCodeType::Code6x6),
+        "globalid" | "global_id" | "global-id" => Ok(ARMatrixCodeType::GlobalID),
         other => Err(format!("Unknown matrix code type: '{other}'")),
     }
 }

--- a/crates/core/src/ar/bch.rs
+++ b/crates/core/src/ar/bch.rs
@@ -37,6 +37,53 @@
 use crate::types::ARMatrixCodeType;
 use crate::{arlog_d, arlog_e};
 
+// =====================================================================
+// GF(2^m) lookup tables — ported verbatim from arPattGetID.c lines
+// 1826-1831 in the upstream WebARKitLib C code.
+// =====================================================================
+
+/// GF(2^4) `alpha_to` table (n = 15) — used by BCH(15, k, t).
+const BCH_15_ALPHA_TO: [i32; 15] = [1, 2, 4, 8, 3, 6, 12, 11, 5, 10, 7, 14, 15, 13, 9];
+
+/// GF(2^4) `index_of` (inverse) table — `BCH_15_INDEX_OF[BCH_15_ALPHA_TO[i]] = i`.
+const BCH_15_INDEX_OF: [i32; 16] = [-1, 0, 1, 4, 2, 8, 5, 10, 3, 14, 9, 7, 6, 13, 11, 12];
+
+/// GF(2^5) `alpha_to` table (n = 31) — used by BCH(31, k, t).
+const BCH_31_ALPHA_TO: [i32; 31] = [
+    1, 2, 4, 8, 16, 5, 10, 20, 13, 26, 17, 7, 14, 28, 29, 31, 27, 19, 3, 6, 12, 24, 21, 15, 30, 25,
+    23, 11, 22, 9, 18,
+];
+
+/// GF(2^5) `index_of` (inverse) table — `BCH_31_INDEX_OF[BCH_31_ALPHA_TO[i]] = i`.
+const BCH_31_INDEX_OF: [i32; 32] = [
+    -1, 0, 1, 18, 2, 5, 19, 11, 3, 29, 6, 27, 20, 8, 12, 23, 4, 10, 30, 17, 7, 22, 28, 26, 21, 25,
+    9, 16, 13, 14, 24, 15,
+];
+
+/// GF(2^7) `alpha_to` table (n = 127) — used by BCH(127, 64, 22) for AR_MATRIX_CODE_GLOBAL_ID.
+const BCH_127_ALPHA_TO: [i32; 127] = [
+    1, 2, 4, 8, 16, 32, 64, 3, 6, 12, 24, 48, 96, 67, 5, 10, 20, 40, 80, 35, 70, 15, 30, 60, 120,
+    115, 101, 73, 17, 34, 68, 11, 22, 44, 88, 51, 102, 79, 29, 58, 116, 107, 85, 41, 82, 39, 78,
+    31, 62, 124, 123, 117, 105, 81, 33, 66, 7, 14, 28, 56, 112, 99, 69, 9, 18, 36, 72, 19, 38, 76,
+    27, 54, 108, 91, 53, 106, 87, 45, 90, 55, 110, 95, 61, 122, 119, 109, 89, 49, 98, 71, 13, 26,
+    52, 104, 83, 37, 74, 23, 46, 92, 59, 118, 111, 93, 57, 114, 103, 77, 25, 50, 100, 75, 21, 42,
+    84, 43, 86, 47, 94, 63, 126, 127, 125, 121, 113, 97, 65,
+];
+
+/// GF(2^7) `index_of` (inverse) table — `BCH_127_INDEX_OF[BCH_127_ALPHA_TO[i]] = i`.
+const BCH_127_INDEX_OF: [i32; 128] = [
+    -1, 0, 1, 7, 2, 14, 8, 56, 3, 63, 15, 31, 9, 90, 57, 21, 4, 28, 64, 67, 16, 112, 32, 97, 10,
+    108, 91, 70, 58, 38, 22, 47, 5, 54, 29, 19, 65, 95, 68, 45, 17, 43, 113, 115, 33, 77, 98, 117,
+    11, 87, 109, 35, 92, 74, 71, 79, 59, 104, 39, 100, 23, 82, 48, 119, 6, 126, 55, 13, 30, 62, 20,
+    89, 66, 27, 96, 111, 69, 107, 46, 37, 18, 53, 44, 94, 114, 42, 116, 76, 34, 86, 78, 73, 99,
+    103, 118, 81, 12, 125, 88, 61, 110, 26, 36, 106, 93, 52, 75, 41, 72, 85, 80, 102, 60, 124, 105,
+    25, 40, 51, 101, 84, 24, 123, 83, 50, 49, 122, 120, 121,
+];
+
+// =====================================================================
+// Public decoders for short codes (parity-65, hamming-63).
+// =====================================================================
+
 pub fn decode_parity65(code_raw: u64) -> Result<u64, &'static str> {
     const PARITY65_DECODER_TABLE: [i8; 64] = [
         0, -1, -1, 3, -1, 5, 6, -1, -1, 9, 10, -1, 12, -1, -1, 15, -1, 17, 18, -1, 20, -1, -1, 23,
@@ -96,76 +143,41 @@ pub fn decode_hamming63(code_raw: u64) -> Result<(u64, i32), &'static str> {
     }
 }
 
-pub fn decode_bch(
-    matrix_code_type: ARMatrixCodeType,
-    in_val: u64,
-) -> Result<(u64, i32), &'static str> {
-    let t: usize;
-    let k: usize;
-    let n: usize;
-    let length: usize;
-    let alpha_to: &[i32];
-    let index_of: &[i32];
+// =====================================================================
+// Berlekamp-Massey error correction core.
+// =====================================================================
 
-    const BCH_15_ALPHA_TO: [i32; 15] = [1, 2, 4, 8, 3, 6, 12, 11, 5, 10, 7, 14, 15, 13, 9];
-    const BCH_15_INDEX_OF: [i32; 16] = [-1, 0, 1, 4, 2, 8, 5, 10, 3, 14, 9, 7, 6, 13, 11, 12];
-    const BCH_31_ALPHA_TO: [i32; 31] = [
-        1, 2, 4, 8, 16, 5, 10, 20, 13, 26, 17, 7, 14, 28, 29, 31, 27, 19, 3, 6, 12, 24, 21, 15, 30,
-        25, 23, 11, 22, 9, 18,
-    ];
-    const BCH_31_INDEX_OF: [i32; 32] = [
-        -1, 0, 1, 18, 2, 5, 19, 11, 3, 29, 6, 27, 20, 8, 12, 23, 4, 10, 30, 17, 7, 22, 28, 26, 21,
-        25, 9, 16, 13, 14, 24, 15,
-    ];
-
-    let mut recd = [0u8; 127];
-
-    match matrix_code_type {
-        ARMatrixCodeType::Code4x4BCH1393 | ARMatrixCodeType::Code4x4BCH1355 => {
-            if matrix_code_type == ARMatrixCodeType::Code4x4BCH1393 {
-                t = 1;
-                k = 9;
-            } else {
-                t = 2;
-                k = 5;
-            }
-            n = 15;
-            length = 13;
-            alpha_to = &BCH_15_ALPHA_TO;
-            index_of = &BCH_15_INDEX_OF;
-        }
-        ARMatrixCodeType::Code5x5BCH22125 | ARMatrixCodeType::Code5x5BCH2277 => {
-            if matrix_code_type == ARMatrixCodeType::Code5x5BCH22125 {
-                t = 2;
-                k = 12;
-            } else {
-                t = 3;
-                k = 7;
-            }
-            n = 31;
-            length = 22;
-            alpha_to = &BCH_31_ALPHA_TO;
-            index_of = &BCH_31_INDEX_OF;
-        }
-        _ => {
-            arlog_e!(
-                "decode_bch: unsupported matrix code type {:?}",
-                matrix_code_type
-            );
-            return Err("Unsupported BCH code type");
-        }
-    }
-
-    let mut in_bitwise = in_val;
-    for r in recd[..length].iter_mut() {
-        *r = (in_bitwise & 1) as u8;
-        in_bitwise >>= 1;
-    }
-
-    let mut syn_error = false;
+/// Runs Berlekamp's iterative error-correction algorithm on a received BCH
+/// codeword. Mirrors the Berlekamp-Massey body from `arPattGetID.c`'s
+/// `decode_bch` function.
+///
+/// On success, in-place flips bit positions in `recd` to correct errors.
+///
+/// # Parameters
+/// - `recd` — received bits, indexed `[0..length]` (LSB at index 0). At least
+///   `n` entries (sized to fit `loc`).
+/// - `t` — error-correction capability (max number of correctable errors).
+/// - `n` — codeword length (`2^m - 1` for GF(2^m)).
+/// - `length` — effective input length (used codeword bits; may be < `n` for
+///   shortened codes).
+/// - `alpha_to` / `index_of` — GF(2^m) lookup tables.
+///
+/// # Returns
+/// `Ok(num_corrected)` on success (0 if no errors detected),
+/// `Err` if more than `t` errors were detected and correction failed.
+fn bch_correct_errors(
+    recd: &mut [u8],
+    t: usize,
+    n: usize,
+    length: usize,
+    alpha_to: &[i32],
+    index_of: &[i32],
+) -> Result<i32, &'static str> {
     let t2 = 2 * t;
-    let mut s = vec![0; t2 + 1];
+    let mut s = vec![0i32; t2 + 1];
 
+    // Compute syndromes s[1..=t2].
+    let mut syn_error = false;
     for i in 1..=t2 {
         s[i] = 0;
         for j in 0..length {
@@ -180,136 +192,196 @@ pub fn decode_bch(
     }
 
     let mut l_arr = vec![0usize; t2 + 2];
-    if syn_error {
-        let mut elp = vec![vec![0; 18]; 20];
-        let mut d = [0; 20];
-        let mut u_lu = [0i32; 20];
-        let mut loc = vec![0usize; 127];
-        let mut reg = [0; 10];
 
-        d[0] = 0;
-        d[1] = s[1];
-        elp[0][0] = 0;
-        elp[1][0] = 1;
-        elp[0][1..t2].fill(-1);
-        elp[1][1..t2].fill(0);
-        l_arr[0] = 0;
-        l_arr[1] = 0;
-        u_lu[0] = -1;
-        u_lu[1] = 0;
-        let mut u = 0;
+    if !syn_error {
+        return Ok(0);
+    }
 
-        loop {
-            u += 1;
-            if d[u] == -1 {
-                l_arr[u + 1] = l_arr[u];
-                for i in 0..=l_arr[u] {
-                    elp[u + 1][i] = elp[u][i];
-                    if elp[u][i] >= 0 {
-                        elp[u][i] = index_of[elp[u][i] as usize];
-                    }
-                }
-            } else {
-                let mut q = u as i32 - 1;
-                while d[q as usize] == -1 && q > 0 {
-                    q -= 1;
-                }
-                if q > 0 {
-                    let mut j = q;
-                    loop {
-                        j -= 1;
-                        if d[j as usize] != -1 && u_lu[q as usize] < u_lu[j as usize] {
-                            q = j;
-                        }
-                        if j <= 0 {
-                            break;
-                        }
-                    }
-                }
+    // Berlekamp's iterative algorithm to compute the error-locator polynomial.
+    let mut elp = vec![vec![0i32; t2]; t2 + 2];
+    let mut d = vec![0i32; t2 + 2];
+    let mut u_lu = vec![0i32; t2 + 2];
+    let mut loc = vec![0usize; n];
+    let mut reg = vec![0i32; t + 1];
 
-                let q = q as usize;
-                if l_arr[u] > l_arr[q] + u - q {
-                    l_arr[u + 1] = l_arr[u];
-                } else {
-                    l_arr[u + 1] = l_arr[q] + u - q;
-                }
+    d[0] = 0;
+    d[1] = s[1];
+    elp[0][0] = 0;
+    elp[1][0] = 1;
+    elp[0][1..t2].fill(-1);
+    elp[1][1..t2].fill(0);
+    l_arr[0] = 0;
+    l_arr[1] = 0;
+    u_lu[0] = -1;
+    u_lu[1] = 0;
+    let mut u = 0usize;
 
-                elp[u + 1][..t2].fill(0);
-                for i in 0..=l_arr[q] {
-                    if elp[q][i] != -1 {
-                        elp[u + 1][i + u - q] = alpha_to
-                            [((d[u] + (n as i32) - d[q] + elp[q][i]) % (n as i32)) as usize];
-                    }
-                }
-                for i in 0..=l_arr[u] {
-                    elp[u + 1][i] ^= elp[u][i];
-                    if elp[u][i] >= 0 {
-                        elp[u][i] = index_of[elp[u][i] as usize];
-                    }
-                }
-            }
-            u_lu[u + 1] = u as i32 - l_arr[u + 1] as i32;
-
-            if u < t2 {
-                if s[u + 1] != -1 {
-                    d[u + 1] = alpha_to[s[u + 1] as usize];
-                } else {
-                    d[u + 1] = 0;
-                }
-                for i in 1..=l_arr[u + 1] {
-                    if s[u + 1 - i] != -1 && elp[u + 1][i] != 0 {
-                        d[u + 1] ^= alpha_to[((s[u + 1 - i] + index_of[elp[u + 1][i] as usize])
-                            % (n as i32)) as usize];
-                    }
-                }
-                if d[u + 1] >= 0 {
-                    d[u + 1] = index_of[d[u + 1] as usize];
-                }
-            }
-
-            if u >= t2 || l_arr[u + 1] > t {
-                break;
-            }
-        }
-
+    loop {
         u += 1;
-        if l_arr[u] <= t {
+        if d[u] == -1 {
+            l_arr[u + 1] = l_arr[u];
             for i in 0..=l_arr[u] {
+                elp[u + 1][i] = elp[u][i];
                 if elp[u][i] >= 0 {
                     elp[u][i] = index_of[elp[u][i] as usize];
                 }
             }
-
-            reg[1..=l_arr[u]].copy_from_slice(&elp[u][1..=l_arr[u]]);
-            let mut count = 0;
-            for i in 1..=n {
-                let mut q_err = 1;
-                for j in 1..=l_arr[u] {
-                    if reg[j] != -1 {
-                        reg[j] = (reg[j] + j as i32) % (n as i32);
-                        q_err ^= alpha_to[reg[j] as usize];
+        } else {
+            // Find a previous step q with maximum (q - l_arr[q]) where d[q] != -1.
+            let mut q = u as i32 - 1;
+            while d[q as usize] == -1 && q > 0 {
+                q -= 1;
+            }
+            if q > 0 {
+                let mut j = q;
+                loop {
+                    j -= 1;
+                    if d[j as usize] != -1 && u_lu[q as usize] < u_lu[j as usize] {
+                        q = j;
+                    }
+                    if j <= 0 {
+                        break;
                     }
                 }
-                if q_err == 0 {
-                    loc[count] = n - i;
-                    count += 1;
-                }
             }
 
-            if count == l_arr[u] {
-                for i in 0..l_arr[u] {
-                    recd[loc[i]] ^= 1;
-                }
+            let q = q as usize;
+            if l_arr[u] > l_arr[q] + u - q {
+                l_arr[u + 1] = l_arr[u];
             } else {
-                arlog_d!("decode_bch: count != l[u] (in_val={:#x})", in_val);
-                return Err("BCH correction failed (count != l)");
+                l_arr[u + 1] = l_arr[q] + u - q;
             }
-        } else {
-            arlog_d!("decode_bch: l[u] > t (in_val={:#x})", in_val);
-            return Err("BCH correction failed (l > t)");
+
+            elp[u + 1][..t2].fill(0);
+            for i in 0..=l_arr[q] {
+                if elp[q][i] != -1 {
+                    elp[u + 1][i + u - q] =
+                        alpha_to[((d[u] + (n as i32) - d[q] + elp[q][i]) % (n as i32)) as usize];
+                }
+            }
+            for i in 0..=l_arr[u] {
+                elp[u + 1][i] ^= elp[u][i];
+                if elp[u][i] >= 0 {
+                    elp[u][i] = index_of[elp[u][i] as usize];
+                }
+            }
+        }
+        u_lu[u + 1] = u as i32 - l_arr[u + 1] as i32;
+
+        if u < t2 {
+            if s[u + 1] != -1 {
+                d[u + 1] = alpha_to[s[u + 1] as usize];
+            } else {
+                d[u + 1] = 0;
+            }
+            for i in 1..=l_arr[u + 1] {
+                if s[u + 1 - i] != -1 && elp[u + 1][i] != 0 {
+                    d[u + 1] ^= alpha_to
+                        [((s[u + 1 - i] + index_of[elp[u + 1][i] as usize]) % (n as i32)) as usize];
+                }
+            }
+            if d[u + 1] >= 0 {
+                d[u + 1] = index_of[d[u + 1] as usize];
+            }
+        }
+
+        if u >= t2 || l_arr[u + 1] > t {
+            break;
         }
     }
 
+    u += 1;
+    if l_arr[u] > t {
+        arlog_d!(
+            "bch_correct_errors: l[u]={} > t={} (uncorrectable)",
+            l_arr[u],
+            t
+        );
+        return Err("BCH correction failed (l > t)");
+    }
+
+    for i in 0..=l_arr[u] {
+        if elp[u][i] >= 0 {
+            elp[u][i] = index_of[elp[u][i] as usize];
+        }
+    }
+
+    reg[1..=l_arr[u]].copy_from_slice(&elp[u][1..=l_arr[u]]);
+    let mut count = 0;
+    for i in 1..=n {
+        let mut q_err = 1;
+        for j in 1..=l_arr[u] {
+            if reg[j] != -1 {
+                reg[j] = (reg[j] + j as i32) % (n as i32);
+                q_err ^= alpha_to[reg[j] as usize];
+            }
+        }
+        if q_err == 0 {
+            loc[count] = n - i;
+            count += 1;
+        }
+    }
+
+    if count != l_arr[u] {
+        arlog_d!(
+            "bch_correct_errors: count={} != l[u]={} (uncorrectable)",
+            count,
+            l_arr[u]
+        );
+        return Err("BCH correction failed (count != l)");
+    }
+
+    for i in 0..l_arr[u] {
+        recd[loc[i]] ^= 1;
+    }
+
+    Ok(l_arr[u] as i32)
+}
+
+// =====================================================================
+// Public BCH decoders.
+// =====================================================================
+
+/// Decodes a BCH-encoded matrix code (BCH(15, k, t) or BCH(31, k, t)).
+///
+/// Used for `Code4x4BCH*` and `Code5x5BCH*` matrix code variants.
+/// For `AR_MATRIX_CODE_GLOBAL_ID`, use [`decode_bch_global_id`] instead, which
+/// takes a pre-extracted 127-bit array (since 120 bits don't fit in `u64`).
+pub fn decode_bch(
+    matrix_code_type: ARMatrixCodeType,
+    in_val: u64,
+) -> Result<(u64, i32), &'static str> {
+    let (t, k, n, length, alpha_to, index_of): (usize, usize, usize, usize, &[i32], &[i32]) =
+        match matrix_code_type {
+            ARMatrixCodeType::Code4x4BCH1393 => (1, 9, 15, 13, &BCH_15_ALPHA_TO, &BCH_15_INDEX_OF),
+            ARMatrixCodeType::Code4x4BCH1355 => (2, 5, 15, 13, &BCH_15_ALPHA_TO, &BCH_15_INDEX_OF),
+            ARMatrixCodeType::Code5x5BCH22125 => {
+                (2, 12, 31, 22, &BCH_31_ALPHA_TO, &BCH_31_INDEX_OF)
+            }
+            ARMatrixCodeType::Code5x5BCH2277 => (3, 7, 31, 22, &BCH_31_ALPHA_TO, &BCH_31_INDEX_OF),
+            _ => {
+                arlog_e!(
+                    "decode_bch: unsupported matrix code type {:?}",
+                    matrix_code_type
+                );
+                return Err("Unsupported BCH code type");
+            }
+        };
+
+    // Unpack u64 input into bit array (LSB at index 0). Buffer is sized for
+    // the largest n we support (127) so the same buffer can flow into
+    // `bch_correct_errors`, which uses `n` for `loc`-indexing internally.
+    let mut recd = [0u8; 127];
+    let mut in_bitwise = in_val;
+    for r in recd[..length].iter_mut() {
+        *r = (in_bitwise & 1) as u8;
+        in_bitwise >>= 1;
+    }
+
+    let corrected = bch_correct_errors(&mut recd, t, n, length, alpha_to, index_of)?;
+
+    // Repack the data bits into the output u64. Data bits live in the upper
+    // `k` positions of the codeword: `recd[(length - k)..length]`.
     let mut out_p = 0u64;
     let mut out_bit = 1u64;
     for &r in &recd[(length - k)..length] {
@@ -319,10 +391,313 @@ pub fn decode_bch(
         out_bit <<= 1;
     }
 
-    let corrected = if syn_error {
-        l_arr[s.len() - 1] as i32
-    } else {
-        0
-    };
     Ok((out_p, corrected))
+}
+
+/// Decodes a BCH(127, 64, 22) `AR_MATRIX_CODE_GLOBAL_ID` codeword in-place.
+///
+/// Mirrors the GLOBAL_ID branch of `decode_bch` in `arPattGetID.c`
+/// (lines 1864-1870 in upstream): t=9, k=64, n=127, length=120.
+///
+/// # Parameters
+/// - `recd127` — the 127-element bit array extracted from the marker grid by
+///   [`crate::matrix::extract_global_id_bits`] (LSB at index 0). Mutated
+///   in-place during error correction.
+///
+/// # Returns
+/// - `Ok((global_id, errors_corrected))` on successful decode.
+/// - `Err("BCH correction failed ...")` if more than 9 errors were detected.
+///
+/// # Notes
+/// The output `global_id` is a 64-bit unsigned integer representing the
+/// decoded marker identifier. Error correction can fix up to `t = 9` bit
+/// errors per codeword (Hamming distance 22).
+pub fn decode_bch_global_id(recd127: &mut [u8; 127]) -> Result<(u64, i32), &'static str> {
+    const T: usize = 9;
+    const K: usize = 64;
+    const N: usize = 127;
+    const LENGTH: usize = 120;
+
+    let corrected =
+        bch_correct_errors(recd127, T, N, LENGTH, &BCH_127_ALPHA_TO, &BCH_127_INDEX_OF)?;
+
+    // Pack data bits from upper `k` positions of the codeword into a u64.
+    let mut out_p = 0u64;
+    let mut out_bit = 1u64;
+    for &r in &recd127[(LENGTH - K)..LENGTH] {
+        if r != 0 {
+            out_p |= out_bit;
+        }
+        out_bit <<= 1;
+    }
+
+    Ok((out_p, corrected))
+}
+
+// =====================================================================
+// Tests.
+// =====================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds the BCH(127, 64, 22) generator polynomial g(x) as a bit vector.
+    ///
+    /// `g(x) = ∏_{i=1..=2t} M_i(x)` where `M_i(x)` is the minimal polynomial
+    /// of α^i over GF(2). Over GF(2), `M_(2j)(x) = M_j(x)`, so we only iterate
+    /// over odd powers and skip duplicates via cyclotomic-coset tracking.
+    ///
+    /// Returns 64 generator coefficients: `g[0]` = constant term, `g[63]`
+    /// = leading coefficient (degree 63).
+    fn build_bch127_generator() -> Vec<u8> {
+        const N: usize = 127;
+        const T: usize = 9;
+
+        // Track which conjugacy classes we've already covered. Each odd j in
+        // [1, 2t] that hasn't been visited yet contributes one factor.
+        let mut seen = [false; N];
+        let mut g = vec![1u8]; // start with g(x) = 1
+
+        for j in (1..=2 * T).filter(|j| j % 2 == 1) {
+            if seen[j] {
+                continue;
+            }
+            // Walk cyclotomic coset of j: {j, 2j, 4j, ...} mod N.
+            let mut coset = Vec::new();
+            let mut x = j;
+            while !seen[x] {
+                seen[x] = true;
+                coset.push(x);
+                x = (x * 2) % N;
+            }
+
+            // Build minimal polynomial M_j(x) = ∏ (x - α^i) for i in coset.
+            // Multiply g by (x - α^i) iteratively in GF(2)[x] using GF(2^7)
+            // coefficient arithmetic via BCH_127_ALPHA_TO / BCH_127_INDEX_OF.
+            //
+            // Working representation: polynomial coefficients are GF(2^7)
+            // elements stored as i32 (0 represents zero element).
+            let mut m_coeffs: Vec<i32> = vec![1]; // M(x) = 1 in GF(2^7)
+            for &i in &coset {
+                let alpha_i = BCH_127_ALPHA_TO[i] as i32;
+                // Multiply m_coeffs by (x + α^i) (subtraction == addition in GF(2)).
+                let mut new_m = vec![0i32; m_coeffs.len() + 1];
+                for (idx, &c) in m_coeffs.iter().enumerate() {
+                    new_m[idx + 1] ^= c;
+                    new_m[idx] ^= gf128_mul(c, alpha_i);
+                }
+                m_coeffs = new_m;
+            }
+            // M_j(x) coefficients should all be in {0, 1} after the cyclotomic
+            // coset is fully traversed (Galois conjugates collapse to GF(2)).
+            // Convert to binary form.
+            let m_bin: Vec<u8> = m_coeffs
+                .iter()
+                .map(|&c| {
+                    debug_assert!(c == 0 || c == 1, "non-binary coefficient: {c}");
+                    c as u8
+                })
+                .collect();
+
+            // Multiply g by M_j: polynomial multiplication in GF(2)[x].
+            let mut new_g = vec![0u8; g.len() + m_bin.len() - 1];
+            for (i, &gi) in g.iter().enumerate() {
+                if gi == 0 {
+                    continue;
+                }
+                for (j, &mj) in m_bin.iter().enumerate() {
+                    new_g[i + j] ^= mj;
+                }
+            }
+            g = new_g;
+        }
+
+        // BCH(127, 64, 22) is a shortened BCH(127, 71). The generator polynomial
+        // is determined by the BCH(127, 71) design — g(x) has degree
+        // n - k_unshortened = 127 - 71 = 56 (i.e. 57 coefficients). Shortening
+        // sets the 7 most significant message bits to zero but does not change g.
+        debug_assert_eq!(g.len(), 57, "BCH(127,71) generator must have degree 56");
+        g
+    }
+
+    /// GF(2^7) multiplication via the alpha_to/index_of tables.
+    fn gf128_mul(a: i32, b: i32) -> i32 {
+        if a == 0 || b == 0 {
+            return 0;
+        }
+        let log_a = BCH_127_INDEX_OF[a as usize];
+        let log_b = BCH_127_INDEX_OF[b as usize];
+        BCH_127_ALPHA_TO[((log_a + log_b) % 127) as usize]
+    }
+
+    /// Encodes a 64-bit `global_id` into a 127-element BCH(127, 64, 22) codeword.
+    ///
+    /// Systematic encoding: `c(x) = m(x) · x^(n-k) + (m(x) · x^(n-k) mod g(x))`.
+    /// - Message bits go into positions `[length - k .. length] = [56..120]`.
+    /// - Parity bits go into positions `[0..56]`.
+    /// - Positions `[120..127]` are zero (shortened code).
+    ///
+    /// The output layout matches what [`decode_bch_global_id`] expects.
+    fn encode_bch_global_id(global_id: u64) -> [u8; 127] {
+        const N_K: usize = 56; // 56 parity bits — degree of generator polynomial
+        const K: usize = 64;
+        const LENGTH: usize = 120;
+        const G_DEG: usize = 56; // generator degree
+
+        let g = build_bch127_generator(); // 57 binary coefficients (degree 56)
+
+        // Build the dividend `m(x) · x^(n-k)`: message bits placed at high
+        // positions [N_K..LENGTH], zeros elsewhere. Polynomial division of
+        // this dividend by g(x) yields the remainder we need for the parity
+        // section. The division process mutates the high positions too, so
+        // we'll re-apply the original message after computing the remainder.
+        let mut dividend = [0u8; 127];
+        for i in 0..K {
+            dividend[N_K + i] = ((global_id >> i) & 1) as u8;
+        }
+
+        // Long division: iterate from the highest non-zero position down,
+        // eliminating each one by XOR-ing g(x) shifted so its leading term
+        // (g[G_DEG] = 1) aligns with the current pivot.
+        for i in (N_K..LENGTH).rev() {
+            if dividend[i] == 1 {
+                for (j, &gj) in g.iter().enumerate() {
+                    if gj == 1 {
+                        dividend[i - G_DEG + j] ^= 1;
+                    }
+                }
+            }
+        }
+
+        // Assemble the systematic codeword: parity (= remainder) at low
+        // positions, original message at high positions.
+        let mut codeword = [0u8; 127];
+        codeword[0..N_K].copy_from_slice(&dividend[0..N_K]);
+        for i in 0..K {
+            codeword[N_K + i] = ((global_id >> i) & 1) as u8;
+        }
+
+        codeword
+    }
+
+    // ---- decode_parity65 / decode_hamming63 sanity checks ----------------
+
+    #[test]
+    fn test_decode_parity65_zero() {
+        assert_eq!(decode_parity65(0), Ok(0));
+    }
+
+    #[test]
+    fn test_decode_hamming63_zero() {
+        assert_eq!(decode_hamming63(0), Ok((0, 0)));
+    }
+
+    // ---- decode_bch (BCH-15 / BCH-31) sanity checks ----------------------
+
+    #[test]
+    fn test_decode_bch_4x4_zero_codeword() {
+        // The all-zeros codeword is always valid → decodes to 0.
+        let (id, errors) = decode_bch(ARMatrixCodeType::Code4x4BCH1393, 0).unwrap();
+        assert_eq!(id, 0);
+        assert_eq!(errors, 0);
+    }
+
+    #[test]
+    fn test_decode_bch_5x5_zero_codeword() {
+        let (id, errors) = decode_bch(ARMatrixCodeType::Code5x5BCH22125, 0).unwrap();
+        assert_eq!(id, 0);
+        assert_eq!(errors, 0);
+    }
+
+    // ---- BCH-127 generator polynomial sanity check -----------------------
+
+    #[test]
+    fn test_bch127_generator_degree() {
+        let g = build_bch127_generator();
+        // BCH(127, 64, 22) is a shortened BCH(127, 71). g(x) has degree 56,
+        // determined by the LCM of minimal polynomials M_1..M_15 over GF(2^7).
+        assert_eq!(g.len(), 57);
+        // Leading and constant coefficients must be 1.
+        assert_eq!(g[56], 1);
+        assert_eq!(g[0], 1);
+    }
+
+    // ---- decode_bch_global_id tests --------------------------------------
+
+    #[test]
+    fn test_decode_bch_global_id_zero_codeword() {
+        // All-zeros input is a valid codeword → decodes to 0 with no errors.
+        let mut recd = [0u8; 127];
+        let (id, errors) = decode_bch_global_id(&mut recd).unwrap();
+        assert_eq!(id, 0);
+        assert_eq!(errors, 0);
+    }
+
+    #[test]
+    fn test_decode_bch_global_id_roundtrip_known_pattern() {
+        // Encode → decode roundtrip for a hand-picked global_id.
+        let global_id = 0x1234_5678_DEAD_BEEF_u64;
+        let mut recd = encode_bch_global_id(global_id);
+        let (decoded, errors) = decode_bch_global_id(&mut recd).unwrap();
+        assert_eq!(decoded, global_id);
+        assert_eq!(errors, 0);
+    }
+
+    #[test]
+    fn test_decode_bch_global_id_roundtrip_max_value() {
+        let global_id = u64::MAX;
+        let mut recd = encode_bch_global_id(global_id);
+        let (decoded, errors) = decode_bch_global_id(&mut recd).unwrap();
+        assert_eq!(decoded, global_id);
+        assert_eq!(errors, 0);
+    }
+
+    #[test]
+    fn test_decode_bch_global_id_single_bit_error() {
+        // Flip a single bit in the parity region → BCH must correct it.
+        let global_id = 42u64;
+        let mut recd = encode_bch_global_id(global_id);
+        recd[7] ^= 1;
+        let (decoded, errors) = decode_bch_global_id(&mut recd).unwrap();
+        assert_eq!(decoded, global_id);
+        assert_eq!(errors, 1);
+    }
+
+    #[test]
+    fn test_decode_bch_global_id_data_bit_error() {
+        // Flip a single bit in the data region → BCH must correct it.
+        let global_id = 0xCAFE_BABE_u64;
+        let mut recd = encode_bch_global_id(global_id);
+        recd[80] ^= 1;
+        let (decoded, errors) = decode_bch_global_id(&mut recd).unwrap();
+        assert_eq!(decoded, global_id);
+        assert_eq!(errors, 1);
+    }
+
+    #[test]
+    fn test_decode_bch_global_id_nine_bit_errors_correctable() {
+        // BCH(127, 64, 22) corrects up to t = 9 errors. At the boundary,
+        // decoding must still succeed.
+        let global_id = 0xABCD_1234_5678_9ABC_u64;
+        let mut recd = encode_bch_global_id(global_id);
+        for i in 0..9 {
+            recd[i * 13] ^= 1; // spread errors out (positions 0, 13, 26, ...)
+        }
+        let (decoded, errors) = decode_bch_global_id(&mut recd).unwrap();
+        assert_eq!(decoded, global_id);
+        assert_eq!(errors, 9);
+    }
+
+    #[test]
+    fn test_decode_bch_global_id_too_many_errors_fails() {
+        // Flipping 15 well-spread bits exceeds t = 9. Decoder must error.
+        let global_id = 99u64;
+        let mut recd = encode_bch_global_id(global_id);
+        for i in 0..15 {
+            recd[i * 7] ^= 1;
+        }
+        let result = decode_bch_global_id(&mut recd);
+        assert!(result.is_err(), "expected uncorrectable error pattern");
+    }
 }

--- a/crates/core/src/ar/bch.rs
+++ b/crates/core/src/ar/bch.rs
@@ -439,8 +439,12 @@ pub fn decode_bch_global_id(recd127: &mut [u8; 127]) -> Result<(u64, i32), &'sta
 // =====================================================================
 
 #[cfg(test)]
-mod tests {
-    use super::*;
+/// Test-only helpers exposed at `pub(crate)` visibility so other modules
+/// (e.g. `matrix::tests`) can use the BCH-127 encoder for end-to-end
+/// roundtrip fixtures.
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use super::{BCH_127_ALPHA_TO, BCH_127_INDEX_OF};
 
     /// Builds the BCH(127, 64, 22) generator polynomial g(x) as a bit vector.
     ///
@@ -448,9 +452,9 @@ mod tests {
     /// of α^i over GF(2). Over GF(2), `M_(2j)(x) = M_j(x)`, so we only iterate
     /// over odd powers and skip duplicates via cyclotomic-coset tracking.
     ///
-    /// Returns 64 generator coefficients: `g[0]` = constant term, `g[63]`
-    /// = leading coefficient (degree 63).
-    fn build_bch127_generator() -> Vec<u8> {
+    /// Returns 57 generator coefficients (degree 56): `g[0]` = constant term,
+    /// `g[56]` = leading coefficient.
+    pub(crate) fn build_bch127_generator() -> Vec<u8> {
         const N: usize = 127;
         const T: usize = 9;
 
@@ -522,7 +526,7 @@ mod tests {
     }
 
     /// GF(2^7) multiplication via the alpha_to/index_of tables.
-    fn gf128_mul(a: i32, b: i32) -> i32 {
+    pub(crate) fn gf128_mul(a: i32, b: i32) -> i32 {
         if a == 0 || b == 0 {
             return 0;
         }
@@ -538,8 +542,8 @@ mod tests {
     /// - Parity bits go into positions `[0..56]`.
     /// - Positions `[120..127]` are zero (shortened code).
     ///
-    /// The output layout matches what [`decode_bch_global_id`] expects.
-    fn encode_bch_global_id(global_id: u64) -> [u8; 127] {
+    /// The output layout matches what [`super::decode_bch_global_id`] expects.
+    pub(crate) fn encode_bch_global_id(global_id: u64) -> [u8; 127] {
         const N_K: usize = 56; // 56 parity bits — degree of generator polynomial
         const K: usize = 64;
         const LENGTH: usize = 120;
@@ -580,6 +584,12 @@ mod tests {
 
         codeword
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_helpers::{build_bch127_generator, encode_bch_global_id};
+    use super::*;
 
     // ---- decode_parity65 / decode_hamming63 sanity checks ----------------
 

--- a/crates/core/src/ar/marker.rs
+++ b/crates/core/src/ar/marker.rs
@@ -1761,6 +1761,7 @@ mod tests {
             dir: 0,
             cf: 0.8,
             error_corrected: 0,
+            global_id: 0,
         };
         marker.id_patt = ok.id;
         marker.dir_patt = ok.dir;
@@ -1976,11 +1977,13 @@ mod tests {
             dir: 3,
             cf: 0.91,
             error_corrected: 0,
+            global_id: 0,
         };
         assert_eq!(ok.id, 5);
         assert_eq!(ok.dir, 3);
         assert!((ok.cf - 0.91).abs() < 1e-9);
         assert_eq!(ok.error_corrected, 0);
+        assert_eq!(ok.global_id, 0);
     }
 
     /// Verifies cutoff_phase is set to MatchBarcodeEdcFail when matrix decoding

--- a/crates/core/src/ar/marker.rs
+++ b/crates/core/src/ar/marker.rs
@@ -1239,12 +1239,16 @@ pub fn ar_get_marker_info(
                     marker_info[j].dir_matrix = ok.dir;
                     marker_info[j].cf_matrix = ok.cf;
                     marker_info[j].error_corrected = ok.error_corrected;
+                    // Populated only for AR_MATRIX_CODE_GLOBAL_ID; 0 otherwise.
+                    // Mirrors C `arPattGetIDGlobal` writing `*codeGlobalID_p`.
+                    marker_info[j].global_id = ok.global_id;
                     marker_info[j].cutoff_phase = crate::types::ARMarkerInfoCutoffPhase::None;
                     arlog_d!(
-                        "ar_get_marker_info: barcode id={}, dir={}, cf={:.4}",
+                        "ar_get_marker_info: barcode id={}, dir={}, cf={:.4}, global_id={:#x}",
                         ok.id,
                         ok.dir,
-                        ok.cf
+                        ok.cf,
+                        ok.global_id
                     );
                 }
                 Err(e) => {
@@ -1252,6 +1256,7 @@ pub fn ar_get_marker_info(
                     marker_info[j].id_matrix = -1;
                     marker_info[j].dir_matrix = -1;
                     marker_info[j].cf_matrix = 0.0;
+                    marker_info[j].global_id = 0;
                     marker_info[j].cutoff_phase = e.into();
                 }
             }

--- a/crates/core/src/ar/matrix.rs
+++ b/crates/core/src/ar/matrix.rs
@@ -27,9 +27,20 @@
 //! Ported from arGetMatrixCode.c and associated ECC logic.
 
 use super::marker::ar_get_line;
-use crate::types::{ARHandle, ARMarkerInfo, ARMarkerInfo2, ARMatrixCodeType, ARdouble};
+use crate::types::{ARHandle, ARMarkerInfo, ARMarkerInfo2, ARMatrixCodeType, ARdouble, MatchError};
 use crate::{arlog_d, arlog_e};
 use log::trace;
+
+/// Outer dimension (in cells) of the AR_MATRIX_CODE_GLOBAL_ID grid sampled
+/// from the marker. Mirrors `AR_GLOBAL_ID_OUTER_SIZE` in the C code
+/// (`arPattGetID.c:98`).
+pub(crate) const AR_GLOBAL_ID_OUTER_SIZE: usize = 14;
+
+/// Border thickness (in cells) of the GlobalID grid. Cells with both indices
+/// inside the inner `OUTER - 2*INNER = 8`-cell core are *not* used for data;
+/// only the border ring contributes bits. Mirrors `AR_GLOBAL_ID_INNER_SIZE`
+/// in the C code (`arPattGetID.c:99`).
+pub(crate) const AR_GLOBAL_ID_INNER_SIZE: usize = 3;
 
 /// Results of a matrix code decoding attempt.
 #[derive(Debug, Clone, PartialEq)]
@@ -524,6 +535,188 @@ fn decode_matrix_raw(
     }
 }
 
+/// Extracts the 120 GlobalID bits from a 14×14 sampled grid.
+///
+/// Mirrors C `get_global_id_code()` in `arPattGetID.c:2282-2404`. Detects the
+/// orientation L-pattern from the four corner cells, then walks the border
+/// ring (skipping the inner 8×8 zone and three of the four corner 2×2
+/// blocks) to read 120 bits in a canonical order regardless of marker
+/// rotation.
+///
+/// # Parameters
+/// - `data` — 14×14 sampled grayscale buffer (row-major:
+///   `data[j * OUTER + i]` is the cell at column `i`, row `j`).
+///
+/// # Returns
+/// - `Ok((recd127, dir, cf))` — `recd127[0..120]` holds the read bits
+///   (bit 119 = first read, bit 0 = last read); `dir` is 0..=3; `cf` is the
+///   confidence (`min_contrast / 30.0`, capped at 1.0).
+/// - `Err(MatchError::Contrast)` if the corner contrast is < 30.
+/// - `Err(MatchError::BarcodeNotFound)` if no `(1, 1, 0)` L-pattern is found
+///   in the four corner cells.
+pub(crate) fn extract_global_id_bits(data: &[u8]) -> Result<([u8; 127], i32, f64), MatchError> {
+    const SIZE: usize = AR_GLOBAL_ID_OUTER_SIZE;
+    debug_assert_eq!(data.len(), SIZE * SIZE);
+
+    // 1. Compute threshold from the four corner cells.
+    //    Linear positions match C: 0, (S-1)*S, S*S-1, S-1.
+    let corner = [0usize, (SIZE - 1) * SIZE, SIZE * SIZE - 1, SIZE - 1];
+    let mut max = 0u8;
+    let mut min = 255u8;
+    for &c in &corner {
+        let p = data[c];
+        if p > max {
+            max = p;
+        }
+        if p < min {
+            min = p;
+        }
+    }
+    if (max as i32 - min as i32) < 30 {
+        arlog_d!(
+            "extract_global_id_bits: insufficient contrast (max-min={})",
+            max as i32 - min as i32
+        );
+        return Err(MatchError::Contrast);
+    }
+    let thresh = ((max as u16 + min as u16) / 2) as u8;
+
+    // 2. Detect orientation. An unrotated marker has corners (1, 1, 0, ?)
+    //    where 1 means "darker than threshold". Rotations cycle the
+    //    L-pattern through positions [i, i+1, i+2] (mod 4).
+    let dir_code: [u8; 4] = [
+        if data[corner[0]] < thresh { 1 } else { 0 },
+        if data[corner[1]] < thresh { 1 } else { 0 },
+        if data[corner[2]] < thresh { 1 } else { 0 },
+        if data[corner[3]] < thresh { 1 } else { 0 },
+    ];
+    let dir = (0..4)
+        .find(|&i| dir_code[i] == 1 && dir_code[(i + 1) % 4] == 1 && dir_code[(i + 2) % 4] == 0)
+        .ok_or_else(|| {
+            arlog_d!(
+                "extract_global_id_bits: locator pattern not found (dirCode={:?})",
+                dir_code
+            );
+            MatchError::BarcodeNotFound
+        })?;
+
+    // 3. Walk the border ring in the order dictated by `dir`, reading 120
+    //    bits into `recd127[0..120]` (MSB-first: bit 119 is the first cell
+    //    visited, bit 0 the last).
+    let mut recd127 = [0u8; 127];
+    let mut bit: i32 = 119;
+    let mut contrast_min: i32 = 255;
+
+    let mut read_pixel = |i: usize, j: usize, bit: &mut i32, cmin: &mut i32| {
+        let contrast = data[j * SIZE + i] as i32 - thresh as i32;
+        recd127[*bit as usize] = if contrast < 0 { 1 } else { 0 };
+        *bit -= 1;
+        let abs_c = contrast.abs();
+        if abs_c < *cmin {
+            *cmin = abs_c;
+        }
+    };
+
+    match dir {
+        0 => {
+            for j in 0..SIZE {
+                for i in 0..SIZE {
+                    if should_skip_global_id_cell(i, j, 0) {
+                        continue;
+                    }
+                    read_pixel(i, j, &mut bit, &mut contrast_min);
+                }
+            }
+        }
+        1 => {
+            for i in 0..SIZE {
+                for j in (0..SIZE).rev() {
+                    if should_skip_global_id_cell(i, j, 1) {
+                        continue;
+                    }
+                    read_pixel(i, j, &mut bit, &mut contrast_min);
+                }
+            }
+        }
+        2 => {
+            for j in (0..SIZE).rev() {
+                for i in (0..SIZE).rev() {
+                    if should_skip_global_id_cell(i, j, 2) {
+                        continue;
+                    }
+                    read_pixel(i, j, &mut bit, &mut contrast_min);
+                }
+            }
+        }
+        3 => {
+            for i in (0..SIZE).rev() {
+                for j in 0..SIZE {
+                    if should_skip_global_id_cell(i, j, 3) {
+                        continue;
+                    }
+                    read_pixel(i, j, &mut bit, &mut contrast_min);
+                }
+            }
+        }
+        _ => unreachable!(),
+    }
+
+    debug_assert_eq!(bit, -1, "expected exactly 120 bits to be read");
+
+    // 4. Confidence based on minimum observed contrast: full confidence at
+    //    >= 30, scaled below.
+    let cf = if contrast_min > 30 {
+        1.0
+    } else {
+        contrast_min as f64 / 30.0
+    };
+
+    Ok((recd127, dir as i32, cf))
+}
+
+/// Returns `true` if the `(i, j)` cell of a 14×14 GlobalID grid should be
+/// skipped during bit extraction for the given `dir`.
+///
+/// Two skip categories:
+/// 1. The interior 8×8 zone (cells where both `i` and `j` lie strictly between
+///    `INNER - 1` and `OUTER - INNER`) carries no data.
+/// 2. Three of the four 2×2 corner blocks per `dir`: the three blocks that
+///    form the L-shape locator. The fourth corner is the "data corner" and
+///    contributes 4 of the 120 bits. The corner cycle is:
+///    - dir 0 → skip TL, BL, BR (data at TR)
+///    - dir 1 → skip BL, BR, TR (data at TL)
+///    - dir 2 → skip BR, TR, TL (data at BL)
+///    - dir 3 → skip TR, TL, BL (data at BR)
+fn should_skip_global_id_cell(i: usize, j: usize, dir: usize) -> bool {
+    const SIZE: usize = AR_GLOBAL_ID_OUTER_SIZE;
+    const INNER: usize = AR_GLOBAL_ID_INNER_SIZE;
+
+    // Inner 8×8 skip zone.
+    if i > INNER - 1 && i < SIZE - INNER && j > INNER - 1 && j < SIZE - INNER {
+        return true;
+    }
+
+    // Round indices down to the nearest even number to identify the 2×2
+    // corner blocks: top-left = (0,0), bottom-left = (0,12),
+    // bottom-right = (12,12), top-right = (12,0). MAX_Q = SIZE - 2 = 12.
+    let i_q = i & !1;
+    let j_q = j & !1;
+    const MAX_Q: usize = SIZE - 2;
+
+    let tl = i_q == 0 && j_q == 0;
+    let bl = i_q == 0 && j_q == MAX_Q;
+    let br = i_q == MAX_Q && j_q == MAX_Q;
+    let tr = i_q == MAX_Q && j_q == 0;
+
+    match dir {
+        0 => tl || bl || br,
+        1 => bl || br || tr,
+        2 => br || tr || tl,
+        3 => tr || tl || bl,
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -555,5 +748,241 @@ mod tests {
         );
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), MatchError::Contrast);
+    }
+
+    // -----------------------------------------------------------------
+    // GlobalID bit extraction tests
+    // -----------------------------------------------------------------
+
+    /// Builds a 14×14 grid encoding 120 known bits at the data positions for a
+    /// given direction, plus the L-shape locator pattern. This is the inverse
+    /// of `extract_global_id_bits` for `dir = 0`.
+    ///
+    /// The data corner (the 2×2 NOT skipped by the dir's skip rules) receives
+    /// 4 of the 120 bits; remaining bits fill border cells in the same
+    /// iteration order as the extractor.
+    fn make_global_id_grid_dir0(bits120: &[u8; 120]) -> [u8; 14 * 14] {
+        const SIZE: usize = AR_GLOBAL_ID_OUTER_SIZE;
+        let mut grid = [128u8; SIZE * SIZE]; // mid-gray default for interior
+
+        // Establish the dir 0 L-pattern (TL=dark, BL=dark, BR=light, TR=data).
+        // We'll set TR's corner pixel below as part of the bit fill.
+        grid[0] = 0; // TL (dark = bit 1)
+        grid[(SIZE - 1) * SIZE] = 0; // BL (dark)
+        grid[SIZE * SIZE - 1] = 255; // BR (light = bit 0)
+
+        // Walk the dir 0 iteration writing bits 119..0 to non-skip cells.
+        let mut bit: i32 = 119;
+        for j in 0..SIZE {
+            for i in 0..SIZE {
+                if should_skip_global_id_cell(i, j, 0) {
+                    continue;
+                }
+                grid[j * SIZE + i] = if bits120[bit as usize] != 0 { 0 } else { 255 };
+                bit -= 1;
+            }
+        }
+        debug_assert_eq!(bit, -1);
+        grid
+    }
+
+    /// Rotates a 14×14 grid 90° clockwise (used to produce dir=1, 2, 3 inputs
+    /// from a dir=0-formatted base grid).
+    fn rotate_grid_cw(grid: &[u8; 14 * 14]) -> [u8; 14 * 14] {
+        const SIZE: usize = AR_GLOBAL_ID_OUTER_SIZE;
+        let mut out = [0u8; SIZE * SIZE];
+        for j in 0..SIZE {
+            for i in 0..SIZE {
+                // Rotated cell at (i', j') = (SIZE-1-j, i).
+                let new_i = SIZE - 1 - j;
+                let new_j = i;
+                out[new_j * SIZE + new_i] = grid[j * SIZE + i];
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn test_extract_global_id_bits_low_contrast() {
+        // Uniform image -> max-min < 30 -> Contrast error.
+        let data = [128u8; 14 * 14];
+        let result = extract_global_id_bits(&data);
+        assert_eq!(result.unwrap_err(), MatchError::Contrast);
+    }
+
+    #[test]
+    fn test_extract_global_id_bits_no_locator_pattern() {
+        // 4 corners high contrast but not in (1,1,0,?) cyclic L-shape.
+        // Set all four corners to the same value -> can't form (1,1,0).
+        let mut data = [128u8; 14 * 14];
+        data[0] = 0; // TL dark
+        data[(14 - 1) * 14] = 0; // BL dark
+        data[14 * 14 - 1] = 0; // BR dark (breaks the L: needs to be light)
+        data[14 - 1] = 0; // TR dark
+                          // We also need contrast > 30, so introduce a light pixel somewhere.
+        data[7 * 14 + 7] = 255;
+        // But the corner check uses corner pixels for max/min. Make max=0 (all dark).
+        // Actually max-min must be >= 30, and it's computed over corners only.
+        // Force one corner light so contrast passes but no L is formed.
+        data[14 * 14 - 1] = 255; // BR light
+                                 // Now corners = (0, 0, 255, 0) -> dirCode = (1, 1, 0, 1).
+                                 // Check L: i=0 -> (1,1,0) ✓ -> dir=0. So this DOES form L. We need a
+                                 // different invalid pattern. (1,0,1,0) has no L: at any i, dirCode[i+2]
+                                 // is the same as dirCode[i].
+        data[(14 - 1) * 14] = 255; // BL light -> corners = (0, 255, 255, 0) -> (1,0,0,1)
+                                   // Check: i=0 (1,0,0) no; i=1 (0,0,1) no; i=2 (0,1,1) no; i=3 (1,1,0) yes -> dir=3.
+                                   // Still passes. Try (1,0,1,0): TL=dark, BL=light, BR=dark, TR=light.
+        data[0] = 0; // TL dark
+        data[(14 - 1) * 14] = 255; // BL light
+        data[14 * 14 - 1] = 0; // BR dark
+        data[14 - 1] = 255; // TR light
+                            // dirCode = (1, 0, 1, 0): no three consecutive (1,1,0) exist.
+        let result = extract_global_id_bits(&data);
+        assert_eq!(result.unwrap_err(), MatchError::BarcodeNotFound);
+    }
+
+    #[test]
+    fn test_extract_global_id_bits_dir0_detected() {
+        // Build a grid with the dir 0 L-pattern (TL=1, BL=1, BR=0).
+        let bits = [0u8; 120];
+        let grid = make_global_id_grid_dir0(&bits);
+        let (recd, dir, _cf) = extract_global_id_bits(&grid).unwrap();
+        assert_eq!(dir, 0);
+        // All non-corner cells were filled with 255 (light = bit 0).
+        for &b in &recd[..120] {
+            assert_eq!(b, 0);
+        }
+    }
+
+    #[test]
+    fn test_extract_global_id_bits_all_directions_recover_same_bits() {
+        // Build a known 120-bit pattern and confirm each rotation of the
+        // input grid yields the same `recd[0..120]` (different dir values).
+        let mut bits = [0u8; 120];
+        for i in 0..120 {
+            // Pseudo-random pattern: prime-indexed positions are 1.
+            bits[i] = if matches!(
+                i,
+                2 | 3
+                    | 5
+                    | 7
+                    | 11
+                    | 13
+                    | 17
+                    | 19
+                    | 23
+                    | 29
+                    | 31
+                    | 37
+                    | 41
+                    | 43
+                    | 47
+                    | 53
+                    | 59
+                    | 61
+                    | 67
+                    | 71
+                    | 73
+                    | 79
+                    | 83
+                    | 89
+                    | 97
+                    | 101
+                    | 103
+                    | 107
+                    | 109
+                    | 113
+            ) {
+                1
+            } else {
+                0
+            };
+        }
+
+        // The four iteration patterns are designed to "undo" the rotation, so
+        // each successive 90° CW image rotation yields `dir = N + 3 mod 4`
+        // (i.e. counts down through 0 → 3 → 2 → 1) while the canonical bit
+        // order in `recd[..120]` stays invariant.
+        let grid0 = make_global_id_grid_dir0(&bits);
+
+        let (recd0, dir0, _) = extract_global_id_bits(&grid0).unwrap();
+        assert_eq!(dir0, 0);
+        assert_eq!(recd0[..120], bits[..]);
+
+        let grid_cw1 = rotate_grid_cw(&grid0);
+        let (recd1, dir1, _) = extract_global_id_bits(&grid_cw1).unwrap();
+        assert_eq!(dir1, 3);
+        assert_eq!(recd1[..120], bits[..]);
+
+        let grid_cw2 = rotate_grid_cw(&grid_cw1);
+        let (recd2, dir2, _) = extract_global_id_bits(&grid_cw2).unwrap();
+        assert_eq!(dir2, 2);
+        assert_eq!(recd2[..120], bits[..]);
+
+        let grid_cw3 = rotate_grid_cw(&grid_cw2);
+        let (recd3, dir3, _) = extract_global_id_bits(&grid_cw3).unwrap();
+        assert_eq!(dir3, 1);
+        assert_eq!(recd3[..120], bits[..]);
+    }
+
+    #[test]
+    fn test_should_skip_global_id_cell_inner_zone() {
+        // Cells with both indices in [3, 10] are interior (skip) for any dir.
+        for dir in 0..4 {
+            for j in 3..=10 {
+                for i in 3..=10 {
+                    assert!(
+                        should_skip_global_id_cell(i, j, dir),
+                        "dir={} (i={}, j={}) should be skipped (interior)",
+                        dir,
+                        i,
+                        j
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_should_skip_global_id_cell_data_corner_per_dir() {
+        // Data corner per dir (the 2×2 NOT in the skip set):
+        //   dir 0 -> TR (i_q=12, j_q=0)
+        //   dir 1 -> TL (i_q=0,  j_q=0)
+        //   dir 2 -> BL (i_q=0,  j_q=12)
+        //   dir 3 -> BR (i_q=12, j_q=12)
+        let data_corner = [(12, 0), (0, 0), (0, 12), (12, 12)];
+        for (dir, &(i_q, j_q)) in data_corner.iter().enumerate() {
+            for di in 0..2 {
+                for dj in 0..2 {
+                    let i = i_q + di;
+                    let j = j_q + dj;
+                    assert!(
+                        !should_skip_global_id_cell(i, j, dir),
+                        "dir={} data corner cell ({}, {}) must NOT be skipped",
+                        dir,
+                        i,
+                        j
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_should_skip_global_id_cell_count_120() {
+        // For every direction, the iteration over the full grid must produce
+        // exactly 120 readable cells.
+        const SIZE: usize = AR_GLOBAL_ID_OUTER_SIZE;
+        for dir in 0..4 {
+            let mut count = 0;
+            for j in 0..SIZE {
+                for i in 0..SIZE {
+                    if !should_skip_global_id_cell(i, j, dir) {
+                        count += 1;
+                    }
+                }
+            }
+            assert_eq!(count, 120, "dir={} should yield 120 readable cells", dir);
+        }
     }
 }

--- a/crates/core/src/ar/matrix.rs
+++ b/crates/core/src/ar/matrix.rs
@@ -103,6 +103,12 @@ pub fn ar_matrix_code_get_id(
 ) -> Result<crate::types::MatchOk, crate::types::MatchError> {
     use crate::types::{MatchError, MatchOk};
 
+    // GlobalID uses a different grid size (14×14), bit layout, and ECC scheme;
+    // route it to the dedicated decoder mirroring `arPattGetID.c:200-218`.
+    if code_type == ARMatrixCodeType::GlobalID {
+        return ar_matrix_code_get_id_global(image, xsize, ysize, vertex, pixel_format);
+    }
+
     let dim = (code_type as i32) & 0xFF;
     if !(3..=6).contains(&dim) {
         arlog_e!(
@@ -533,6 +539,81 @@ fn decode_matrix_raw(
             Ok((code_raw as i32, 0))
         }
     }
+}
+
+/// Decodes an `AR_MATRIX_CODE_GLOBAL_ID` marker — 14×14 grid with BCH(127, 64,
+/// 22) error correction and a 64-bit identifier.
+///
+/// Mirrors the GlobalID branch of `arPattGetIDGlobal` in
+/// `arPattGetID.c:200-218`:
+///   1. Sample a 14×14 grid using `patt_ratio = 14 / (14 + 2) = 0.875`.
+///   2. Extract 120 bits via [`extract_global_id_bits`].
+///   3. BCH-decode via [`crate::bch::decode_bch_global_id`].
+///   4. Reject `u64::MAX` as a frequently-misrecognised pattern (heuristic).
+///   5. For backward compatibility with `id_matrix`, set the lower 31 bits of
+///      `global_id` as the regular matrix `id` when the upper 33 bits are zero
+///      (mirrors `arPattGetID.c:214`).
+fn ar_matrix_code_get_id_global(
+    image: &[u8],
+    xsize: i32,
+    ysize: i32,
+    vertex: &[[ARdouble; 2]; 4],
+    pixel_format: crate::types::ARPixelFormat,
+) -> Result<crate::types::MatchOk, MatchError> {
+    use crate::types::MatchOk;
+
+    // Sample a 14×14 grid. The C code passes pattRatio = 14 / (14 + 2) = 0.875
+    // to `arPattGetImage2`, which corresponds to a 1-cell border around the
+    // 14-cell pattern (16-cell total marker space).
+    let mut grid = vec![0u8; AR_GLOBAL_ID_OUTER_SIZE * AR_GLOBAL_ID_OUTER_SIZE];
+    let patt_ratio = AR_GLOBAL_ID_OUTER_SIZE as f64 / (AR_GLOBAL_ID_OUTER_SIZE as f64 + 2.0);
+    sample_grid(
+        image,
+        xsize,
+        ysize,
+        vertex,
+        AR_GLOBAL_ID_OUTER_SIZE as i32,
+        pixel_format,
+        patt_ratio,
+        &mut grid,
+    )
+    .map_err(|_| {
+        arlog_d!("ar_matrix_code_get_id_global: sample_grid failed");
+        MatchError::PatternExtraction
+    })?;
+
+    // Extract the 120 data bits (orientation-aware).
+    let (mut recd127, dir, cf) = extract_global_id_bits(&grid)?;
+
+    // BCH(127, 64, 22) decode. Up to 9 bit errors are correctable.
+    let (global_id, error_corrected) =
+        crate::bch::decode_bch_global_id(&mut recd127).map_err(|_| {
+            arlog_d!("ar_matrix_code_get_id_global: BCH decode failed");
+            MatchError::BarcodeEdcFail
+        })?;
+
+    // Heuristic: `u64::MAX` is a known false-positive pattern. The C code maps
+    // this to error code -5, which is `MatchError::HeuristicTroublesomeMatrixCodes`.
+    if global_id == u64::MAX {
+        arlog_d!("ar_matrix_code_get_id_global: heuristic rejected (UINT64_MAX)");
+        return Err(MatchError::HeuristicTroublesomeMatrixCodes);
+    }
+
+    // Backward-compat: when the upper 33 bits are zero, populate `id` with the
+    // lower 31 bits as if this were a regular matrix code.
+    let id = if (global_id & 0xFFFF_8000_u64) == 0 {
+        (global_id & 0x0000_7FFF_u64) as i32
+    } else {
+        0
+    };
+
+    Ok(MatchOk {
+        id,
+        dir,
+        cf,
+        error_corrected,
+        global_id,
+    })
 }
 
 /// Extracts the 120 GlobalID bits from a 14×14 sampled grid.
@@ -966,6 +1047,108 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// Embeds a 14×14 GlobalID grid into a 16×16 monochrome image at pixels
+    /// `(1..=14, 1..=14)`, leaving the 1-pixel border at the marker default.
+    /// Designed so that vertex `[[0,0],[16,0],[16,16],[0,16]]` with
+    /// `patt_ratio = 0.875` samples exactly one image pixel per cell.
+    fn embed_grid_in_16x16_image(grid: &[u8; 14 * 14]) -> Vec<u8> {
+        let mut image = vec![128u8; 16 * 16];
+        for j in 0..14 {
+            for i in 0..14 {
+                image[(1 + j) * 16 + (1 + i)] = grid[j * 14 + i];
+            }
+        }
+        image
+    }
+
+    #[test]
+    fn test_ar_matrix_code_get_id_global_id_routing_low_contrast() {
+        // Uniform image with code_type = GlobalID must hit the GlobalID branch
+        // and return MatchError::Contrast (not Generic from the dim check).
+        use crate::types::{ARMatrixCodeType, ARPixelFormat, MatchError};
+        let image = vec![128u8; 16 * 16];
+        let vertex = [[0.0f64, 0.0], [16.0, 0.0], [16.0, 16.0], [0.0, 16.0]];
+        let result = ar_matrix_code_get_id(
+            &image,
+            16,
+            16,
+            &vertex,
+            ARMatrixCodeType::GlobalID,
+            ARPixelFormat::MONO,
+            // patt_ratio is ignored for GlobalID (the function uses 14/16).
+            0.5,
+        );
+        assert_eq!(result.unwrap_err(), MatchError::Contrast);
+    }
+
+    #[test]
+    fn test_ar_matrix_code_get_id_global_id_full_roundtrip() {
+        // End-to-end: encode a known global_id with BCH(127, 64, 22), embed
+        // its 120-bit payload into a 16×16 image, then run the full decode
+        // pipeline and recover the same global_id.
+        use crate::bch::test_helpers::encode_bch_global_id;
+        use crate::types::{ARMatrixCodeType, ARPixelFormat};
+
+        let original_id: u64 = 0x1234_5678_DEAD_BEEF;
+        let codeword = encode_bch_global_id(original_id);
+
+        // Take the first 120 bits of the 127-bit codeword (the shortened
+        // tail at positions 120..127 is implicitly zero in the grid).
+        let mut bits120 = [0u8; 120];
+        bits120.copy_from_slice(&codeword[..120]);
+
+        let grid = make_global_id_grid_dir0(&bits120);
+        let image = embed_grid_in_16x16_image(&grid);
+        let vertex = [[0.0f64, 0.0], [16.0, 0.0], [16.0, 16.0], [0.0, 16.0]];
+
+        let ok = ar_matrix_code_get_id(
+            &image,
+            16,
+            16,
+            &vertex,
+            ARMatrixCodeType::GlobalID,
+            ARPixelFormat::MONO,
+            0.5,
+        )
+        .expect("decode should succeed");
+
+        assert_eq!(ok.global_id, original_id);
+        assert_eq!(ok.dir, 0);
+        assert_eq!(ok.error_corrected, 0);
+        // Backward-compat: upper 33 bits are non-zero, so id must be 0.
+        assert_eq!(ok.id, 0);
+    }
+
+    #[test]
+    fn test_ar_matrix_code_get_id_global_id_lower_31_bit_id() {
+        // When global_id fits in 31 bits, the backward-compat `id` field
+        // should carry the lower 31 bits (mirrors arPattGetID.c:214).
+        use crate::bch::test_helpers::encode_bch_global_id;
+        use crate::types::{ARMatrixCodeType, ARPixelFormat};
+
+        let original_id: u64 = 0x0000_0000_0000_002A; // 42 — fits in 31 bits.
+        let codeword = encode_bch_global_id(original_id);
+        let mut bits120 = [0u8; 120];
+        bits120.copy_from_slice(&codeword[..120]);
+
+        let image = embed_grid_in_16x16_image(&make_global_id_grid_dir0(&bits120));
+        let vertex = [[0.0f64, 0.0], [16.0, 0.0], [16.0, 16.0], [0.0, 16.0]];
+
+        let ok = ar_matrix_code_get_id(
+            &image,
+            16,
+            16,
+            &vertex,
+            ARMatrixCodeType::GlobalID,
+            ARPixelFormat::MONO,
+            0.5,
+        )
+        .expect("decode should succeed");
+
+        assert_eq!(ok.global_id, 42);
+        assert_eq!(ok.id, 42);
     }
 
     #[test]

--- a/crates/core/src/ar/matrix.rs
+++ b/crates/core/src/ar/matrix.rs
@@ -60,7 +60,7 @@ pub struct MatrixCodeResult {
 /// - `code_type` — selects the square dimension (`3..=6`) and ECC scheme.
 ///
 /// # Returns
-/// `Ok(MatchOk { id, dir, cf, error_corrected })` on successful decode.
+/// `Ok(MatchOk { id, dir, cf, error_corrected, global_id })` on successful decode.
 /// `Err(MatchError::*)` on low contrast, missing locator pattern, ECC failure,
 /// or unsupported `code_type`.
 ///
@@ -284,6 +284,7 @@ pub fn ar_matrix_code_get_id(
             dir: matched_dir,
             cf: 1.0,
             error_corrected: err,
+            global_id: 0,
         })
     } else {
         arlog_d!(

--- a/crates/core/src/ar/pattern.rs
+++ b/crates/core/src/ar/pattern.rs
@@ -421,6 +421,7 @@ pub fn pattern_match(
             dir: res1,
             cf: max,
             error_corrected: 0,
+            global_id: 0,
         })
     } else if mode == AR_TEMPLATE_MATCHING_MONO {
         let size_sqd = size_u * size_u;
@@ -494,6 +495,7 @@ pub fn pattern_match(
             dir: res1,
             cf: max,
             error_corrected: 0,
+            global_id: 0,
         })
     } else {
         arlog_e!("pattern_match: unsupported matching mode {}", mode);

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -184,6 +184,10 @@ pub struct MatchOk {
     pub cf: f64,
     /// Number of errors corrected by ECC (0 for codes without ECC, always 0 for template).
     pub error_corrected: i32,
+    /// 64-bit global ID for `ARMatrixCodeType::GlobalID` matchers.
+    /// Always `0` for template matching and non-GlobalID matrix codes.
+    /// C equivalent: `*codeGlobalID_p` from `arPattGetIDGlobal`.
+    pub global_id: u64,
 }
 
 impl From<MatchError> for ARMarkerInfoCutoffPhase {
@@ -448,6 +452,9 @@ pub enum ARMatrixCodeType {
     Code5x5BCH2277 = 0x05 | 0x600,
     /// 6x6 Matrix Code
     Code6x6 = 0x06,
+    /// 14x14 Matrix Code with BCH (127,64,22) encoding for 64-bit global IDs.
+    /// C equivalent: `AR_MATRIX_CODE_GLOBAL_ID`. Lower byte = 14 (outer grid size).
+    GlobalID = 0x0E | 0x700,
 }
 
 /// Structure holding state of an instance of the square marker tracker.
@@ -692,5 +699,24 @@ mod tests {
             ARMarkerInfoCutoffPhase::from(MatchError::PatternExtraction),
             ARMarkerInfoCutoffPhase::PatternExtraction
         );
+    }
+
+    #[test]
+    fn test_armatrixcodetype_global_id_value() {
+        // Lower byte = 14 (outer grid size); upper byte = 0x700 (free flag slot).
+        assert_eq!(ARMatrixCodeType::GlobalID as i32, 0x0E | 0x700);
+        assert_eq!((ARMatrixCodeType::GlobalID as i32) & 0xFF, 14);
+    }
+
+    #[test]
+    fn test_match_ok_global_id_field() {
+        let ok = MatchOk {
+            id: 1,
+            dir: 0,
+            cf: 1.0,
+            error_corrected: 0,
+            global_id: 0x1234_5678_DEAD_BEEF,
+        };
+        assert_eq!(ok.global_id, 0x1234_5678_DEAD_BEEF);
     }
 }


### PR DESCRIPTION
## Summary

- Implements `AR_MATRIX_CODE_GLOBAL_ID` matrix decoding so `ARMarkerInfo::global_id` is populated for GlobalID markers (was always `0`).
- Mirrors C `arPattGetIDGlobal` / `get_global_id_code` from `arPattGetID.c`, including the BCH(127, 64, 22) ECC, the 14×14 grid layout with 4-direction L-pattern locator, the `u64::MAX` heuristic rejection, and the lower-31-bit backward-compat id mapping.
- Closes #89.

## Layered commits (review-friendly)

1. `feat(matrix): add ARMatrixCodeType::GlobalID variant and MatchOk.global_id field` — type-level scaffolding only.
2. `feat(bch): implement BCH(127,64,22) decoder for AR_MATRIX_CODE_GLOBAL_ID` — refactors the existing `decode_bch` body into a shared Berlekamp-Massey core and adds `decode_bch_global_id`. Includes a runtime BCH(127, 71) generator-polynomial builder for self-contained tests.
3. `feat(matrix): add 14x14 GlobalID bit extraction with 4-direction traversal` — `extract_global_id_bits` + `should_skip_global_id_cell`, with rotation roundtrip tests.
4. `feat(matrix): wire AR_MATRIX_CODE_GLOBAL_ID into ar_matrix_code_get_id and ar_get_marker_info` — top-level branch + plumbing into `ARMarkerInfo`.

## Non-goals

- ARMulti integration (separate work item — flagged in #89).
- GlobalID *encoder* (only the decoder is needed for marker recognition; the in-test encoder is `#[cfg(test)] pub(crate)`).
- Performance optimisation; correctness first.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --all-features` clean
- [x] `cargo clippy --lib --all-features --tests` — no new warnings introduced by this PR
- [x] `cargo test --lib --all-features` — **256 passed, 2 ignored** (was 234 on `dev`; +22 tests, all passing)
- [x] Roundtrip: encode `0x1234_5678_DEAD_BEEF`, embed in 16×16 image, decode through full `ar_matrix_code_get_id` pipeline, recover identical `global_id`
- [x] Rotation: 4-direction roundtrip on a pseudo-random 120-bit pattern returns the same `recd[0..120]` for all 4 image rotations
- [x] Error correction: 1-bit and 9-bit (boundary) BCH errors corrected; 15-bit errors rejected
- [x] Heuristic: `u64::MAX` decode result returns `MatchError::HeuristicTroublesomeMatrixCodes` (mirrors C -5)
- [x] Backward-compat: `global_id = 42` (fits in 31 bits) populates `id = 42`; otherwise `id = 0`
- [x] ~~Manual verification with a real-world AR_MATRIX_CODE_GLOBAL_ID marker image (no upstream test fixtures shipped — would be a useful follow-up)~~ See my comment above.

## Notes

- The pre-existing `kpm_regression::test_full_pipeline_pose` failure on this branch is also present on `dev` at `c2ced9a` — verified by stashing and re-running. Unrelated to this PR.
- BCH-127 lookup tables ported verbatim from `arPattGetID.c:1830-1831`.
- The `global_id` field flows from `MatchOk` into `ARMarkerInfo` only on the direct decode path; the history-merging path in `ar_get_marker_info` (lines 430-449) does not yet propagate `global_id` — could be a small follow-up if desired, but ARMulti isn't in scope here so this isn't blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)