### PR TITLE
fix(arlog): scope test log capture to the thread running the arlog test

### DIFF
--- a/crates/core/src/arlog.rs
+++ b/crates/core/src/arlog.rs
@@ -352,12 +352,20 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Mutex, OnceLock};
+    use std::thread::ThreadId;
 
     type Captured = (log::Level, String, String);
 
     static CAPTURES: OnceLock<Mutex<Vec<Captured>>> = OnceLock::new();
     static TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     static INIT: OnceLock<()> = OnceLock::new();
+
+    // Identifies the thread currently running an arlog test. `cargo test`
+    // runs tests in parallel on multiple threads and shares the global log
+    // dispatcher across all of them, so without this filter logs emitted by
+    // OTHER tests on other threads would leak into our capture buffer and
+    // break our exact-count assertions.
+    static CAPTURING_THREAD: Mutex<Option<ThreadId>> = Mutex::new(None);
 
     fn captures() -> &'static Mutex<Vec<Captured>> {
         CAPTURES.get_or_init(|| Mutex::new(Vec::new()))
@@ -376,6 +384,13 @@ mod tests {
             true
         }
         fn log(&self, record: &log::Record) {
+            // Only capture logs from the thread currently running an arlog
+            // test. Parallel tests on other threads still emit through the
+            // global dispatcher, but their records are dropped here.
+            let active = *CAPTURING_THREAD.lock().unwrap();
+            if active != Some(std::thread::current().id()) {
+                return;
+            }
             captures().lock().unwrap().push((
                 record.level(),
                 record.target().to_string(),
@@ -392,6 +407,9 @@ mod tests {
             let _ = log::set_logger(&LOGGER);
             log::set_max_level(log::LevelFilter::Trace);
         });
+        // Mark THIS thread as the active capture target. test_lock() ensures
+        // only one arlog test runs at a time, so this is safe to overwrite.
+        *CAPTURING_THREAD.lock().unwrap() = Some(std::thread::current().id());
     }
 
     fn drain() -> Vec<Captured> {


### PR DESCRIPTION
## Why

The arlog tests use a global `CaptureLogger` and serialize themselves with `test_lock()`, but `log::set_logger` is process-global. Tests running in parallel on other threads still emit through the same dispatcher, and their records get captured into the buffer the arlog test is about to drain. Exact-count assertions like:

\`\`\`rust
assert_eq!(records.len(), 1);
\`\`\`

then fail with \`left: 2, right: 1\` (or similar).

This bug was latent until the M7 -> dev rollup PR ([#123](https://github.com/webarkit/WebARKitLib-rs/pull/123)) combined dev's new tests with M7's new \`arlog_i!\`/\`arlog_d!\` emitters, increasing the chance of parallel emission landing in an arlog test's window. \`arlog_i_emits_info_record\` started failing consistently on the rollup CI.

## What

Filter at the capture layer by current thread:
- \`init_capture()\` records the test's \`ThreadId\` into \`CAPTURING_THREAD\`.
- \`CaptureLogger::log()\` drops any record not emitted on that thread.

\`test_lock()\` ensures only one arlog test runs at a time, so the active \`ThreadId\` is unambiguous for the duration of the lock.

## What didn't change

The five count-based asserts (\`arlog_i_emits_info_record\`, \`arlog_rel_uses_distinct_target\`, \`arlog_perror_no_prefix\`, \`arlog_perror_with_prefix\`, \`unfiltered_debug_arg_is_evaluated\`) are unchanged. The fix is at the capture layer, so all of them benefit without per-test edits.

## Tests

- \`cargo test -p webarkitlib-rs --lib -- arlog\` → 20 passed (on dev)
- \`cargo test -p webarkitlib-rs --lib\` → 274 passed (full lib suite)
- \`cargo fmt --all -- --check\` → clean
- \`cargo clippy --workspace -- -D warnings\` → clean

I couldn't reproduce the failure on dev alone because dev doesn't have M7's new arlog emitters. The fix's mechanism is mechanical (active thread filter) and verified by inspection; CI on #123 will confirm by going green once this lands and #123 is rebased.

## Unblocks

- [#123](https://github.com/webarkit/WebARKitLib-rs/pull/123) — M7 -> dev rollup

## Base

Target: \`dev\`. Small, focused fix to test infrastructure only.