### PR TITLE
feat(kpm): port interpolate.h + BinomialPyramid32f to Rust (M8 step 2)

### DIFF
--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -115,6 +115,21 @@ fn build_freak_matcher() {
     if !target.contains("msvc") {
         build.flag("-Wno-unused-parameter");
         build.flag("-Wno-sign-compare");
+        // Disable floating-point contraction (fused multiply-add).
+        //
+        // Apple clang on ARM64 emits FMA instructions for `a + b*c`
+        // patterns by default. Linux GCC and MSVC do not. The FMA path is
+        // *more* precise (no intermediate rounding) and produces
+        // platform-dependent f32 output that drifts from the non-FMA path
+        // by up to several ULPs. This breaks dual-mode tests that assert
+        // byte-for-byte parity between the C++ baseline and the Rust port
+        // (which does not use FMA).
+        //
+        // -ffp-contract=off forces all FP additions/multiplications to be
+        // emitted as separate non-fused instructions, restoring
+        // deterministic cross-platform output. Both clang and GCC support
+        // this flag. See M8-2 design doc §7 and the discussion on PR #135.
+        build.flag("-ffp-contract=off");
     }
 
     for src in &cpp_sources {

--- a/crates/core/src/kpm/freak/gaussian_pyramid.rs
+++ b/crates/core/src/kpm/freak/gaussian_pyramid.rs
@@ -640,35 +640,13 @@ mod tests {
         dst
     }
 
-    /// Distance in ULPs between two non-negative f32 values. Returns
-    /// `i64::MAX` for sign mismatches or NaN.
-    #[cfg(feature = "dual-mode")]
-    fn ulp_distance(a: f32, b: f32) -> i64 {
-        if a.is_nan() || b.is_nan() {
-            return i64::MAX;
-        }
-        if a.is_sign_negative() != b.is_sign_negative() {
-            return i64::MAX;
-        }
-        // For same-sign floats, to_bits() is monotonic, so the integer
-        // difference of the bit patterns equals the ULP distance.
-        (a.to_bits() as i64 - b.to_bits() as i64).abs()
-    }
-
     #[test]
     #[cfg(feature = "dual-mode")]
     fn test_gaussian_pyramid_pixels_match_cpp() {
-        // We assert <= 1 ULP rather than strict bit equality because Apple
-        // clang on ARM64 emits FMA (fused multiply-add) instructions for
-        // the binomial filter expression by default, while MSVC and GCC
-        // (Linux) do not. FMA is *more* precise (no intermediate rounding),
-        // so the C++ output differs by 1 ULP across platforms — and the
-        // Rust output (no FMA) lands at one of those rounded values. The
-        // 1-ULP tolerance keeps the test meaningful (it would still fail
-        // on any real algorithm error) while accommodating cross-platform
-        // C++ FP contraction. See docs/design/m8-2-gaussian-pyramid.md §7.
-        const MAX_ULP_DIFF: i64 = 1;
-
+        // Strict byte-for-byte f32 parity. The C++ side is compiled with
+        // `-ffp-contract=off` (see build.rs) to prevent Apple clang on ARM64
+        // from emitting FMA instructions that would drift from the non-FMA
+        // Rust output by multiple ULPs.
         let src_w = 32;
         let src_h = 32;
         let src = gradient_u8(src_h, src_w);
@@ -683,10 +661,10 @@ mod tests {
                 let rust = rust_pyr.level(oct, scale).as_slice();
                 assert_eq!(rust.len(), cpp.len(), "size mismatch at ({oct}, {scale})");
                 for (i, (&r, &c)) in rust.iter().zip(cpp.iter()).enumerate() {
-                    let ulp = ulp_distance(r, c);
-                    assert!(
-                        ulp <= MAX_ULP_DIFF,
-                        "f32 mismatch at ({oct}, {scale}) idx {i}: rust={r}, cpp={c}, ulp_diff={ulp}"
+                    assert_eq!(
+                        r.to_bits(),
+                        c.to_bits(),
+                        "f32 bit mismatch at ({oct}, {scale}) idx {i}: rust={r}, cpp={c}"
                     );
                 }
             }

--- a/crates/core/src/kpm/freak/gaussian_pyramid.rs
+++ b/crates/core/src/kpm/freak/gaussian_pyramid.rs
@@ -640,9 +640,35 @@ mod tests {
         dst
     }
 
+    /// Distance in ULPs between two non-negative f32 values. Returns
+    /// `i64::MAX` for sign mismatches or NaN.
+    #[cfg(feature = "dual-mode")]
+    fn ulp_distance(a: f32, b: f32) -> i64 {
+        if a.is_nan() || b.is_nan() {
+            return i64::MAX;
+        }
+        if a.is_sign_negative() != b.is_sign_negative() {
+            return i64::MAX;
+        }
+        // For same-sign floats, to_bits() is monotonic, so the integer
+        // difference of the bit patterns equals the ULP distance.
+        (a.to_bits() as i64 - b.to_bits() as i64).abs()
+    }
+
     #[test]
     #[cfg(feature = "dual-mode")]
     fn test_gaussian_pyramid_pixels_match_cpp() {
+        // We assert <= 1 ULP rather than strict bit equality because Apple
+        // clang on ARM64 emits FMA (fused multiply-add) instructions for
+        // the binomial filter expression by default, while MSVC and GCC
+        // (Linux) do not. FMA is *more* precise (no intermediate rounding),
+        // so the C++ output differs by 1 ULP across platforms — and the
+        // Rust output (no FMA) lands at one of those rounded values. The
+        // 1-ULP tolerance keeps the test meaningful (it would still fail
+        // on any real algorithm error) while accommodating cross-platform
+        // C++ FP contraction. See docs/design/m8-2-gaussian-pyramid.md §7.
+        const MAX_ULP_DIFF: i64 = 1;
+
         let src_w = 32;
         let src_h = 32;
         let src = gradient_u8(src_h, src_w);
@@ -657,10 +683,10 @@ mod tests {
                 let rust = rust_pyr.level(oct, scale).as_slice();
                 assert_eq!(rust.len(), cpp.len(), "size mismatch at ({oct}, {scale})");
                 for (i, (&r, &c)) in rust.iter().zip(cpp.iter()).enumerate() {
-                    assert_eq!(
-                        r.to_bits(),
-                        c.to_bits(),
-                        "f32 bit mismatch at ({oct}, {scale}) idx {i}: rust={r}, cpp={c}"
+                    let ulp = ulp_distance(r, c);
+                    assert!(
+                        ulp <= MAX_ULP_DIFF,
+                        "f32 mismatch at ({oct}, {scale}) idx {i}: rust={r}, cpp={c}, ulp_diff={ulp}"
                     );
                 }
             }

--- a/crates/core/src/kpm/freak/gaussian_pyramid.rs
+++ b/crates/core/src/kpm/freak/gaussian_pyramid.rs
@@ -1,0 +1,669 @@
+/*
+ *  gaussian_pyramid.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Binomial Gaussian scale-space pyramid (f32 levels, 3 scales per octave).
+//!
+//! Ported from
+//! `WebARKitLib/lib/SRC/KPM/FreakMatcher/detectors/gaussian_scale_space_pyramid.{h,cpp}`
+//! (the `BinomialPyramid32f` concrete impl plus its `GaussianScaleSpacePyramid`
+//! base). The C++ inheritance hierarchy is flattened into one Rust type since
+//! `BinomialPyramid32f` is the only concrete implementation in use.
+//!
+//! Input is `Matrix<u8>` (grayscale); output is `Matrix<f32>` per level
+//! (matches C++ `IMAGE_F32` storage). The binomial filter is a fixed 5-tap
+//! `[1, 4, 6, 4, 1]` kernel applied separably (H then V), with `1 / 256`
+//! normalization on the V pass. Border handling replicates edge pixels for
+//! the 2-pixel border on each side, matching the C++ exactly.
+
+use crate::{arlog_e, arlog_w};
+use purecv::core::Matrix;
+
+/// Errors that can occur while building a [`GaussianScaleSpacePyramid`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum GaussianPyramidError {
+    /// Input image had zero rows or zero columns.
+    EmptyImage,
+    /// Input image is smaller than 5x5; the binomial filter needs 2 border
+    /// pixels on each side.
+    ImageTooSmall { rows: usize, cols: usize },
+    /// `num_octaves` was 0 — a pyramid must have at least one octave.
+    ZeroOctaves,
+    /// Halving for `octave` would produce a level smaller than 5x5.
+    OctaveTooSmall {
+        octave: usize,
+        rows: usize,
+        cols: usize,
+    },
+}
+
+impl std::fmt::Display for GaussianPyramidError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyImage => write!(f, "input image is empty (0 rows or 0 cols)"),
+            Self::ImageTooSmall { rows, cols } => write!(
+                f,
+                "input image is {rows}x{cols}; binomial filter requires >= 5x5"
+            ),
+            Self::ZeroOctaves => write!(f, "num_octaves must be >= 1"),
+            Self::OctaveTooSmall { octave, rows, cols } => write!(
+                f,
+                "octave {octave} would be {rows}x{cols}; binomial filter requires >= 5x5"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for GaussianPyramidError {}
+
+/// Binomial Gaussian scale-space pyramid.
+///
+/// Each octave contains exactly [`Self::NUM_SCALES_PER_OCTAVE`] = 3 levels.
+/// Level dimensions: octave `o` has size `(rows >> o, cols >> o)`. Level
+/// storage is `Matrix<f32>` (row-major).
+#[derive(Debug, Clone)]
+pub struct GaussianScaleSpacePyramid {
+    /// `octaves[oct][scale]` — `Matrix<f32>` for the level.
+    pub octaves: Vec<Vec<Matrix<f32>>>,
+    /// Number of octaves requested at construction.
+    pub num_octaves: usize,
+    /// Scale step factor: `k = 2^(1 / (NUM_SCALES_PER_OCTAVE - 1)) = sqrt(2)`.
+    pub kfactor: f32,
+    /// `1 / ln(k)` — precomputed for [`Self::locate`].
+    pub one_over_log_k: f32,
+}
+
+impl GaussianScaleSpacePyramid {
+    /// C++ `BinomialPyramid32f::alloc` hardcodes 3 scales per octave; the
+    /// build sequence (`filter`, `filter`, `filter_twice`) is 3-specific.
+    pub const NUM_SCALES_PER_OCTAVE: usize = 3;
+
+    /// Create an empty pyramid configured for `num_octaves` octaves.
+    /// Levels are populated by [`Self::build`].
+    #[must_use]
+    pub fn new(num_octaves: usize) -> Self {
+        let k = 2f32.powf(1.0 / (Self::NUM_SCALES_PER_OCTAVE as f32 - 1.0));
+        Self {
+            octaves: Vec::with_capacity(num_octaves),
+            num_octaves,
+            kfactor: k,
+            one_over_log_k: 1.0 / k.ln(),
+        }
+    }
+
+    /// Number of scales per octave (always [`Self::NUM_SCALES_PER_OCTAVE`]).
+    #[must_use]
+    pub fn num_scales_per_octave(&self) -> usize {
+        Self::NUM_SCALES_PER_OCTAVE
+    }
+
+    /// Borrow level at `(octave, scale)`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `octave >= num_octaves` or `scale >= NUM_SCALES_PER_OCTAVE`.
+    #[must_use]
+    pub fn level(&self, octave: usize, scale: usize) -> &Matrix<f32> {
+        &self.octaves[octave][scale]
+    }
+
+    /// Effective sigma at `(octave, scale)`: `k^scale * 2^octave`.
+    #[must_use]
+    pub fn effective_sigma(&self, octave: usize, scale: usize) -> f32 {
+        self.kfactor.powi(scale as i32) * (1u32 << octave) as f32
+    }
+
+    /// Snap `sigma` to the nearest `(octave, scale)` pair. Clamped to the
+    /// pyramid bounds.
+    ///
+    /// C equivalent: `vision::GaussianScaleSpacePyramid::locate(int&, int&, float)`.
+    #[must_use]
+    pub fn locate(&self, sigma: f32) -> (usize, usize) {
+        let mut octave = sigma.log2().floor() as i32;
+        let octave_pow = if octave >= 0 {
+            (1i32 << octave) as f32
+        } else {
+            1.0 / (1i32 << -octave) as f32
+        };
+        let fscale = (sigma / octave_pow).ln() * self.one_over_log_k;
+        let mut scale = fscale.round() as i32;
+
+        // C++: if scale is the last in octave, bump to next octave's scale 0
+        // (coarser octaves are preferred for efficiency).
+        if scale == (Self::NUM_SCALES_PER_OCTAVE as i32) - 1 {
+            octave += 1;
+            scale = 0;
+        }
+
+        // Clamp to pyramid bounds.
+        if octave < 0 {
+            return (0, 0);
+        }
+        if (octave as usize) >= self.num_octaves {
+            return (self.num_octaves - 1, Self::NUM_SCALES_PER_OCTAVE - 1);
+        }
+        let scale = scale.clamp(0, Self::NUM_SCALES_PER_OCTAVE as i32 - 1) as usize;
+        (octave as usize, scale)
+    }
+
+    /// Populate `self.octaves` from `image`. Idempotent (clears prior state).
+    ///
+    /// Build sequence per C++ `BinomialPyramid32f::build`:
+    /// - Octave 0:
+    ///   - `octaves[0][0] = filter(input)` (u8 → f32)
+    ///   - `octaves[0][1] = filter(octaves[0][0])` (f32 → f32)
+    ///   - `octaves[0][2] = filter(filter(octaves[0][1]))` (2 applications)
+    /// - Octave i (i > 0):
+    ///   - `octaves[i][0] = downsample(octaves[i-1][2])`
+    ///   - `octaves[i][1] = filter(octaves[i][0])`
+    ///   - `octaves[i][2] = filter(filter(octaves[i][1]))`
+    pub fn build(&mut self, image: &Matrix<u8>) -> Result<(), GaussianPyramidError> {
+        if self.num_octaves == 0 {
+            arlog_e!("GaussianScaleSpacePyramid::build: num_octaves is 0");
+            return Err(GaussianPyramidError::ZeroOctaves);
+        }
+        if image.rows == 0 || image.cols == 0 {
+            arlog_e!("GaussianScaleSpacePyramid::build: input image is empty");
+            return Err(GaussianPyramidError::EmptyImage);
+        }
+        if image.rows < 5 || image.cols < 5 {
+            arlog_e!(
+                "GaussianScaleSpacePyramid::build: image too small ({}x{}); need >= 5x5",
+                image.rows,
+                image.cols
+            );
+            return Err(GaussianPyramidError::ImageTooSmall {
+                rows: image.rows,
+                cols: image.cols,
+            });
+        }
+        if image.channels != 1 {
+            arlog_w!(
+                "GaussianScaleSpacePyramid::build: input has {} channels; only the first is used",
+                image.channels
+            );
+        }
+
+        self.octaves.clear();
+
+        // Octave 0.
+        let l0 = binomial_4th_order_u8_to_f32(image);
+        let l1 = binomial_4th_order_f32_to_f32(&l0);
+        let l2_tmp = binomial_4th_order_f32_to_f32(&l1);
+        let l2 = binomial_4th_order_f32_to_f32(&l2_tmp);
+        self.octaves.push(vec![l0, l1, l2]);
+
+        // Octaves 1..num_octaves.
+        for oct in 1..self.num_octaves {
+            let prev_last = &self.octaves[oct - 1][Self::NUM_SCALES_PER_OCTAVE - 1];
+            let new_h = prev_last.rows >> 1;
+            let new_w = prev_last.cols >> 1;
+            if new_h < 5 || new_w < 5 {
+                arlog_e!(
+                    "GaussianScaleSpacePyramid::build: octave {oct} would be {new_h}x{new_w}; need >= 5x5"
+                );
+                return Err(GaussianPyramidError::OctaveTooSmall {
+                    octave: oct,
+                    rows: new_h,
+                    cols: new_w,
+                });
+            }
+            let l0 = downsample_bilinear_f32(prev_last);
+            let l1 = binomial_4th_order_f32_to_f32(&l0);
+            let l2_tmp = binomial_4th_order_f32_to_f32(&l1);
+            let l2 = binomial_4th_order_f32_to_f32(&l2_tmp);
+            self.octaves.push(vec![l0, l1, l2]);
+        }
+
+        Ok(())
+    }
+}
+
+/// Compute the number of octaves usable for a given image size, given the
+/// minimum coarsest-octave dimension.
+///
+/// C equivalent: `vision::numOctaves`.
+#[must_use]
+pub fn num_octaves_for(width: usize, height: usize, min_size: usize) -> usize {
+    let mut w = width;
+    let mut h = height;
+    let mut n = 0;
+    while w >= min_size && h >= min_size {
+        w >>= 1;
+        h >>= 1;
+        n += 1;
+    }
+    n
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Private filter helpers — byte-for-byte port of C++ `binomial_4th_order`
+// and `downsample_bilinear` from `gaussian_scale_space_pyramid.cpp`.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, u8 source → f32 dest.
+///
+/// H pass uses `u16` accumulator (max value `16 * 255 = 4080`, fits `u16`).
+/// V pass multiplies by `1 / 256` to yield `f32` output. Border replication:
+/// edge pixels extend the 2-pixel border on each side.
+///
+/// C equivalent: `vision::binomial_4th_order(float*, unsigned short*, const unsigned char*, ...)`.
+fn binomial_4th_order_u8_to_f32(src: &Matrix<u8>) -> Matrix<f32> {
+    let width = src.cols;
+    let height = src.rows;
+    debug_assert!(width >= 5 && height >= 5);
+
+    let src_data = src.as_slice();
+    let mut tmp = vec![0u16; width * height];
+
+    // Horizontal pass.
+    for row in 0..height {
+        let row_off = row * width;
+        let s = &src_data[row_off..row_off + width];
+        // col 0: xm2 = xm1 = c = s[0], xp1 = s[1], xp2 = s[2].
+        tmp[row_off] =
+            6 * s[0] as u16 + 4 * (s[0] as u16 + s[1] as u16) + (s[0] as u16 + s[2] as u16);
+        // col 1: xm2 = s[0], xm1 = s[0], c = s[1], xp1 = s[2], xp2 = s[3].
+        tmp[row_off + 1] =
+            6 * s[1] as u16 + 4 * (s[0] as u16 + s[2] as u16) + (s[0] as u16 + s[3] as u16);
+        // Non-border cols.
+        for col in 2..width - 2 {
+            tmp[row_off + col] = 6 * s[col] as u16
+                + 4 * (s[col - 1] as u16 + s[col + 1] as u16)
+                + (s[col - 2] as u16 + s[col + 2] as u16);
+        }
+        // col width-2: xp2 clamped to s[width-1].
+        let c = width - 2;
+        tmp[row_off + c] = 6 * s[c] as u16
+            + 4 * (s[c - 1] as u16 + s[c + 1] as u16)
+            + (s[c - 2] as u16 + s[c + 1] as u16);
+        // col width-1: xp1 = xp2 = s[width-1].
+        let c = width - 1;
+        tmp[row_off + c] =
+            6 * s[c] as u16 + 4 * (s[c - 1] as u16 + s[c] as u16) + (s[c - 2] as u16 + s[c] as u16);
+    }
+
+    // Vertical pass.
+    let mut dst_data = vec![0f32; width * height];
+    const INV_256: f32 = 1.0 / 256.0;
+
+    // Top border: rows 0 and 1.
+    for col in 0..width {
+        // row 0: pm2 = pm1 = p = tmp[col]; pp1 = tmp[width+col]; pp2 = tmp[2w+col].
+        let p = tmp[col] as u32;
+        let pp1 = tmp[width + col] as u32;
+        let pp2 = tmp[2 * width + col] as u32;
+        dst_data[col] = ((6 * p + 4 * (p + pp1) + p + pp2) as f32) * INV_256;
+        // row 1: pm2 = pm1 = tmp[col]; p = tmp[w+col]; pp1 = tmp[2w+col]; pp2 = tmp[3w+col].
+        let pm = tmp[col] as u32;
+        let p = tmp[width + col] as u32;
+        let pp1 = tmp[2 * width + col] as u32;
+        let pp2 = tmp[3 * width + col] as u32;
+        dst_data[width + col] = ((6 * p + 4 * (pm + pp1) + pm + pp2) as f32) * INV_256;
+    }
+
+    // Non-border rows.
+    for row in 2..height - 2 {
+        let row_off = row * width;
+        for col in 0..width {
+            let pm2 = tmp[(row - 2) * width + col] as u32;
+            let pm1 = tmp[(row - 1) * width + col] as u32;
+            let p = tmp[row_off + col] as u32;
+            let pp1 = tmp[(row + 1) * width + col] as u32;
+            let pp2 = tmp[(row + 2) * width + col] as u32;
+            dst_data[row_off + col] = ((6 * p + 4 * (pm1 + pp1) + pm2 + pp2) as f32) * INV_256;
+        }
+    }
+
+    // Bottom border: rows h-2 and h-1.
+    let h = height;
+    for col in 0..width {
+        // row h-2: pp1 = pp2 = tmp[(h-1)*w + col].
+        let pm2 = tmp[(h - 4) * width + col] as u32;
+        let pm1 = tmp[(h - 3) * width + col] as u32;
+        let p = tmp[(h - 2) * width + col] as u32;
+        let pp = tmp[(h - 1) * width + col] as u32;
+        dst_data[(h - 2) * width + col] = ((6 * p + 4 * (pm1 + pp) + pm2 + pp) as f32) * INV_256;
+        // row h-1: p = pp1 = pp2 = tmp[(h-1)*w + col].
+        let pm2 = tmp[(h - 3) * width + col] as u32;
+        let pm1 = tmp[(h - 2) * width + col] as u32;
+        let p = tmp[(h - 1) * width + col] as u32;
+        dst_data[(h - 1) * width + col] = ((6 * p + 4 * (pm1 + p) + pm2 + p) as f32) * INV_256;
+    }
+
+    Matrix::<f32>::from_vec(height, width, 1, dst_data)
+}
+
+/// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, f32 → f32. Used for
+/// the second and third levels within an octave and for all levels in
+/// non-zero octaves.
+///
+/// C equivalent: `vision::binomial_4th_order(float*, float*, const float*, ...)`.
+fn binomial_4th_order_f32_to_f32(src: &Matrix<f32>) -> Matrix<f32> {
+    let width = src.cols;
+    let height = src.rows;
+    debug_assert!(width >= 5 && height >= 5);
+
+    let src_data = src.as_slice();
+    let mut tmp = vec![0f32; width * height];
+
+    // Horizontal pass. Addition order matches C++ left-to-right exactly to
+    // preserve f32 bit-for-bit parity (no parenthesizing of the (ll + rr) term).
+    for row in 0..height {
+        let row_off = row * width;
+        let s = &src_data[row_off..row_off + width];
+        tmp[row_off] = 6.0 * s[0] + 4.0 * (s[0] + s[1]) + s[0] + s[2];
+        tmp[row_off + 1] = 6.0 * s[1] + 4.0 * (s[0] + s[2]) + s[0] + s[3];
+        for col in 2..width - 2 {
+            tmp[row_off + col] =
+                6.0 * s[col] + 4.0 * (s[col - 1] + s[col + 1]) + s[col - 2] + s[col + 2];
+        }
+        let c = width - 2;
+        tmp[row_off + c] = 6.0 * s[c] + 4.0 * (s[c - 1] + s[c + 1]) + s[c - 2] + s[c + 1];
+        let c = width - 1;
+        tmp[row_off + c] = 6.0 * s[c] + 4.0 * (s[c - 1] + s[c]) + s[c - 2] + s[c];
+    }
+
+    // Vertical pass.
+    let mut dst_data = vec![0f32; width * height];
+    const INV_256: f32 = 1.0 / 256.0;
+
+    for col in 0..width {
+        // row 0
+        let p = tmp[col];
+        let pp1 = tmp[width + col];
+        let pp2 = tmp[2 * width + col];
+        dst_data[col] = (6.0 * p + 4.0 * (p + pp1) + p + pp2) * INV_256;
+        // row 1
+        let pm = tmp[col];
+        let p = tmp[width + col];
+        let pp1 = tmp[2 * width + col];
+        let pp2 = tmp[3 * width + col];
+        dst_data[width + col] = (6.0 * p + 4.0 * (pm + pp1) + pm + pp2) * INV_256;
+    }
+
+    for row in 2..height - 2 {
+        let row_off = row * width;
+        for col in 0..width {
+            let pm2 = tmp[(row - 2) * width + col];
+            let pm1 = tmp[(row - 1) * width + col];
+            let p = tmp[row_off + col];
+            let pp1 = tmp[(row + 1) * width + col];
+            let pp2 = tmp[(row + 2) * width + col];
+            dst_data[row_off + col] = (6.0 * p + 4.0 * (pm1 + pp1) + pm2 + pp2) * INV_256;
+        }
+    }
+
+    let h = height;
+    for col in 0..width {
+        let pm2 = tmp[(h - 4) * width + col];
+        let pm1 = tmp[(h - 3) * width + col];
+        let p = tmp[(h - 2) * width + col];
+        let pp = tmp[(h - 1) * width + col];
+        dst_data[(h - 2) * width + col] = (6.0 * p + 4.0 * (pm1 + pp) + pm2 + pp) * INV_256;
+        let pm2 = tmp[(h - 3) * width + col];
+        let pm1 = tmp[(h - 2) * width + col];
+        let p = tmp[(h - 1) * width + col];
+        dst_data[(h - 1) * width + col] = (6.0 * p + 4.0 * (pm1 + p) + pm2 + p) * INV_256;
+    }
+
+    Matrix::<f32>::from_vec(height, width, 1, dst_data)
+}
+
+/// 2x2 bilinear downsample. Output dims: `(src.rows >> 1, src.cols >> 1)`.
+/// Per output pixel: `(p00 + p01 + p10 + p11) * 0.25`. No `ceil` adjustment
+/// (unlike the M8-1 box-filter pyramid).
+///
+/// C equivalent: `vision::downsample_bilinear`.
+fn downsample_bilinear_f32(src: &Matrix<f32>) -> Matrix<f32> {
+    let dst_w = src.cols >> 1;
+    let dst_h = src.rows >> 1;
+    let src_data = src.as_slice();
+    let src_w = src.cols;
+
+    let mut dst_data = Vec::<f32>::with_capacity(dst_w * dst_h);
+    for row in 0..dst_h {
+        let r0 = (row * 2) * src_w;
+        let r1 = r0 + src_w;
+        for col in 0..dst_w {
+            let c = col * 2;
+            let sum =
+                src_data[r0 + c] + src_data[r0 + c + 1] + src_data[r1 + c] + src_data[r1 + c + 1];
+            dst_data.push(sum * 0.25);
+        }
+    }
+    Matrix::<f32>::from_vec(dst_h, dst_w, 1, dst_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gradient_u8(rows: usize, cols: usize) -> Matrix<u8> {
+        let data: Vec<u8> = (0..rows * cols).map(|i| (i & 0xFF) as u8).collect();
+        Matrix::<u8>::from_vec(rows, cols, 1, data)
+    }
+
+    // ── Configuration sanity ─────────────────────────────────────────────
+
+    #[test]
+    fn test_kfactor_for_3_scales() {
+        let p = GaussianScaleSpacePyramid::new(1);
+        assert!(
+            (p.kfactor - 2f32.sqrt()).abs() < 1e-6,
+            "expected sqrt(2), got {}",
+            p.kfactor
+        );
+    }
+
+    #[test]
+    fn test_gaussian_pyramid_octave_count() {
+        let img = gradient_u8(64, 64);
+        let mut p = GaussianScaleSpacePyramid::new(3);
+        p.build(&img).unwrap();
+        assert_eq!(p.octaves.len(), 3);
+        for oct in &p.octaves {
+            assert_eq!(oct.len(), GaussianScaleSpacePyramid::NUM_SCALES_PER_OCTAVE);
+        }
+    }
+
+    #[test]
+    fn test_gaussian_pyramid_octave_downsamples() {
+        let img = gradient_u8(64, 64);
+        let mut p = GaussianScaleSpacePyramid::new(3);
+        p.build(&img).unwrap();
+        assert_eq!(p.level(0, 0).cols, 64);
+        assert_eq!(p.level(1, 0).cols, 32);
+        assert_eq!(p.level(2, 0).cols, 16);
+        assert_eq!(p.level(0, 0).rows, 64);
+        assert_eq!(p.level(1, 0).rows, 32);
+        assert_eq!(p.level(2, 0).rows, 16);
+    }
+
+    #[test]
+    fn test_gaussian_pyramid_sigma_increases() {
+        let p = GaussianScaleSpacePyramid::new(3);
+        // Within an octave: sigma grows by k each scale.
+        for oct in 0..3 {
+            for s in 0..2 {
+                assert!(
+                    p.effective_sigma(oct, s + 1) > p.effective_sigma(oct, s),
+                    "sigma did not increase within octave {oct} from scale {s} to {}",
+                    s + 1
+                );
+            }
+        }
+        // Across octaves: sigma doubles each octave at the same scale.
+        for s in 0..3 {
+            assert!(
+                p.effective_sigma(1, s) > p.effective_sigma(0, s),
+                "sigma did not increase from octave 0 to 1 at scale {s}"
+            );
+        }
+        // effective_sigma(0, 0) is the implicit base sigma == 1.0.
+        assert!((p.effective_sigma(0, 0) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_locate_clamps_to_pyramid_bounds() {
+        let p = GaussianScaleSpacePyramid::new(2);
+        // Very small sigma → (0, 0).
+        assert_eq!(p.locate(0.1), (0, 0));
+        // Very large sigma → last octave, last scale.
+        let (o, s) = p.locate(1000.0);
+        assert_eq!(o, 1);
+        assert_eq!(s, GaussianScaleSpacePyramid::NUM_SCALES_PER_OCTAVE - 1);
+    }
+
+    #[test]
+    fn test_gaussian_pyramid_build_is_idempotent() {
+        let img1 = gradient_u8(32, 32);
+        let img2 = gradient_u8(16, 16);
+        let mut p = GaussianScaleSpacePyramid::new(2);
+        p.build(&img1).unwrap();
+        p.build(&img2).unwrap();
+        assert_eq!(p.octaves.len(), 2);
+        // Reflects img2, not img1.
+        assert_eq!(p.level(0, 0).rows, 16);
+        assert_eq!(p.level(0, 0).cols, 16);
+    }
+
+    // ── Error variants ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_gaussian_pyramid_empty_image_returns_error() {
+        let img = Matrix::<u8>::zeros(0, 0, 1);
+        let mut p = GaussianScaleSpacePyramid::new(2);
+        assert_eq!(p.build(&img), Err(GaussianPyramidError::EmptyImage));
+    }
+
+    #[test]
+    fn test_gaussian_pyramid_image_too_small_returns_error() {
+        let img = gradient_u8(4, 4); // < 5
+        let mut p = GaussianScaleSpacePyramid::new(1);
+        assert!(matches!(
+            p.build(&img),
+            Err(GaussianPyramidError::ImageTooSmall { .. })
+        ));
+    }
+
+    #[test]
+    fn test_gaussian_pyramid_zero_octaves_returns_error() {
+        let img = gradient_u8(16, 16);
+        let mut p = GaussianScaleSpacePyramid::new(0);
+        assert_eq!(p.build(&img), Err(GaussianPyramidError::ZeroOctaves));
+    }
+
+    #[test]
+    fn test_num_octaves_for() {
+        // 64x64, min_size 8: 64→32→16→8→4 (stop because 4 < 8) → 4 octaves.
+        assert_eq!(num_octaves_for(64, 64, 8), 4);
+        // 100x50, min_size 16: limited by height. 50→25→12 (stop) → 2 octaves.
+        assert_eq!(num_octaves_for(100, 50, 16), 2);
+    }
+
+    // ── Dual-mode: byte-for-byte parity vs C++ ───────────────────────────
+
+    #[cfg(feature = "dual-mode")]
+    extern "C" {
+        fn webarkit_cpp_binomial_pyramid_build_level(
+            src: *const u8,
+            src_w: i32,
+            src_h: i32,
+            num_octaves: i32,
+            target_octave: i32,
+            target_scale: i32,
+            dst_out: *mut f32,
+            dst_capacity_floats: i32,
+        ) -> i32;
+    }
+
+    #[cfg(feature = "dual-mode")]
+    fn cpp_build_level(
+        src: &[u8],
+        src_w: usize,
+        src_h: usize,
+        num_octaves: usize,
+        target_octave: usize,
+        target_scale: usize,
+    ) -> Vec<f32> {
+        let lvl_w = src_w >> target_octave;
+        let lvl_h = src_h >> target_octave;
+        let mut dst = vec![0f32; lvl_w * lvl_h];
+        // SAFETY: src and dst are valid for the declared lengths; the C++
+        // shim checks capacity and copies row-by-row.
+        let rc = unsafe {
+            webarkit_cpp_binomial_pyramid_build_level(
+                src.as_ptr(),
+                src_w as i32,
+                src_h as i32,
+                num_octaves as i32,
+                target_octave as i32,
+                target_scale as i32,
+                dst.as_mut_ptr(),
+                dst.len() as i32,
+            )
+        };
+        assert_eq!(rc, 0, "C++ shim returned error {rc}");
+        dst
+    }
+
+    #[test]
+    #[cfg(feature = "dual-mode")]
+    fn test_gaussian_pyramid_pixels_match_cpp() {
+        let src_w = 32;
+        let src_h = 32;
+        let src = gradient_u8(src_h, src_w);
+        let num_octaves = 3;
+
+        let mut rust_pyr = GaussianScaleSpacePyramid::new(num_octaves);
+        rust_pyr.build(&src).unwrap();
+
+        for oct in 0..num_octaves {
+            for scale in 0..GaussianScaleSpacePyramid::NUM_SCALES_PER_OCTAVE {
+                let cpp = cpp_build_level(src.as_slice(), src_w, src_h, num_octaves, oct, scale);
+                let rust = rust_pyr.level(oct, scale).as_slice();
+                assert_eq!(rust.len(), cpp.len(), "size mismatch at ({oct}, {scale})");
+                for (i, (&r, &c)) in rust.iter().zip(cpp.iter()).enumerate() {
+                    assert_eq!(
+                        r.to_bits(),
+                        c.to_bits(),
+                        "f32 bit mismatch at ({oct}, {scale}) idx {i}: rust={r}, cpp={c}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/core/src/kpm/freak/hough.rs
+++ b/crates/core/src/kpm/freak/hough.rs
@@ -392,10 +392,6 @@ impl HoughSimilarityVoting {
 #[derive(Clone, Debug)]
 pub struct DoGScaleInvariantDetector;
 
-/// Placeholder for GaussianScaleSpacePyramid from M8.
-#[derive(Clone, Debug)]
-pub struct GaussianScaleSpacePyramid;
-
 /// Placeholder for Keyframe from M8.
 #[derive(Clone, Debug)]
 pub struct Keyframe {
@@ -448,7 +444,7 @@ pub struct HoughMatch {
 pub fn find_features(
     _keyframe: &mut Keyframe,
     _detector: &DoGScaleInvariantDetector,
-    _pyramid: &GaussianScaleSpacePyramid,
+    _pyramid: &super::gaussian_pyramid::GaussianScaleSpacePyramid,
 ) -> Result<(), KpmError> {
     arlog_i!("find_features: stub implementation (M8 pending)");
     Ok(())

--- a/crates/core/src/kpm/freak/interpolate.rs
+++ b/crates/core/src/kpm/freak/interpolate.rs
@@ -1,0 +1,181 @@
+/*
+ *  interpolate.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Bilinear interpolation utilities and pyramid coordinate mappings.
+//!
+//! Ported from `WebARKitLib/lib/SRC/KPM/FreakMatcher/detectors/interpolate.h`
+//! and the point-mapping helpers in
+//! `WebARKitLib/lib/SRC/KPM/FreakMatcher/detectors/gaussian_scale_space_pyramid.h`.
+//!
+//! The OOB returns `0.0` behavior is a Rust safety improvement over the C++
+//! `ASSERT`s; callers that need strict in-bounds checks can pre-validate.
+
+use purecv::core::Matrix;
+
+/// Bilinear interpolation at `(x, y)` on a `Matrix<u8>` level.
+///
+/// Returns `0.0` if `(x, y)` requires a neighbor pixel outside the image
+/// (i.e. `x < 0`, `y < 0`, `x + 1 >= cols`, or `y + 1 >= rows`).
+///
+/// C equivalent: `vision::bilinear_interpolation<unsigned char, float>`.
+#[inline(always)]
+pub fn bilinear_interpolate_u8(image: &Matrix<u8>, x: f32, y: f32) -> f32 {
+    bilinear_interpolate(image.as_slice(), image.cols, image.rows, x, y)
+}
+
+/// Bilinear interpolation at `(x, y)` on a `Matrix<f32>` level.
+///
+/// Returns `0.0` if `(x, y)` is out of bounds.
+///
+/// C equivalent: `vision::bilinear_interpolation<float, float>`.
+#[inline(always)]
+pub fn bilinear_interpolate_f32(image: &Matrix<f32>, x: f32, y: f32) -> f32 {
+    let cols = image.cols;
+    let rows = image.rows;
+    let x0 = x.floor() as i32;
+    let y0 = y.floor() as i32;
+    if x0 < 0 || y0 < 0 {
+        return 0.0;
+    }
+    let x0u = x0 as usize;
+    let y0u = y0 as usize;
+    if x0u + 1 >= cols || y0u + 1 >= rows {
+        return 0.0;
+    }
+    let dx = x - x0 as f32;
+    let dy = y - y0 as f32;
+    let data = image.as_slice();
+    let p00 = data[y0u * cols + x0u];
+    let p01 = data[y0u * cols + x0u + 1];
+    let p10 = data[(y0u + 1) * cols + x0u];
+    let p11 = data[(y0u + 1) * cols + x0u + 1];
+    (1.0 - dy) * ((1.0 - dx) * p00 + dx * p01) + dy * ((1.0 - dx) * p10 + dx * p11)
+}
+
+/// Bilinear interpolation on a raw row-major `&[u8]` buffer.
+///
+/// Used by FREAK descriptor sampling where the buffer may be a slice of a
+/// `Matrix<u8>` level. Returns `0.0` if `(x, y)` is out of bounds.
+#[inline(always)]
+pub fn bilinear_interpolate(data: &[u8], width: usize, height: usize, x: f32, y: f32) -> f32 {
+    let x0 = x.floor() as i32;
+    let y0 = y.floor() as i32;
+    if x0 < 0 || y0 < 0 {
+        return 0.0;
+    }
+    let x0u = x0 as usize;
+    let y0u = y0 as usize;
+    if x0u + 1 >= width || y0u + 1 >= height {
+        return 0.0;
+    }
+    let dx = x - x0 as f32;
+    let dy = y - y0 as f32;
+    let p00 = data[y0u * width + x0u] as f32;
+    let p01 = data[y0u * width + x0u + 1] as f32;
+    let p10 = data[(y0u + 1) * width + x0u] as f32;
+    let p11 = data[(y0u + 1) * width + x0u + 1] as f32;
+    (1.0 - dy) * ((1.0 - dx) * p00 + dx * p01) + dy * ((1.0 - dx) * p10 + dx * p11)
+}
+
+/// Map an octave-local point back to fine-image coordinates.
+///
+/// `xp = x * 2^octave + 2^(octave-1) - 0.5`, same for `yp`.
+///
+/// C equivalent: `vision::bilinear_upsample_point` (3-arg variant).
+#[inline(always)]
+#[must_use]
+pub fn bilinear_upsample_point(x: f32, y: f32, octave: i32) -> (f32, f32) {
+    let a = 2f32.powi(octave - 1) - 0.5;
+    let b = (1i32 << octave) as f32;
+    (x * b + a, y * b + a)
+}
+
+/// Map a fine-image point down to octave-local coordinates.
+///
+/// `xp = x / 2^octave + 1 / (2 * 2^octave) - 0.5`, same for `yp`.
+///
+/// C equivalent: `vision::bilinear_downsample_point` (3-arg variant).
+#[inline(always)]
+#[must_use]
+pub fn bilinear_downsample_point(x: f32, y: f32, octave: i32) -> (f32, f32) {
+    let a = 1.0 / (1i32 << octave) as f32;
+    let b = 0.5 * a - 0.5;
+    (x * a + b, y * a + b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gradient_u8(rows: usize, cols: usize) -> Matrix<u8> {
+        let data: Vec<u8> = (0..rows * cols).map(|i| (i & 0xFF) as u8).collect();
+        Matrix::<u8>::from_vec(rows, cols, 1, data)
+    }
+
+    #[test]
+    fn test_bilinear_interpolate_at_integer_coords() {
+        let img = gradient_u8(8, 8);
+        // pixel(y=2, x=3) = 2*8 + 3 = 19.
+        let v = bilinear_interpolate_u8(&img, 3.0, 2.0);
+        assert!((v - 19.0).abs() < 1e-4, "expected 19.0, got {v}");
+    }
+
+    #[test]
+    fn test_bilinear_interpolate_out_of_bounds_returns_zero() {
+        let img = gradient_u8(4, 4);
+        assert_eq!(bilinear_interpolate_u8(&img, -0.1, 1.0), 0.0);
+        assert_eq!(bilinear_interpolate_u8(&img, 1.0, -0.1), 0.0);
+        // x = 3.0 needs neighbor at col 4 (OOB; cols = 4).
+        assert_eq!(bilinear_interpolate_u8(&img, 3.0, 1.0), 0.0);
+        assert_eq!(bilinear_interpolate_u8(&img, 1.0, 3.0), 0.0);
+    }
+
+    #[test]
+    fn test_bilinear_interpolate_midpoint() {
+        // 2x2 image: [10, 20; 30, 40]. At (0.5, 0.5) = average = 25.
+        let img = Matrix::<u8>::from_vec(2, 2, 1, vec![10, 20, 30, 40]);
+        let v = bilinear_interpolate_u8(&img, 0.5, 0.5);
+        assert!((v - 25.0).abs() < 1e-4, "expected 25.0, got {v}");
+    }
+
+    #[test]
+    fn test_bilinear_upsample_downsample_roundtrip() {
+        let (xp, yp) = bilinear_upsample_point(10.0, 20.0, 2);
+        let (x_back, y_back) = bilinear_downsample_point(xp, yp, 2);
+        assert!((x_back - 10.0).abs() < 1e-4);
+        assert!((y_back - 20.0).abs() < 1e-4);
+    }
+}

--- a/crates/core/src/kpm/freak/mod.rs
+++ b/crates/core/src/kpm/freak/mod.rs
@@ -41,17 +41,24 @@
 //! implementation and optimized for performance.
 
 pub mod clustering;
+pub mod gaussian_pyramid;
 pub mod homography;
 pub mod hough;
+pub mod interpolate;
 pub mod matcher;
 pub mod math;
 pub mod pyramid;
 
 // Public re-exports for convenience
 pub use clustering::{hamming_distance_96, BhcNode, BinaryHierarchicalClustering, KMedoids};
+pub use gaussian_pyramid::{num_octaves_for, GaussianPyramidError, GaussianScaleSpacePyramid};
 pub use hough::{
     find_features, find_hough_matches, find_hough_similarity, BinParams, DoGScaleInvariantDetector,
-    FeaturePoint, GaussianScaleSpacePyramid, HoughMatch, HoughSimilarityVoting, Keyframe, Match,
+    FeaturePoint, HoughMatch, HoughSimilarityVoting, Keyframe, Match,
+};
+pub use interpolate::{
+    bilinear_downsample_point, bilinear_interpolate, bilinear_interpolate_f32,
+    bilinear_interpolate_u8, bilinear_upsample_point,
 };
 pub use matcher::{FeatureMatcher, FeatureStore};
 pub use pyramid::{Pyramid, PyramidError};

--- a/crates/core/src/kpm/kpm_c_api.cpp
+++ b/crates/core/src/kpm/kpm_c_api.cpp
@@ -56,6 +56,8 @@
 #include <math/linear_solvers.h>
 #include <math/rand.h>
 #include <homography_estimation/robust_homography.h>
+#include <detectors/gaussian_scale_space_pyramid.h>
+#include <framework/image.h>
 #include <Eigen/Core>
 #include <unsupported/Eigen/MatrixFunctions>
 
@@ -503,6 +505,57 @@ int webarkit_cpp_fast_random(int* seed) {
 
 void webarkit_cpp_array_shuffle(int* v, int pop_size, int sample_size, int* seed) {
     vision::ArrayShuffle<int>(v, pop_size, sample_size, *seed);
+}
+
+/* ---- Dual-mode validation: BinomialPyramid32f bridge (Milestone 8, #127) ---- */
+
+int webarkit_cpp_binomial_pyramid_build_level(
+    const unsigned char* src,
+    int src_w,
+    int src_h,
+    int num_octaves,
+    int target_octave,
+    int target_scale,
+    float* dst_out,
+    int dst_capacity_floats) {
+
+    if (!src || !dst_out || src_w < 5 || src_h < 5 || num_octaves < 1
+        || target_octave < 0 || target_octave >= num_octaves
+        || target_scale < 0 || target_scale >= 3) {
+        return 1;
+    }
+
+    const int lvl_w = src_w >> target_octave;
+    const int lvl_h = src_h >> target_octave;
+    if (lvl_w < 5 || lvl_h < 5) {
+        return 2;
+    }
+    if (dst_capacity_floats < lvl_w * lvl_h) {
+        return 3;
+    }
+
+    try {
+        vision::Image image(
+            const_cast<unsigned char*>(src), vision::IMAGE_UINT8,
+            src_w, src_h, src_w /* step */, 1);
+
+        vision::BinomialPyramid32f pyr;
+        pyr.alloc(src_w, src_h, num_octaves);
+        pyr.build(image);
+
+        const vision::Image& lvl = pyr.get(target_octave, target_scale);
+        const float* lvl_ptr = reinterpret_cast<const float*>(lvl.get());
+        const int lvl_step_floats = static_cast<int>(lvl.step() / sizeof(float));
+        for (int row = 0; row < lvl_h; ++row) {
+            std::memcpy(
+                dst_out + row * lvl_w,
+                lvl_ptr + row * lvl_step_floats,
+                static_cast<size_t>(lvl_w) * sizeof(float));
+        }
+        return 0;
+    } catch (...) {
+        return 4;
+    }
 }
 
 } // extern "C"

--- a/crates/core/src/kpm/kpm_c_api.h
+++ b/crates/core/src/kpm/kpm_c_api.h
@@ -239,6 +239,34 @@ int webarkit_cpp_match_features_guided(
 int  webarkit_cpp_fast_random(int* seed);
 void webarkit_cpp_array_shuffle(int* v, int pop_size, int sample_size, int* seed);
 
+/* ---- Dual-mode validation: BinomialPyramid32f bridge (Milestone 8, #127) ---- */
+
+/* Build a vision::BinomialPyramid32f from `src` (grayscale, src_w x src_h,
+ * row-major, tight stride) and copy the f32 level at (target_octave,
+ * target_scale) into `dst_out`.
+ *
+ * `num_octaves` is the pyramid depth.
+ * `target_octave` must be in [0, num_octaves); `target_scale` in [0, 3).
+ *
+ * The level (o, s) has size (src_w >> o) x (src_h >> o). The caller must
+ * provide `dst_capacity_floats` >= that product (in floats, not bytes).
+ *
+ * Returns:
+ *   0  success
+ *   1  validation error (null ptr, bad dims, out-of-range indices)
+ *   2  octave too small for binomial filter (< 5x5)
+ *   3  dst_capacity_floats too small for the requested level
+ *   4  C++ exception caught (ASSERT, std::exception, etc.) */
+int webarkit_cpp_binomial_pyramid_build_level(
+    const unsigned char* src,
+    int src_w,
+    int src_h,
+    int num_octaves,
+    int target_octave,
+    int target_scale,
+    float* dst_out,
+    int dst_capacity_floats);
+
 #ifdef __cplusplus
 }
 #endif

--- a/docs/design/m8-2-gaussian-pyramid.md
+++ b/docs/design/m8-2-gaussian-pyramid.md
@@ -164,4 +164,6 @@ Returns 0 on success; non-zero codes for validation failure, octave too small, b
 
 1. **purecv `Matrix<f32>` API parity with `Matrix<u8>`** — will verify before coding; minor adaptations possible.
 2. **f32 bit-for-bit parity** — relies on deterministic integer arithmetic + `* (1.0 / 256.0)`. If LLVM reassociates the binomial sum differently than the C++ compiler, parity could break. Mitigation: use the *exact* additive order from the C++ source (no commutative rewriting).
+
+   **Update (post-merge of M8-1, pre-merge of M8-2)**: This risk materialized on macOS. Apple clang on ARM64 emits FMA (fused multiply-add) instructions for the binomial filter expression by default, while MSVC (Windows) and GCC (Linux) do not. The result is a 1-ULP difference in C++ output between macOS and the other platforms. The dual-mode test was relaxed to ≤1 ULP tolerance — strict bit equality is impractical given cross-platform C++ FP contraction. The 1-ULP tolerance still catches any algorithm error while accommodating the platform variance. Local 1-ULP bugs (like the H-pass parenthesization caught during implementation) are still detected because they produce >1 ULP errors at higher scales.
 3. **FFI shim must compile cleanly on all CI targets** — including macOS (post-#117 libc++ fix) and the flaky macOS rust-cache (#134). If #134 isn't fixed, expect occasional CI re-runs.

--- a/docs/design/m8-2-gaussian-pyramid.md
+++ b/docs/design/m8-2-gaussian-pyramid.md
@@ -111,6 +111,53 @@ int webarkit_cpp_binomial_pyramid_build_level(
 
 Returns 0 on success; non-zero codes for validation failure, octave too small, buffer overflow, C++ exception.
 
+### 3.5 Bilinear interpolation formula
+
+Implemented verbatim as the issue spec requested in
+[`crates/core/src/kpm/freak/interpolate.rs:85`](../../crates/core/src/kpm/freak/interpolate.rs#L85)
+and
+[`crates/core/src/kpm/freak/interpolate.rs:110`](../../crates/core/src/kpm/freak/interpolate.rs#L110):
+
+```rust
+let dx = x - x0 as f32;
+let dy = y - y0 as f32;
+(1.0 - dy) * ((1.0 - dx) * p00 + dx * p01) + dy * ((1.0 - dx) * p10 + dx * p11)
+```
+
+Where `p00, p01, p10, p11` are the four neighbor pixels surrounding the
+sample point `(x, y)`, with `x0 = floor(x)` and `y0 = floor(y)`. Returns
+`0.0` when `(x, y)` requires a neighbor outside the image bounds (Rust
+safety improvement over the C++ `ASSERT`s).
+
+#### Relation to the C++ source
+
+The C++ in `interpolate.h` uses the equivalent 4-weight form:
+
+```cpp
+res = w0 * p00 + w1 * p01 + w2 * p10 + w3 * p11;
+// w0 = (xp_plus_1 - x) * (yp_plus_1 - y)   = (1 - dx) * (1 - dy)
+// w1 = (x - xp)        * (yp_plus_1 - y)   =      dx  * (1 - dy)
+// w2 = (xp_plus_1 - x) * (y - yp)          = (1 - dx) *      dy
+// w3 = (x - xp)        * (y - yp)          =      dx  *      dy
+```
+
+Algebraically identical to the factored Rust form. The factored form has
+**4 multiplications** (vs C++'s **8**) for the same result. For `f32`
+the two forms are not guaranteed to produce bit-identical output because
+floating-point addition is not associative, but the bilinear
+interpolation **is not part of the dual-mode parity test** — only the
+binomial filter is. The bilinear functions are exercised by
+`test_bilinear_interpolate_*` unit tests that assert values within a
+small tolerance.
+
+#### Single shared implementation
+
+`bilinear_interpolate_u8` does not duplicate the formula — it forwards
+to `bilinear_interpolate(image.as_slice(), image.cols, image.rows, x, y)`
+so the actual math lives in one place. `bilinear_interpolate_f32`
+duplicates the formula because it operates on `&Matrix<f32>` (different
+pixel type), but the structure is identical.
+
 ---
 
 ## 4. Assumptions

--- a/docs/design/m8-2-gaussian-pyramid.md
+++ b/docs/design/m8-2-gaussian-pyramid.md
@@ -1,0 +1,167 @@
+# Milestone 8 — Step 2: Bilinear Interpolation + Gaussian Scale-Space Pyramid
+
+**Status**: Design approved, ready for implementation
+**Branch**: `feat/m8-2-interpolate-gaussian-pyramid` (PR target: `feat/m8-freak-detector`)
+**Issue**: #127
+**Author**: Walter Perdan ([@kalwalt](https://github.com/kalwalt))
+**Date**: 2026-05-15
+
+---
+
+## 1. Understanding Summary
+
+- **What**: Port `interpolate.h` + `gaussian_scale_space_pyramid.{h,cpp}` to two new Rust modules:
+  - `crates/core/src/kpm/freak/interpolate.rs`
+  - `crates/core/src/kpm/freak/gaussian_pyramid.rs`
+- **Why**: Step 2 of Milestone 8. The Gaussian scale-space pyramid is the input to the DoG detector (M8-3); bilinear interpolation is used throughout the FREAK pipeline.
+- **Who**: Internal infrastructure consumed by M8-3 (DoG), M8-4 (FREAK descriptor), and downstream KPM matching.
+- **Success criterion**: `f32` pyramid output is byte-identical to C++ `BinomialPyramid32f::build`, verified by a live FFI dual-mode test (`#[cfg(feature = "dual-mode")]`).
+- **Non-goals (this PR)**: DoG detector, FREAK descriptor, SIMD/rayon optimization, harris.* dead code, fixture-based testing.
+
+---
+
+## 2. Decision Log
+
+| # | Decision | Alternatives considered | Rationale |
+|---|----------|-------------------------|-----------|
+| 1 | Faithful C++ port — `[1,4,6,4,1]/16` binomial filter, `Matrix<f32>` storage, 3 scales/octave hardcoded | True Gaussian with `ceil(3*sigma)*2+1` kernel + u8 storage; hybrid u8 storage with binomial filter | "Port" means preserve behavior. C++ uses a fixed binomial filter (not sigma-parameterized) and f32 storage. Bit-for-bit parity matters because M8-3 (DoG) was tuned against this exact output |
+| 2 | Port all helpers from the C++ header in this PR (`bilinear_upsample_point`, `bilinear_downsample_point`, `num_octaves_for`, `effective_sigma`, `kfactor`, `locate`) | Minimum surface only; defer point-mapping helpers to M8-3 | Same C++ header; M8-3 needs them; each is 5–20 lines; tests are trivial |
+| 3 | Split into 3 sibling modules: `pyramid.rs` (M8-1, existing) + `gaussian_pyramid.rs` (new) + `interpolate.rs` (new) | Everything in `pyramid.rs`; `pyramid.rs` + one new file | Mirrors C++ file organization; keeps each file focused; interpolation is reusable independent of any pyramid type |
+| 4 | Live FFI dual-mode test (existing project pattern) | Pre-generated binary fixture file in `tests/fixtures/` | Matches PRs #76, #77, clustering test; no binary blob in git; output always current vs C++ baseline |
+| 5 | Per-level FFI shim: `webarkit_cpp_binomial_pyramid_build_level(...)` | Whole-pyramid shim with array of buffers | Simpler C-ABI; one rebuild per test call is negligible cost for a 32×32 input |
+| 6 | Constructor `new(num_octaves: usize)` only — drop `num_levels` and `sigma_0` from original prompt | Original prompt: `new(num_octaves, num_levels, sigma_0)` | C++ `BinomialPyramid32f` hardcodes 3 scales (build sequence is 3-specific). Sigma is *derived*: `sigma(oct, scale) = k^scale * 2^oct` with `k = 2^(1/(num_scales-1))` |
+| 7 | `build(&mut self, image: &Matrix<u8>) -> Result<(), GaussianPyramidError>`; idempotent (clear & rebuild) | C++ `void` signature; non-idempotent | Mirrors M8-1; project "log + return Err" idiom (CLAUDE.md §1) |
+| 8 | `NUM_SCALES_PER_OCTAVE = 3` exposed as public `const` | Magic number; constructor parameter | Avoids magic number in callers; documents the C++ contract |
+| 9 | Bilinear API: 3 concrete fns (u8/f32/raw-slice), `f32` return for u8 input, OOB → `0.0` | Generic-over-T with trait; literal C++ u8-returns-u8 | Matches prompt; preserves precision; safer than C++ `ASSERT`s |
+
+---
+
+## 3. Final API
+
+### 3.1 `interpolate.rs`
+
+```rust
+pub fn bilinear_interpolate_u8(image: &Matrix<u8>, x: f32, y: f32) -> f32;
+pub fn bilinear_interpolate_f32(image: &Matrix<f32>, x: f32, y: f32) -> f32;
+pub fn bilinear_interpolate(data: &[u8], width: usize, height: usize, x: f32, y: f32) -> f32;
+pub fn bilinear_upsample_point(x: f32, y: f32, octave: i32) -> (f32, f32);
+pub fn bilinear_downsample_point(x: f32, y: f32, octave: i32) -> (f32, f32);
+```
+
+Formula: `result = (1-dy) * ((1-dx) * p00 + dx * p01) + dy * ((1-dx) * p10 + dx * p11)`
+where `dx = x - floor(x)`, `dy = y - floor(y)`.
+
+### 3.2 `gaussian_pyramid.rs`
+
+```rust
+pub struct GaussianScaleSpacePyramid {
+    pub octaves: Vec<Vec<Matrix<f32>>>,
+    pub num_octaves: usize,
+    pub kfactor: f32,
+    pub one_over_log_k: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GaussianPyramidError {
+    EmptyImage,
+    ImageTooSmall { rows: usize, cols: usize },
+    ZeroOctaves,
+    OctaveTooSmall { octave: usize, rows: usize, cols: usize },
+}
+
+impl GaussianScaleSpacePyramid {
+    pub const NUM_SCALES_PER_OCTAVE: usize = 3;
+
+    pub fn new(num_octaves: usize) -> Self;
+    pub fn build(&mut self, image: &Matrix<u8>) -> Result<(), GaussianPyramidError>;
+    pub fn level(&self, octave: usize, scale: usize) -> &Matrix<f32>;
+    pub fn num_scales_per_octave(&self) -> usize;
+    pub fn effective_sigma(&self, octave: usize, scale: usize) -> f32;
+    pub fn locate(&self, sigma: f32) -> (usize, usize);
+}
+
+pub fn num_octaves_for(width: usize, height: usize, min_size: usize) -> usize;
+```
+
+### 3.3 Build sequence (per C++ `BinomialPyramid32f::build`)
+
+- **Octave 0**:
+  - `octaves[0][0] = filter(input)` — u8 → f32
+  - `octaves[0][1] = filter(octaves[0][0])` — f32 → f32
+  - `octaves[0][2] = filter(filter(octaves[0][1]))` — 2 applications
+- **Octave i (i > 0)**:
+  - `octaves[i][0] = downsample(octaves[i-1][2])` — half-size, bilinear 2×2 average
+  - `octaves[i][1] = filter(octaves[i][0])`
+  - `octaves[i][2] = filter(filter(octaves[i][1]))`
+
+Filter coefficients (separable):
+- **H pass**: `6c + 4(l+r) + (ll+rr)` (u16 accumulator for u8 src, f32 for f32 src)
+- **V pass**: same shape × `1/256`
+- **Border**: replicate edge pixels for 2-pixel border
+
+### 3.4 FFI shim (`kpm_c_api.h/.cpp`)
+
+```c
+int webarkit_cpp_binomial_pyramid_build_level(
+    const uint8_t* src, int src_w, int src_h,
+    int num_octaves,
+    int target_octave, int target_scale,
+    float* dst_out, int dst_capacity_floats);
+```
+
+Returns 0 on success; non-zero codes for validation failure, octave too small, buffer overflow, C++ exception.
+
+---
+
+## 4. Assumptions
+
+1. `purecv 0.4.0` supports `Matrix<f32>` with the same surface as `Matrix<u8>`. Will verify before coding.
+2. The H pass output max is `16 × 255 = 4080` (fits `u16`); V pass output `* 1/256` is exactly representable in `f32`, so bit-for-bit parity with C++ is achievable.
+3. C++ `Image` may have row stride > width when `AUTO_STEP` aligns; FFI shim copies row-by-row using `lvl.step() / sizeof(float)`.
+4. `apply_filter_twice` shared-buffer optimization in C++ does not affect output (filter is deterministic); Rust port allocates a fresh intermediate buffer per pass — same final bytes.
+5. Test data: synthetic gradient (`pixel = (r * cols + c) & 0xFF`); no fixture files in git.
+6. License header: `.claude/HEADER.txt`, year 2026.
+7. No `CHANGELOG.md` edits (release-only).
+
+---
+
+## 5. Test Plan
+
+### 5.1 `interpolate.rs` (4 tests)
+
+- `test_bilinear_interpolate_at_integer_coords`
+- `test_bilinear_interpolate_out_of_bounds_returns_zero`
+- `test_bilinear_interpolate_midpoint` — verifies `(0.5, 0.5)` produces average of 4 corners
+- `test_bilinear_upsample_downsample_roundtrip`
+
+### 5.2 `gaussian_pyramid.rs` (9 unit tests + 1 dual-mode)
+
+- `test_kfactor_for_3_scales` — `kfactor ≈ √2`
+- `test_gaussian_pyramid_octave_count`
+- `test_gaussian_pyramid_octave_downsamples` — `level(oct, 0).cols == src_cols >> oct`
+- `test_gaussian_pyramid_sigma_increases` — within and across octaves
+- `test_locate_clamps_to_pyramid_bounds`
+- `test_gaussian_pyramid_build_is_idempotent`
+- `test_gaussian_pyramid_empty_image_returns_error`
+- `test_gaussian_pyramid_image_too_small_returns_error`
+- `test_gaussian_pyramid_zero_octaves_returns_error`
+- `test_num_octaves_for`
+- `test_gaussian_pyramid_pixels_match_cpp` (`#[cfg(feature = "dual-mode")]`) — byte-for-byte `f32::to_bits()` parity at all (octave, scale) levels for a 32×32 gradient input
+
+**Verification**: `cargo test -p webarkitlib-rs -- kpm::freak` + `cargo test -p webarkitlib-rs --lib --features dual-mode`.
+
+---
+
+## 6. Follow-up Work (Out of Scope This PR)
+
+- **M8-3**: DoG scale-invariant detector (will consume this pyramid)
+- **M8-4**: FREAK descriptor extraction
+- **Perf**: criterion benchmark, then SIMD path for the binomial filter (file a follow-up issue analogous to #131/#132 for `Pyramid` once this lands)
+
+---
+
+## 7. Open Risks
+
+1. **purecv `Matrix<f32>` API parity with `Matrix<u8>`** — will verify before coding; minor adaptations possible.
+2. **f32 bit-for-bit parity** — relies on deterministic integer arithmetic + `* (1.0 / 256.0)`. If LLVM reassociates the binomial sum differently than the C++ compiler, parity could break. Mitigation: use the *exact* additive order from the C++ source (no commutative rewriting).
+3. **FFI shim must compile cleanly on all CI targets** — including macOS (post-#117 libc++ fix) and the flaky macOS rust-cache (#134). If #134 isn't fixed, expect occasional CI re-runs.


### PR DESCRIPTION
## Summary

Step 2 of **Milestone 8** (FREAK descriptor & DoG detector). Ports the C++ bilinear interpolation utilities and the binomial Gaussian scale-space pyramid (`BinomialPyramid32f`) from `WebARKitLib/lib/SRC/KPM/FreakMatcher/detectors/` to two new Rust modules under `crates/core/src/kpm/freak/`.

The Gaussian pyramid is the input to the DoG detector (next M8 step); the bilinear interpolation is used throughout the FREAK pipeline.

**Refs**: #125, #127
**Base**: `feat/m8-freak-detector` (M8 integration branch)
**Builds on**: #130 (M8-1 box-filter pyramid)

## What's in this PR

- **New**: `crates/core/src/kpm/freak/interpolate.rs` — 5 free functions (3 bilinear + 2 point-mapping) + 4 unit tests
- **New**: `crates/core/src/kpm/freak/gaussian_pyramid.rs` — `GaussianScaleSpacePyramid` struct + binomial filter + downsample + `locate` + 10 unit tests + 1 dual-mode FFI parity test
- **Edit**: `crates/core/src/kpm/freak/mod.rs` — module declarations + re-exports
- **Edit**: `crates/core/src/kpm/freak/hough.rs` — replace M8 placeholder `GaussianScaleSpacePyramid` struct with the real type; update `find_features` stub signature
- **Edit**: `crates/core/src/kpm/kpm_c_api.{h,cpp}` — new FFI shim `webarkit_cpp_binomial_pyramid_build_level` (~75 lines) for dual-mode testing
- **New**: `docs/design/m8-2-gaussian-pyramid.md` — full design document with decision log

## Algorithm

5-tap separable `[1, 4, 6, 4, 1]` binomial filter, ported byte-for-byte from C++ `binomial_4th_order`:

- **H pass**: `6*c + 4*(l+r) + ll + rr` (u16 accumulator for u8 src, f32 for f32 src)
- **V pass**: same shape × `1/256` normalization (yields f32 output)
- **Border**: replicate edge pixels for the 2-pixel border on each side

**Build sequence** per octave (matches `BinomialPyramid32f::build`):
- `level[0] = filter(input)`
- `level[1] = filter(level[0])`
- `level[2] = filter(filter(level[1]))` — two applications
- Octave (i>0) bridges via 2×2 bilinear downsample of `octaves[i-1][2]`

## Design Decisions

See `docs/design/m8-2-gaussian-pyramid.md` for the full decision log (9 entries). Highlights:

| Decision | Rationale |
|----------|-----------|
| Faithful C++ port — `[1,4,6,4,1]/16` binomial filter, `Matrix<f32>` storage, 3 scales/octave hardcoded | Original prompt called for a sigma-parameterized Gaussian with u8 storage; the C++ does neither. Bit-for-bit parity matters because M8-3 (DoG) was tuned against this exact output |
| Constructor takes only `num_octaves` (drops `num_levels` and `sigma_0` from original prompt) | C++ hardcodes 3 scales; sigma is derived via `k = 2^(1/2)` |
| Split into 3 sibling modules (`pyramid.rs` / `gaussian_pyramid.rs` / `interpolate.rs`) | Mirrors C++ file organization; keeps each file focused; interpolation is reusable |
| Live FFI dual-mode test (not pre-generated fixture) | Matches established project pattern (PRs #76, #77, clustering); no binary blob in git; output always current vs C++ |
| Per-level FFI shim | Simpler C-ABI than whole-pyramid; one rebuild per test call is negligible cost for 32×32 input |
| `build()` returns `Result<(), GaussianPyramidError>`; idempotent | Mirrors M8-1; project "log + return Err" idiom |

## One bug caught during implementation

The first dual-mode test run failed with a **1 ULP f32 drift** at `(octave=1, scale=1)`:

```
assertion `left == right` failed: f32 bit mismatch at (1, 1) idx 0: rust=58.472332, cpp=58.47233
```

**Root cause**: my Rust H pass wrote `+ (s[col-2] + s[col+2])` (parenthesized) while C++ writes `+ src[col-2] + src[col+2]` (left-to-right). f32 addition is not associative — the two reduction trees produced different bit patterns.

**Fix**: dropped the parens; matched C++ left-to-right addition exactly. Bit-for-bit parity restored.

This is precisely the risk the design doc flagged in §7 "Open Risks":

> 2. f32 bit-for-bit parity — relies on deterministic integer arithmetic + `* (1.0 / 256.0)`. If LLVM reassociates the binomial sum differently than the C++ compiler, parity could break. Mitigation: use the *exact* additive order from the C++ source (no commutative rewriting).

## What's NOT in this PR (intentional)

- **DoG detector** (M8 step 3 — uses this pyramid)
- **FREAK descriptor extraction** (M8 step 4)
- **Harris detector** — dead code from the removed SURF pipeline
- **SIMD/rayon** — defer to follow-up perf PR analogous to #131/#132

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build -p webarkitlib-rs` — clean
- [x] `cargo clippy` on new modules — zero issues
- [x] `cargo test -p webarkitlib-rs --lib -- kpm::freak::{interpolate,gaussian_pyramid}` — **14 passed, 0 failed**
- [x] `cargo test -p webarkitlib-rs --lib --features dual-mode -- ...pixels_match_cpp` — **bit-for-bit C++ parity confirmed** at all 9 levels (3 octaves × 3 scales)

```
running 15 tests
test kpm::freak::gaussian_pyramid::tests::test_gaussian_pyramid_empty_image_returns_error ... ok
test kpm::freak::gaussian_pyramid::tests::test_gaussian_pyramid_image_too_small_returns_error ... ok
test kpm::freak::gaussian_pyramid::tests::test_gaussian_pyramid_build_is_idempotent ... ok
test kpm::freak::gaussian_pyramid::tests::test_gaussian_pyramid_zero_octaves_returns_error ... ok
test kpm::freak::gaussian_pyramid::tests::test_gaussian_pyramid_sigma_increases ... ok
test kpm::freak::interpolate::tests::test_bilinear_interpolate_midpoint ... ok
test kpm::freak::gaussian_pyramid::tests::test_num_octaves_for ... ok
test kpm::freak::interpolate::tests::test_bilinear_interpolate_at_integer_coords ... ok
test kpm::freak::gaussian_pyramid::tests::test_kfactor_for_3_scales ... ok
test kpm::freak::gaussian_pyramid::tests::test_locate_clamps_to_pyramid_bounds ... ok
test kpm::freak::interpolate::tests::test_bilinear_interpolate_out_of_bounds_returns_zero ... ok
test kpm::freak::interpolate::tests::test_bilinear_upsample_downsample_roundtrip ... ok
test kpm::freak::gaussian_pyramid::tests::test_gaussian_pyramid_pixels_match_cpp ... ok
test kpm::freak::gaussian_pyramid::tests::test_gaussian_pyramid_octave_downsamples ... ok
test kpm::freak::gaussian_pyramid::tests::test_gaussian_pyramid_octave_count ... ok

test result: ok. 15 passed; 0 failed
```

## Reviewer checklist

- [x] Binomial filter coefficients match C++ `binomial_4th_order` (H: `6c + 4(l+r) + ll + rr`, V: same × `1/256`)
- [x] Border handling replicates edge pixels exactly as C++
- [x] f32 addition order is left-to-right (no parens around `ll + rr`)
- [x] `effective_sigma(0, 0) == 1.0` (implicit base sigma)
- [x] `kfactor == sqrt(2)` for 3 scales/octave
- [x] LGPL header present on both new files
- [x] No `println!` / `eprintln!` in library code (uses `arlog_e!` / `arlog_w!`)
- [x] `CHANGELOG.md` not touched (release-only rule)
- [x] Branch targets `feat/m8-freak-detector` (M8 integration branch), not `dev`
- [x] FFI shim correctly handles `Image::step()` stride (row-by-row memcpy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)