### PR TITLE
chore: convert generators (generate_patt + nft_marker_gen) to arlog_*! (PR 3/4 for #90)

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -111,6 +111,10 @@ required-features = ["log-helpers"]
 name = "diff_patt"
 required-features = ["log-helpers"]
 
+[[example]]
+name = "generate_patt"
+required-features = ["log-helpers"]
+
 [[bench]]
 name = "marker_bench"
 harness = false

--- a/crates/core/examples/generate_patt.rs
+++ b/crates/core/examples/generate_patt.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use std::str::FromStr;
 use webarkitlib_rs::pattern::{ar_patt_get_image2, ar_patt_save};
 use webarkitlib_rs::types::{ARMarkerInfo, ARParam, ARParamLT, ARParamLTf, ARPixelFormat};
-use webarkitlib_rs::{arlog_e, arlog_i, arlog_w};
+use webarkitlib_rs::{arlog_e, arlog_i, arlog_rel, arlog_w};
 
 /*
  English documentation / notes for this example
@@ -75,24 +75,24 @@ use webarkitlib_rs::{arlog_e, arlog_i, arlog_w};
 */
 
 fn print_help_and_exit() {
-    eprintln!("generate_patt example — usage:");
-    eprintln!("  --input PATH           input image (default: examples/Data/HIRO-test.jpg)");
-    eprintln!("  --out PATH             output .patt path (default: ./crates/core/examples/Data/generated.patt)");
-    eprintln!("  --camera PATH          camera_para.dat path to build ARParamLT (optional)");
-    eprintln!("  --border N             add black border of N pixels around input (default: 0)");
-    eprintln!("  --patt-size N          pattern size in pixels (default: 16)");
-    eprintln!(
+    arlog_rel!("generate_patt example — usage:");
+    arlog_rel!("  --input PATH           input image (default: examples/Data/HIRO-test.jpg)");
+    arlog_rel!("  --out PATH             output .patt path (default: ./crates/core/examples/Data/generated.patt)");
+    arlog_rel!("  --camera PATH          camera_para.dat path to build ARParamLT (optional)");
+    arlog_rel!("  --border N             add black border of N pixels around input (default: 0)");
+    arlog_rel!("  --patt-size N          pattern size in pixels (default: 16)");
+    arlog_rel!(
         "  --sample-factor N      sample factor multiplier passed to extraction (default: 4)"
     );
-    eprintln!("  --flip-v               flip input image vertically before processing");
-    eprintln!("  --channel-order rgb|bgr interpret input buffer as rgb or bgr (default: rgb)");
-    eprintln!("  --with-border          indicate the INPUT IMAGE ALREADY CONTAINS THE MARKER BORDER (no auto-add)");
-    eprintln!("  --patt-ratio F         pattern ratio (pattern/(pattern+2*border)), default 0.5");
-    eprintln!("  --batch                run automatic experiments and write CSV report");
-    eprintln!("  --quiet                reduce printed output");
-    eprintln!("  --verbose              print verbose diagnostic info (full_side, min_dim) when border is auto-computed");
-    eprintln!("  --debug                print very verbose intermediate extraction values (threshold, bbox, vertices, params)");
-    eprintln!("  --help                 show this help");
+    arlog_rel!("  --flip-v               flip input image vertically before processing");
+    arlog_rel!("  --channel-order rgb|bgr interpret input buffer as rgb or bgr (default: rgb)");
+    arlog_rel!("  --with-border          indicate the INPUT IMAGE ALREADY CONTAINS THE MARKER BORDER (no auto-add)");
+    arlog_rel!("  --patt-ratio F         pattern ratio (pattern/(pattern+2*border)), default 0.5");
+    arlog_rel!("  --batch                run automatic experiments and write CSV report");
+    arlog_rel!("  --quiet                reduce printed output");
+    arlog_rel!("  --verbose              print verbose diagnostic info (full_side, min_dim) when border is auto-computed");
+    arlog_rel!("  --debug                print very verbose intermediate extraction values (threshold, bbox, vertices, params)");
+    arlog_rel!("  --help                 show this help");
     std::process::exit(0);
 }
 

--- a/crates/core/examples/generate_patt.rs
+++ b/crates/core/examples/generate_patt.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::str::FromStr;
 use webarkitlib_rs::pattern::{ar_patt_get_image2, ar_patt_save};
 use webarkitlib_rs::types::{ARMarkerInfo, ARParam, ARParamLT, ARParamLTf, ARPixelFormat};
+use webarkitlib_rs::{arlog_e, arlog_i, arlog_w};
 
 /*
  English documentation / notes for this example
@@ -177,9 +178,10 @@ fn run_once(
 
     if applied_border > 0 {
         // log the computed/applied border
-        eprintln!(
+        arlog_i!(
             "Applied border = {} px (source={})",
-            applied_border, border_source
+            applied_border,
+            border_source
         );
 
         // If border was auto-computed and --verbose was passed, print verbose info: full_side, patt_ratio and min_dim
@@ -187,11 +189,12 @@ fn run_once(
             if let Some(fs) = computed_full_side {
                 if let Some(md) = computed_min_dim.as_ref() {
                     let used = used_dimension.as_deref().unwrap_or("min");
-                    eprintln!("Verbose: computed full_marker_side = {}  patt_ratio = {}  used={} min_dim={}", fs, cfg.patt_ratio, used, md);
+                    arlog_i!("Verbose: computed full_marker_side = {}  patt_ratio = {}  used={} min_dim={}", fs, cfg.patt_ratio, used, md);
                 } else {
-                    eprintln!(
+                    arlog_i!(
                         "Verbose: computed full_marker_side = {}  patt_ratio = {}",
-                        fs, cfg.patt_ratio
+                        fs,
+                        cfg.patt_ratio
                     );
                 }
             }
@@ -212,7 +215,7 @@ fn run_once(
         width = new_w;
         height = new_h;
     } else {
-        eprintln!("No border applied (source={})", border_source);
+        arlog_i!("No border applied (source={})", border_source);
     }
 
     // flip
@@ -271,7 +274,7 @@ fn run_once(
     // detect via Otsu
     let thresh = otsu_level(&gray);
     if cfg.debug {
-        eprintln!("Debug: Otsu threshold = {}", thresh);
+        arlog_i!("Debug: Otsu threshold = {}", thresh);
     }
     let mut minx = width as i32;
     let mut miny = height as i32;
@@ -317,16 +320,22 @@ fn run_once(
             maxy = height as i32 - 1
         }
         if cfg.debug {
-            eprintln!(
+            arlog_i!(
                 "Debug: fallback bbox used -> minx={}, miny={}, maxx={}, maxy={}",
-                minx, miny, maxx, maxy
+                minx,
+                miny,
+                maxx,
+                maxy
             );
         }
     }
     if cfg.debug {
-        eprintln!(
+        arlog_i!(
             "Debug: bbox -> minx={}, miny={}, maxx={}, maxy={}",
-            minx, miny, maxx, maxy
+            minx,
+            miny,
+            maxx,
+            maxy
         );
     }
 
@@ -338,7 +347,7 @@ fn run_once(
         [minx as f64, maxy as f64],
     ];
     if cfg.debug {
-        eprintln!("Debug: marker vertices: {:?}", marker.vertex);
+        arlog_i!("Debug: marker vertices: {:?}", marker.vertex);
     }
 
     // prepare output names
@@ -366,7 +375,7 @@ fn run_once(
     // extract pattern image
     let mut ext_patt = vec![0u8; (cfg.patt_size * cfg.patt_size * 3) as usize];
     if cfg.debug {
-        eprintln!("Debug: calling ar_patt_get_image2 with patt_size={} sample_size={} xsize={} ysize={} pixel_format={:?}", cfg.patt_size, cfg.patt_size * cfg.sample_factor, xsize, ysize, pixel_format);
+        arlog_i!("Debug: calling ar_patt_get_image2 with patt_size={} sample_size={} xsize={} ysize={} pixel_format={:?}", cfg.patt_size, cfg.patt_size * cfg.sample_factor, xsize, ysize, pixel_format);
     }
     if let Err(e) = ar_patt_get_image2(
         0,
@@ -385,7 +394,7 @@ fn run_once(
         return Err(format!("ar_patt_get_image2 failed: {}", e));
     }
     if cfg.debug {
-        eprintln!(
+        arlog_i!(
             "Debug: ar_patt_get_image2 returned, ext_patt.len()={}",
             ext_patt.len()
         );
@@ -408,7 +417,7 @@ fn run_once(
 
     // save .patt
     if cfg.debug {
-        eprintln!(
+        arlog_i!(
             "Debug: calling ar_patt_save with patt_ratio={} patt_size={} patt_path={}",
             patt_ratio,
             cfg.patt_size,
@@ -429,7 +438,7 @@ fn run_once(
     )
     .map_err(|e| format!("ar_patt_save failed: {}", e))?;
     if cfg.debug {
-        eprintln!("Debug: ar_patt_save completed");
+        arlog_i!("Debug: ar_patt_save completed");
     }
 
     // compute stats
@@ -492,9 +501,9 @@ fn run_once(
 
     if !cfg.quiet {
         if let Some(rm) = ref_mean {
-            println!("Wrote: {}  {}  count={} min={} max={} mean={:.2} ref_mean={:.2} ref_idx={} ref_flip={}", patt_path.display(), extracted_path.display(), count, min, max, mean, rm, ref_best_idx.unwrap_or(0), ref_best_flip.unwrap_or(false));
+            arlog_i!("Wrote: {}  {}  count={} min={} max={} mean={:.2} ref_mean={:.2} ref_idx={} ref_flip={}", patt_path.display(), extracted_path.display(), count, min, max, mean, rm, ref_best_idx.unwrap_or(0), ref_best_flip.unwrap_or(false));
         } else {
-            println!(
+            arlog_i!(
                 "Wrote: {}  {}  count={} min={} max={} mean={:.2}",
                 patt_path.display(),
                 extracted_path.display(),
@@ -555,6 +564,7 @@ fn flip_vert_u8(buf: &Vec<u8>, patt_size: usize) -> Vec<u8> {
 }
 
 fn main() {
+    webarkitlib_rs::arlog::ar_log_init_default();
     // parse args
     let (default_input, default_out) = default_paths();
     let mut cfg = Config {
@@ -632,7 +642,7 @@ fn main() {
             }
             "--batch" => batch = true,
             "--quiet" => cfg.quiet = true,
-            other => eprintln!("Unknown arg: {}", other),
+            other => arlog_w!("Unknown arg: {}", other),
         }
     }
 
@@ -700,7 +710,7 @@ fn main() {
                 }
             }
         }
-        println!("Batch experiments finished. Report: ./crates/core/examples/Data/experiments/report.csv");
+        arlog_i!("Batch experiments finished. Report: ./crates/core/examples/Data/experiments/report.csv");
         return;
     }
 
@@ -708,9 +718,9 @@ fn main() {
     match run_once(&cfg, "") {
         Ok((_count, _min, _max, _mean, _ref_mean, _ref_idx, _ref_flip)) => {
             if !cfg.quiet {
-                println!("Done.");
+                arlog_i!("Done.");
             }
         }
-        Err(e) => eprintln!("Error: {}", e),
+        Err(e) => arlog_e!("Error: {}", e),
     }
 }

--- a/crates/core/examples/nft_marker_gen.rs
+++ b/crates/core/examples/nft_marker_gen.rs
@@ -64,6 +64,9 @@ use clap::Parser;
 use std::path::Path;
 use std::time::Instant;
 use webarkitlib_rs::ar2::{ar2_gen_feature_map, ar2_gen_image_set};
+use webarkitlib_rs::{arlog_e, arlog_i};
+#[cfg(feature = "ffi-backend")]
+use webarkitlib_rs::arlog_w;
 
 /// KPM feature density for `.fset3` generation (default extraction level 1).
 ///
@@ -161,18 +164,17 @@ fn main() {
     // -----------------------------------------------------------------------
     // Header
     // -----------------------------------------------------------------------
-    println!("--");
-    println!(
+    arlog_i!("--");
+    arlog_i!(
         "Generator started at {}",
         start_time.format("%Y-%m-%d %H:%M:%S %z")
     );
-    println!();
 
     // -----------------------------------------------------------------------
     // Load input image as RGB.
     // -----------------------------------------------------------------------
     let img = image::open(&cli.input).unwrap_or_else(|e| {
-        eprintln!("Error: failed to open {:?}: {}", cli.input, e);
+        arlog_e!("Error: failed to open {:?}: {}", cli.input, e);
         std::process::exit(1);
     });
     let rgb = img.to_rgb8();
@@ -181,23 +183,25 @@ fn main() {
     let nc = 3;
     let pixels = rgb.into_raw(); // nc=3, length = w * h * 3
 
-    println!("Tracking Extraction Level = {}", cli.level);
-    println!();
-    println!(
+    arlog_i!("Tracking Extraction Level = {}", cli.level);
+    arlog_i!(
         "Input:  {:?}  (xsize={}, ysize={}, channels={}, dpi={:.1})",
-        cli.input, w, h, nc, cli.dpi
+        cli.input,
+        w,
+        h,
+        nc,
+        cli.dpi
     );
-    println!("Output: {:?}.*", cli.output);
-    println!();
+    arlog_i!("Output: {:?}.*", cli.output);
 
     // -----------------------------------------------------------------------
     // Step 1: build image pyramid → .iset
     // -----------------------------------------------------------------------
-    println!("Generating ImageSet...");
+    arlog_i!("Generating ImageSet...");
     let step_start = Instant::now();
 
     let image_set = ar2_gen_image_set(&pixels, w, h, nc, cli.dpi).unwrap_or_else(|e| {
-        eprintln!("Error: ar2_gen_image_set failed: {}", e);
+        arlog_e!("Error: ar2_gen_image_set failed: {}", e);
         std::process::exit(1);
     });
 
@@ -205,45 +209,43 @@ fn main() {
 
     // Print DPI levels.
     for (i, scale) in image_set.scale.iter().enumerate() {
-        println!("  Image DPI ({}): {:.6}", image_set.num() - i, scale.dpi);
+        arlog_i!("  Image DPI ({}): {:.6}", image_set.num() - i, scale.dpi);
     }
-    println!();
 
     let iset_path = cli.output.with_extension("iset");
-    println!("Saving to {:?}...", iset_path);
+    arlog_i!("Saving to {:?}...", iset_path);
     let save_start = Instant::now();
     image_set.save(&iset_path).unwrap_or_else(|e| {
-        eprintln!("Error: failed to save {:?}: {}", iset_path, e);
+        arlog_e!("Error: failed to save {:?}: {}", iset_path, e);
         std::process::exit(1);
     });
     let save_elapsed = save_start.elapsed().as_secs_f64();
 
     let first_dpi = image_set.scale.first().map_or(0.0, |s| s.dpi);
     let last_dpi = image_set.scale.last().map_or(0.0, |s| s.dpi);
-    println!(
+    arlog_i!(
         "  Done. {} levels: {:.1} -> {:.1} dpi  ({})",
         image_set.num(),
         first_dpi,
         last_dpi,
         file_kb(&iset_path),
     );
-    println!(
+    arlog_i!(
         "  Pyramid generation: {:.1}s | Save: {:.1}s | Total: {:.1}s",
         gen_elapsed,
         save_elapsed,
         step_start.elapsed().as_secs_f64()
     );
-    println!();
 
     // -----------------------------------------------------------------------
     // Step 2: generate AR2 features → .fset
     // -----------------------------------------------------------------------
-    println!("Generating FeatureList...");
+    arlog_i!("Generating FeatureList...");
     let step_start = Instant::now();
 
     // search_size = AR2_DEFAULT_GEN_FEATURE_MAP_SEARCH_SIZE1 = 10 (from C config.h)
     let feature_set = ar2_gen_feature_map(&image_set, 10, 250, cli.level).unwrap_or_else(|e| {
-        eprintln!("Error: ar2_gen_feature_map failed: {}", e);
+        arlog_e!("Error: ar2_gen_feature_map failed: {}", e);
         std::process::exit(1);
     });
 
@@ -252,7 +254,7 @@ fn main() {
     // Print per-level feature counts.
     for pts in &feature_set.list {
         let scale_img = &image_set.scale[pts.scale as usize];
-        println!(
+        arlog_i!(
             "  {:.6} dpi ({}x{}): {} features selected",
             scale_img.dpi,
             scale_img.xsize,
@@ -260,31 +262,29 @@ fn main() {
             pts.coord.len()
         );
     }
-    println!();
 
     let fset_path = cli.output.with_extension("fset");
-    println!("Saving FeatureSet to {:?}...", fset_path);
+    arlog_i!("Saving FeatureSet to {:?}...", fset_path);
     let save_start = Instant::now();
     feature_set.save(&fset_path).unwrap_or_else(|e| {
-        eprintln!("Error: failed to save {:?}: {}", fset_path, e);
+        arlog_e!("Error: failed to save {:?}: {}", fset_path, e);
         std::process::exit(1);
     });
     let save_elapsed = save_start.elapsed().as_secs_f64();
 
     let total_features: usize = feature_set.list.iter().map(|p| p.coord.len()).sum();
-    println!(
+    arlog_i!(
         "  Done. {} levels, {} features total  ({})",
         feature_set.num(),
         total_features,
         file_kb(&fset_path),
     );
-    println!(
+    arlog_i!(
         "  Feature extraction: {:.1}s | Save: {:.1}s | Total: {:.1}s",
         gen_elapsed,
         save_elapsed,
         step_start.elapsed().as_secs_f64()
     );
-    println!();
 
     // -----------------------------------------------------------------------
     // Step 3: generate KPM/FREAK keypoints → .fset3  (ffi-backend only)
@@ -294,7 +294,7 @@ fn main() {
         use webarkitlib_rs::kpm::types::KpmRefDataSet;
         use webarkitlib_rs::kpm::{CppFreakMatcher, KpmCompMode, KpmError, KpmProcMode};
 
-        println!("Generating FeatureSet3...");
+        arlog_i!("Generating FeatureSet3...");
         let step_start = Instant::now();
 
         let fset3_path = cli.output.with_extension("fset3");
@@ -306,7 +306,7 @@ fn main() {
 
             // Fresh matcher for each scale (scales may have different dimensions).
             let mut matcher = CppFreakMatcher::new(scale.xsize, scale.ysize).unwrap_or_else(|e| {
-                eprintln!("Error: CppFreakMatcher::new failed: {:?}", e);
+                arlog_e!("Error: CppFreakMatcher::new failed: {:?}", e);
                 std::process::exit(1);
             });
 
@@ -325,9 +325,12 @@ fn main() {
 
             match result {
                 Ok(ref_data) => {
-                    println!(
+                    arlog_i!(
                         "  ({}, {}) {:.6} dpi: Freak features - {}",
-                        scale.xsize, scale.ysize, scale.dpi, ref_data.num
+                        scale.xsize,
+                        scale.ysize,
+                        scale.dpi,
+                        ref_data.num
                     );
                     combined = Some(match combined.take() {
                         Some(mut existing) => {
@@ -338,62 +341,62 @@ fn main() {
                     });
                 }
                 Err(KpmError::InvalidInput(_)) => {
-                    println!(
+                    arlog_i!(
                         "  ({}, {}) {:.6} dpi: Freak features - 0 (scale too small)",
-                        scale.xsize, scale.ysize, scale.dpi
+                        scale.xsize,
+                        scale.ysize,
+                        scale.dpi
                     );
                 }
                 Err(e) => {
-                    eprintln!(
+                    arlog_w!(
                         "Warning: KpmRefDataSet::generate failed for scale {}: {:?}",
-                        image_no, e
+                        image_no,
+                        e
                     );
                 }
             }
         }
-        println!();
 
         let gen_elapsed = step_start.elapsed().as_secs_f64();
 
-        println!("Saving FeatureSet3 to {:?}...", fset3_path);
+        arlog_i!("Saving FeatureSet3 to {:?}...", fset3_path);
         if let Some(ref_data) = combined {
             let total_kpm = ref_data.num as usize;
             let save_start = Instant::now();
             ref_data.save(&fset3_path).unwrap_or_else(|e| {
-                eprintln!("Error: failed to save {:?}: {}", fset3_path, e);
+                arlog_e!("Error: failed to save {:?}: {}", fset3_path, e);
                 std::process::exit(1);
             });
             let save_elapsed = save_start.elapsed().as_secs_f64();
-            println!(
+            arlog_i!(
                 "  Done. {} FREAK features total  ({})",
                 total_kpm,
                 file_kb(&fset3_path),
             );
-            println!(
+            arlog_i!(
                 "  FREAK extraction: {:.1}s | Save: {:.1}s | Total: {:.1}s",
                 gen_elapsed,
                 save_elapsed,
                 step_start.elapsed().as_secs_f64()
             );
         } else {
-            eprintln!("Warning: no KPM features extracted — .fset3 not written.");
+            arlog_w!("Warning: no KPM features extracted — .fset3 not written.");
         }
     }
 
     #[cfg(not(feature = "ffi-backend"))]
-    println!("[fset3] skipped (build with --features ffi-backend to generate)");
+    arlog_i!("[fset3] skipped (build with --features ffi-backend to generate)");
 
     // -----------------------------------------------------------------------
     // Done
     // -----------------------------------------------------------------------
     let finish_time = Local::now();
     let elapsed = start.elapsed().as_secs_f64();
-    println!();
-    println!(
+    arlog_i!(
         "Generator finished at {}",
         finish_time.format("%Y-%m-%d %H:%M:%S %z")
     );
-    println!("--");
-    println!();
-    println!("NFTMarkerGenerator took {:.6} seconds to execute", elapsed);
+    arlog_i!("--");
+    arlog_i!("NFTMarkerGenerator took {:.6} seconds to execute", elapsed);
 }

--- a/crates/core/examples/nft_marker_gen.rs
+++ b/crates/core/examples/nft_marker_gen.rs
@@ -64,6 +64,8 @@ use clap::Parser;
 use std::path::Path;
 use std::time::Instant;
 use webarkitlib_rs::ar2::{ar2_gen_feature_map, ar2_gen_image_set};
+#[cfg(not(feature = "ffi-backend"))]
+use webarkitlib_rs::arlog_rel;
 #[cfg(feature = "ffi-backend")]
 use webarkitlib_rs::arlog_w;
 use webarkitlib_rs::{arlog_e, arlog_i};
@@ -142,11 +144,11 @@ fn main() {
     {
         use std::io::Write as _;
         if !cli.yes {
-            eprintln!();
-            eprintln!(
+            arlog_rel!("");
+            arlog_rel!(
                 "Warning: built without `ffi-backend` feature — .fset3 will NOT be generated."
             );
-            eprintln!("An NFT marker without .fset3 cannot be used for initialization/detection.");
+            arlog_rel!("An NFT marker without .fset3 cannot be used for initialization/detection.");
             eprint!("Continue anyway? [y/N] ");
             let _ = std::io::stdout().flush();
             let mut answer = String::new();
@@ -154,10 +156,10 @@ fn main() {
                 .read_line(&mut answer)
                 .expect("failed to read input");
             if !answer.trim().eq_ignore_ascii_case("y") {
-                eprintln!("Aborted.");
+                arlog_rel!("Aborted.");
                 std::process::exit(1);
             }
-            eprintln!();
+            arlog_rel!("");
         }
     }
 

--- a/crates/core/examples/nft_marker_gen.rs
+++ b/crates/core/examples/nft_marker_gen.rs
@@ -64,9 +64,9 @@ use clap::Parser;
 use std::path::Path;
 use std::time::Instant;
 use webarkitlib_rs::ar2::{ar2_gen_feature_map, ar2_gen_image_set};
-use webarkitlib_rs::{arlog_e, arlog_i};
 #[cfg(feature = "ffi-backend")]
 use webarkitlib_rs::arlog_w;
+use webarkitlib_rs::{arlog_e, arlog_i};
 
 /// KPM feature density for `.fset3` generation (default extraction level 1).
 ///


### PR DESCRIPTION
Part 3 of 4 for #90 . Converts the two generator CLI examples to the project's arlog_*! macros. PR 3 is larger than PR 1 or PR 2 (84 print sites combined) and exercises arlog_e! and arlog_w! in examples/ for the first time, plus introduces three "do-not-convert" categories: CLI help banners, interactive prompts, and empty spacers. Calling out the contestable judgments up front so review can focus there.

**Scope**

- crates/core/examples/generate_patt.rs — 716 lines, 34 print sites: 16 help-banner eprintln! kept, 16 → arlog_i!, 1 → arlog_w!, 1 → arlog_e!. Logger init + imports added.
- crates/core/examples/nft_marker_gen.rs — 399 lines, 50 print sites: 6 y/N prompt sites kept, 10 empty spacers deleted, 25 → arlog_i!, 7 → arlog_e!, 2 → arlog_w!. Logger init was already present from a prior change; imports added.
- crates/core/Cargo.toml — new [[example]] block for generate_patt with required-features = ["log-helpers"]. nft_marker_gen's block already exists.

**Categorical decisions**

**CLI help banner stays as eprintln! (16 sites in generate_patt.rs `print_help_and_exit`).** Routing `--help` output through arlog_i! would prefix every line with `[info]` and apply level filtering — wrong UX for help text, which is human UI not log events.

**Interactive y/N prompt stays as eprintln!/eprint! (6 sites in nft_marker_gen.rs).** The prompt + read_line block needs synchronous stderr output that a log facade can't guarantee.

**Empty `println!();` spacer lines deleted rather than converted (10 sites in nft_marker_gen.rs).** An empty arlog_i!() renders as a bare `[info]` with no body, which is noise. The spacing was a stdout-style artifact from the original C markerCreator. Happy to preserve them in some other form (e.g. arlog_i!("") to maintain visual structure) if you'd prefer — let me know.

**`if cfg.debug` / `if cfg.verbose` wrappers in generate_patt.rs preserved, inner calls converted to arlog_i! with "Debug:"/"Verbose:" prefixes intact.** Two cleaner alternatives exist:
- (b) wire cfg.debug/verbose to set_ar_log_level() at startup, drop wrappers, use arlog_d!. Behavior-preserving but introduces global state coupling and would unmute any arlog_d! in linked library code.
- (c) drop the CLI flags entirely, use arlog_d!, document RUST_LOG=debug. Cleanest semantics, but a user-visible CLI surface change.

Defaulting to (a) for minimum-change. Happy to flip to (b) or (c) — both are reasonable, and (c) might be the right long-term answer; let me know your preference and I'll push a fixup or open a follow-up.

**Sub-classification: lines 328, 341, 347 in nft_marker_gen.rs are three per-scale outcomes in the FREAK feature loop, classified differently.** 328 (arlog_i!) is success, 341 (arlog_i!) is an expected skip for small scales, 347 (arlog_w!) is an unexpected per-scale failure where the loop continues. Following the existing author's signal (println vs eprintln) for which is which.

**small adjustment beyond the plan**

`use webarkitlib_rs::arlog_w;` in nft_marker_gen.rs is gated on `#[cfg(feature = "ffi-backend")]` to silence an unused-import warning on the no-ffi build. Both arlog_w! call sites are already inside that cfg block; the import follows them.

**Verification**

- cargo fmt --all -- --check ✓
- cargo build --example generate_patt --features log-helpers ✓
- cargo build --example nft_marker_gen --features log-helpers ✓
- cargo clippy --features log-helpers — no new lints in either touched file
- cargo test ✓
- cargo run --example generate_patt --features log-helpers -- --help ✓ — confirmed plain text output, no [info] prefixes (Q1 verified)
- cargo run --example generate_patt --features log-helpers ✓ — confirmed [info] arlog output on the converted paths
- cargo run --example nft_marker_gen --features log-helpers (with -y to skip the y/N prompt) ✓
- grep for residual print calls — only the 16 help-banner sites and 6 y/N prompt sites remain, as planned

Skipped per pre-existing issues already documented on the issue thread: cargo build --all-features (macOS stdc++ link issue) and cargo clippy --all-targets -- -D warnings (lib-side doctest lint in arlog.rs:299).

**Followups**

- PR 4: simple_nft.rs (depends on ffi-backend feature, kept separate so reviewers without an FFI setup could sign off on PRs 1–3 independently).