### PR TITLE
feat(kpm): port DoG detector + OrientationAssignment to Rust (M8 step 3)

### DIFF
--- a/crates/core/src/kpm/freak/detector.rs
+++ b/crates/core/src/kpm/freak/detector.rs
@@ -1196,6 +1196,11 @@ mod tests {
     fn test_dog_keypoints_match_cpp_count() {
         // Tolerance covers sort tie-breaking and bucket ordering variance
         // only. Any algorithm-level error would dwarf this.
+        //
+        // Empirical local result (Windows MSVC, clean rebuild): |diff| = 0.
+        // The tolerance is kept at 5 to absorb potential cross-platform
+        // FP variance (Linux GCC / macOS Apple clang) before tightening
+        // to exact match in a follow-up if CI shows consistent equality.
         const MAX_TIE_DIVERGENCE: i32 = 5;
 
         let img = load_grayscale("../../benchmarks/data/found.jpg");
@@ -1227,6 +1232,68 @@ mod tests {
         assert!(
             diff <= MAX_TIE_DIVERGENCE,
             "keypoint count divergence: rust={rust_count}, cpp={cpp_count}, |diff|={diff} > {MAX_TIE_DIVERGENCE}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "dual-mode")]
+    fn test_dog_keypoints_match_cpp_count_with_orientation() {
+        // Companion to `test_dog_keypoints_match_cpp_count` with
+        // `find_orientation = true`, exercising the OrientationAssignment
+        // gradient-histogram step.
+        //
+        // Why the tolerance is wider (10 vs 5):
+        //   1. Each keypoint can produce *multiple* DoGFeaturePoint copies
+        //      (one per dominant orientation peak >= 0.8 · max_height).
+        //      Tie-breaking at the peak threshold boundary multiplies any
+        //      f32 rounding variance.
+        //   2. The orientation smoothing kernel
+        //      `[0.274068619061197, 0.451862761877606, ...]` sums to
+        //      exactly 1.0 in f64 but its f32 representation may differ
+        //      by 1 ULP between platforms. Five smoothing iterations
+        //      compound that variance.
+        //   3. Bucket pruning runs before orientation in C++, so the
+        //      pre-orientation count is bounded by max_pts. Post-
+        //      orientation, the count can exceed max_pts (each keypoint
+        //      contributing 1..N orientations).
+        //
+        // Empirical local result (Windows MSVC, clean rebuild): |diff| = 0.
+        // The orientation step did NOT introduce any divergence on this
+        // image, contrary to the speculative concern that the 1-ULP
+        // SMOOTH_KERNEL change might shift peak detection. The tolerance
+        // is set to 10 (vs 5 for orientation-off) to absorb potential
+        // cross-platform variance in the orientation gradient histogram.
+        const MAX_TIE_DIVERGENCE: i32 = 10;
+
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let num_octaves = 3;
+        let laplacian_threshold = 0.0;
+        let edge_threshold = 10.0;
+        let max_pts = 5000;
+        let find_orientation = true;
+
+        let pyr = build_test_pyramid(&img, num_octaves);
+        let det = DoGScaleInvariantDetector::new(
+            laplacian_threshold,
+            edge_threshold,
+            max_pts,
+            find_orientation,
+        );
+        let rust_count = det.detect(&pyr).len() as i32;
+
+        let cpp_count = cpp_detect_count(
+            &img,
+            num_octaves,
+            laplacian_threshold,
+            edge_threshold,
+            max_pts,
+            find_orientation,
+        );
+
+        let diff = (rust_count - cpp_count).abs();
+        assert!(
+            diff <= MAX_TIE_DIVERGENCE,
+            "with-orientation keypoint count divergence: rust={rust_count}, cpp={cpp_count}, |diff|={diff} > {MAX_TIE_DIVERGENCE}"
         );
     }
 }

--- a/crates/core/src/kpm/freak/detector.rs
+++ b/crates/core/src/kpm/freak/detector.rs
@@ -1,0 +1,1232 @@
+/*
+ *  detector.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Scale-invariant keypoint detector based on the Difference-of-Gaussians
+//! (DoG) of the Gaussian scale-space pyramid.
+//!
+//! Ported from `WebARKitLib/.../detectors/DoG_scale_invariant_detector.{h,cpp}`.
+//! Uses 3D extrema in the DoG scale-space, Lowe-style sub-pixel refinement
+//! via the 3×3 Hessian (with cross-octave variants when extrema straddle
+//! octave boundaries), edge-curvature rejection, bucket-based spatial
+//! pruning for keypoint diversity, and gradient-histogram orientation
+//! assignment.
+//!
+//! ## Pipeline (matches C++ `DoGScaleInvariantDetector::detect`)
+//!
+//! 1. Build DoG pyramid: `dog[s] = pyramid[s] - pyramid[s+1]` (less-blurred
+//!    minus more-blurred).
+//! 2. 3D extrema across the DoG flat-indexed image stack (3 spatial-pattern
+//!    variants for cross-octave neighbours).
+//! 3. Sub-pixel refinement via 3×3 Hessian solve, with cross-octave
+//!    variants.
+//! 4. Edge-curvature rejection (`(Dxx+Dyy)² / det`).
+//! 5. Bucket-based spatial pruning (best-K per bucket).
+//! 6. Orientation assignment via [`OrientationAssignment`] (only if
+//!    `find_orientation == true`).
+
+// Private extrema-extraction helpers below take many parameters by design:
+// they receive the three laplacian slices, dimension context, and dispatch
+// metadata. Grouping into a struct would obscure the parallel structure
+// with the three C++ inline expansions of `NONMAX_CHECK`.
+#![allow(clippy::too_many_arguments)]
+// solve_3x3 implements Gaussian elimination on a 3×3 augmented matrix.
+// Index-based iteration mirrors standard textbook formulations and stays
+// clearer than iterator-based equivalents for this size.
+#![allow(clippy::needless_range_loop)]
+
+use crate::arlog_w;
+use purecv::core::Matrix;
+
+use super::gaussian_pyramid::GaussianScaleSpacePyramid;
+use super::hough::FeaturePoint;
+use super::interpolate::{
+    bilinear_downsample_point, bilinear_interpolate_f32, bilinear_upsample_point,
+};
+use super::orientation::{compute_polar_gradient_image, OrientationAssignment};
+
+/// Number of DoG levels per octave. With 3 Gaussian scales per octave,
+/// adjacent pairs produce `3 - 1 = 2` DoG levels.
+pub const NUM_DOG_PER_OCTAVE: usize = GaussianScaleSpacePyramid::NUM_SCALES_PER_OCTAVE - 1;
+
+/// A keypoint detected by [`DoGScaleInvariantDetector`].
+///
+/// This is the detector's working type, carrying refinement diagnostics
+/// the FREAK descriptor (M8-4) needs to sample the right pyramid level.
+/// For storage in the visual database (Hough voting, FREAK matching), use
+/// the [`From<&DoGFeaturePoint>`] projection to [`FeaturePoint`].
+///
+/// C equivalent: `vision::DoGScaleInvariantDetector::FeaturePoint`.
+///
+/// Note: `(x, y)` are stored in **fine-image** coordinates (after
+/// `bilinear_upsample_point`), matching C++ `mFeaturePoints[i].x/y`.
+#[derive(Debug, Clone, Copy)]
+pub struct DoGFeaturePoint {
+    /// Sub-pixel x in the fine image.
+    pub x: f32,
+    /// Sub-pixel y in the fine image.
+    pub y: f32,
+    /// Dominant orientation in radians, in [0, 2π). Zero if
+    /// `find_orientation == false` at detection time.
+    pub angle: f32,
+    /// Octave index in the source pyramid.
+    pub octave: i32,
+    /// Integer DoG-scale index within the octave (0..NUM_DOG_PER_OCTAVE).
+    pub scale: i32,
+    /// Sub-pixel scale value: `scale + u[2]` from refinement, clipped to
+    /// `[0, NUM_DOG_PER_OCTAVE]`. Matches C++ `kp.sp_scale`.
+    pub sp_scale: f32,
+    /// Refined DoG response (signed). `score >= 0` ⇒ local maximum,
+    /// `score < 0` ⇒ local minimum.
+    pub score: f32,
+    /// Characteristic Gaussian sigma after refinement:
+    /// `effective_sigma(octave, sp_scale)`.
+    pub sigma: f32,
+    /// Edge-curvature score from `compute_edge_score`. Lower magnitude =
+    /// more corner-like; rejected if `|edge_score| ≥ (et + 1)² / et`.
+    pub edge_score: f32,
+}
+
+impl From<&DoGFeaturePoint> for FeaturePoint {
+    fn from(d: &DoGFeaturePoint) -> Self {
+        FeaturePoint {
+            x: d.x,
+            y: d.y,
+            angle: d.angle,
+            scale: d.sigma, // persistent type holds characteristic radius
+            maxima: d.score >= 0.0,
+        }
+    }
+}
+
+/// Scale-invariant keypoint detector.
+///
+/// C equivalent: `vision::DoGScaleInvariantDetector`.
+///
+/// **Defaults**: matches the C++ constructor (lines 108-119 of
+/// `DoG_scale_invariant_detector.cpp`):
+/// - `laplacian_threshold = 0` (no contrast filter by default)
+/// - `edge_threshold = 10` (Hessian threshold = `(10+1)²/10 = 12.1`)
+/// - `max_subpixel_distance_sqr = 9` (`3*3`; reject if `‖δ‖² > 9`)
+/// - `num_buckets_x = num_buckets_y = 10`
+/// - `find_orientation = true`
+/// - `max_num_feature_points = 5000`
+pub struct DoGScaleInvariantDetector {
+    laplacian_threshold: f32,
+    edge_threshold: f32,
+    max_subpixel_distance_sqr: f32,
+    num_buckets_x: usize,
+    num_buckets_y: usize,
+    max_num_feature_points: usize,
+    find_orientation: bool,
+    orientation_assignment: OrientationAssignment,
+}
+
+impl DoGScaleInvariantDetector {
+    /// Maximum keypoint cap; matches C++ `kMaxNumFeaturePoints = 5000`.
+    pub const DEFAULT_MAX_NUM_FEATURE_POINTS: usize = 5000;
+
+    /// Construct with config. Other parameters take FREAK defaults.
+    #[must_use]
+    pub fn new(
+        laplacian_threshold: f32,
+        edge_threshold: f32,
+        max_num_feature_points: usize,
+        find_orientation: bool,
+    ) -> Self {
+        debug_assert!(edge_threshold > 0.0, "edge_threshold must be positive");
+        Self {
+            laplacian_threshold,
+            edge_threshold,
+            max_subpixel_distance_sqr: 9.0, // C++ 3*3
+            num_buckets_x: 10,
+            num_buckets_y: 10,
+            max_num_feature_points,
+            find_orientation,
+            orientation_assignment: OrientationAssignment::new(),
+        }
+    }
+
+    /// Detect scale-invariant feature points in the Gaussian pyramid.
+    #[must_use]
+    pub fn detect(&self, pyramid: &GaussianScaleSpacePyramid) -> Vec<DoGFeaturePoint> {
+        if pyramid.num_octaves == 0 {
+            arlog_w!("DoGScaleInvariantDetector::detect: pyramid has zero octaves");
+            return Vec::new();
+        }
+
+        // (a) Build the DoG pyramid (flat-indexed).
+        let dog = build_dog_pyramid_flat(pyramid);
+        if dog.len() < 3 {
+            // Need at least one interior DoG index for 3D extrema.
+            return Vec::new();
+        }
+
+        // (b) Extract minima/maxima with cross-octave dimension dispatch.
+        let mut points = extract_features(&dog, pyramid, self.laplacian_threshold);
+
+        // (c, d, e) Sub-pixel refinement + edge rejection.
+        refine_subpixel_locations(
+            &mut points,
+            &dog,
+            pyramid,
+            self.laplacian_threshold,
+            self.edge_threshold,
+            self.max_subpixel_distance_sqr,
+        );
+
+        // (f) Bucket pruning (BEFORE orientation, matches C++).
+        let fine_w = pyramid.level(0, 0).cols;
+        let fine_h = pyramid.level(0, 0).rows;
+        let points = prune_features_bucketed(
+            points,
+            fine_w,
+            fine_h,
+            self.num_buckets_x,
+            self.num_buckets_y,
+            self.max_num_feature_points,
+        );
+
+        // (g) Orientation assignment.
+        if self.find_orientation {
+            assign_orientations(points, pyramid, &self.orientation_assignment)
+        } else {
+            points
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// DoG pyramid construction
+// ──────────────────────────────────────────────────────────────────────
+
+/// Build the flat-indexed DoG pyramid.
+///
+/// `dog[octave * NUM_DOG_PER_OCTAVE + s]` for `s` in
+/// `0..NUM_DOG_PER_OCTAVE`. Each entry is a `Matrix<f32>` with the same
+/// dimensions as the source octave.
+///
+/// **DoG direction**: `dog[s] = pyramid[s] - pyramid[s+1]` (less-blurred
+/// minus more-blurred), matching C++ `difference_image_binomial`.
+fn build_dog_pyramid_flat(pyramid: &GaussianScaleSpacePyramid) -> Vec<Matrix<f32>> {
+    let mut dog = Vec::with_capacity(pyramid.num_octaves * NUM_DOG_PER_OCTAVE);
+    for oct in 0..pyramid.num_octaves {
+        for s in 0..NUM_DOG_PER_OCTAVE {
+            dog.push(dog_image(pyramid.level(oct, s), pyramid.level(oct, s + 1)));
+        }
+    }
+    dog
+}
+
+/// Per-pixel difference image: `dst = a - b`.
+fn dog_image(a: &Matrix<f32>, b: &Matrix<f32>) -> Matrix<f32> {
+    debug_assert!(a.rows == b.rows && a.cols == b.cols);
+    let data: Vec<f32> = a
+        .as_slice()
+        .iter()
+        .zip(b.as_slice().iter())
+        .map(|(av, bv)| av - bv)
+        .collect();
+    Matrix::<f32>::from_vec(a.rows, a.cols, 1, data)
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Extrema extraction
+// ──────────────────────────────────────────────────────────────────────
+
+fn extract_features(
+    dog: &[Matrix<f32>],
+    pyramid: &GaussianScaleSpacePyramid,
+    laplacian_threshold: f32,
+) -> Vec<DoGFeaturePoint> {
+    let lap_sqr_threshold = laplacian_threshold * laplacian_threshold;
+    let mut out: Vec<DoGFeaturePoint> = Vec::new();
+
+    for i in 1..(dog.len() - 1) {
+        let im0 = &dog[i - 1];
+        let im1 = &dog[i];
+        let im2 = &dog[i + 1];
+
+        let octave = (i / NUM_DOG_PER_OCTAVE) as i32;
+        let scale = (i % NUM_DOG_PER_OCTAVE) as i32;
+
+        let same = im0.cols == im1.cols
+            && im0.cols == im2.cols
+            && im0.rows == im1.rows
+            && im0.rows == im2.rows;
+        let fine_octave_pair = im0.cols == im1.cols
+            && (im1.cols >> 1) == im2.cols
+            && im0.rows == im1.rows
+            && (im1.rows >> 1) == im2.rows;
+        let coarse_octave_pair = (im0.cols >> 1) == im1.cols
+            && im1.cols == im2.cols
+            && (im0.rows >> 1) == im1.rows
+            && im1.rows == im2.rows;
+
+        if same {
+            extract_features_same_octave(
+                &mut out,
+                im0,
+                im1,
+                im2,
+                octave,
+                scale,
+                pyramid,
+                lap_sqr_threshold,
+            );
+        } else if fine_octave_pair {
+            extract_features_fine_octave_pair(
+                &mut out,
+                im0,
+                im1,
+                im2,
+                octave,
+                scale,
+                pyramid,
+                lap_sqr_threshold,
+            );
+        } else if coarse_octave_pair {
+            extract_features_coarse_octave_pair(
+                &mut out,
+                im0,
+                im1,
+                im2,
+                octave,
+                scale,
+                pyramid,
+                lap_sqr_threshold,
+            );
+        } else {
+            arlog_w!("extract_features: inconsistent DoG dimensions at index {i}; skipping");
+        }
+    }
+
+    out
+}
+
+#[inline]
+fn nonmax_same_octave(
+    op: NonMaxOp,
+    val: f32,
+    im0: &[f32],
+    im1: &[f32],
+    im2: &[f32],
+    w: usize,
+    row: usize,
+    col: usize,
+) -> bool {
+    let i0 = (row - 1) * w + col - 1;
+    let i1 = (row - 1) * w + col;
+    let i2 = (row - 1) * w + col + 1;
+    let j0 = row * w + col - 1;
+    let j1 = row * w + col;
+    let j2 = row * w + col + 1;
+    let k0 = (row + 1) * w + col - 1;
+    let k1 = (row + 1) * w + col;
+    let k2 = (row + 1) * w + col + 1;
+    let cmp = |a: f32, b: f32| match op {
+        NonMaxOp::Greater => a > b,
+        NonMaxOp::Less => a < b,
+    };
+    // im0 (9)
+    cmp(val, im0[i0]) && cmp(val, im0[i1]) && cmp(val, im0[i2])
+        && cmp(val, im0[j0]) && cmp(val, im0[j1]) && cmp(val, im0[j2])
+        && cmp(val, im0[k0]) && cmp(val, im0[k1]) && cmp(val, im0[k2])
+        // im1 (8, skip center)
+        && cmp(val, im1[i0]) && cmp(val, im1[i1]) && cmp(val, im1[i2])
+        && cmp(val, im1[j0]) && cmp(val, im1[j2])
+        && cmp(val, im1[k0]) && cmp(val, im1[k1]) && cmp(val, im1[k2])
+        // im2 (9)
+        && cmp(val, im2[i0]) && cmp(val, im2[i1]) && cmp(val, im2[i2])
+        && cmp(val, im2[j0]) && cmp(val, im2[j1]) && cmp(val, im2[j2])
+        && cmp(val, im2[k0]) && cmp(val, im2[k1]) && cmp(val, im2[k2])
+}
+
+#[derive(Copy, Clone)]
+enum NonMaxOp {
+    Greater,
+    Less,
+}
+
+fn extract_features_same_octave(
+    out: &mut Vec<DoGFeaturePoint>,
+    im0: &Matrix<f32>,
+    im1: &Matrix<f32>,
+    im2: &Matrix<f32>,
+    octave: i32,
+    scale: i32,
+    pyramid: &GaussianScaleSpacePyramid,
+    lap_sqr_threshold: f32,
+) {
+    let w = im1.cols;
+    let h = im1.rows;
+    if w < 3 || h < 3 {
+        return;
+    }
+    let d0 = im0.as_slice();
+    let d1 = im1.as_slice();
+    let d2 = im2.as_slice();
+    for row in 1..(h - 1) {
+        for col in 1..(w - 1) {
+            let value = d1[row * w + col];
+            if value * value < lap_sqr_threshold {
+                continue;
+            }
+            let extrema = nonmax_same_octave(NonMaxOp::Greater, value, d0, d1, d2, w, row, col)
+                || nonmax_same_octave(NonMaxOp::Less, value, d0, d1, d2, w, row, col);
+            if extrema {
+                push_extremum(out, pyramid, octave, scale, col as f32, row as f32, value);
+            }
+        }
+    }
+}
+
+fn extract_features_fine_octave_pair(
+    out: &mut Vec<DoGFeaturePoint>,
+    im0: &Matrix<f32>,
+    im1: &Matrix<f32>,
+    im2: &Matrix<f32>,
+    octave: i32,
+    scale: i32,
+    pyramid: &GaussianScaleSpacePyramid,
+    lap_sqr_threshold: f32,
+) {
+    // im0/im1 same size as octave; im2 half size (next coarser octave).
+    let w = im1.cols;
+    let h = im1.rows;
+    if w < 3 || h < 3 {
+        return;
+    }
+    let d0 = im0.as_slice();
+    let d1 = im1.as_slice();
+    // C++ loop bounds: end_x = floor(((im2.width-1) - 0.5) * 2 + 0.5), same for y.
+    // Conservative: stop at w-2 / h-2 (interior).
+    let end_x = (((im2.cols as f32 - 1.0) - 0.5) * 2.0 + 0.5).floor() as usize;
+    let end_y = (((im2.rows as f32 - 1.0) - 0.5) * 2.0 + 0.5).floor() as usize;
+    let end_x = end_x.min(w - 1);
+    let end_y = end_y.min(h - 1);
+
+    for row in 2..end_y {
+        for col in 2..end_x {
+            let value = d1[row * w + col];
+            if value * value < lap_sqr_threshold {
+                continue;
+            }
+
+            let ds_x = col as f32 * 0.5 - 0.25;
+            let ds_y = row as f32 * 0.5 - 0.25;
+
+            let extrema = nonmax_fine_octave(
+                NonMaxOp::Greater,
+                value,
+                d0,
+                d1,
+                im2,
+                w,
+                row,
+                col,
+                ds_x,
+                ds_y,
+            ) || nonmax_fine_octave(
+                NonMaxOp::Less,
+                value,
+                d0,
+                d1,
+                im2,
+                w,
+                row,
+                col,
+                ds_x,
+                ds_y,
+            );
+            if extrema {
+                push_extremum(out, pyramid, octave, scale, col as f32, row as f32, value);
+            }
+        }
+    }
+}
+
+#[inline]
+fn nonmax_fine_octave(
+    op: NonMaxOp,
+    val: f32,
+    im0: &[f32],
+    im1: &[f32],
+    im2: &Matrix<f32>,
+    w: usize,
+    row: usize,
+    col: usize,
+    ds_x: f32,
+    ds_y: f32,
+) -> bool {
+    let cmp = |a: f32, b: f32| match op {
+        NonMaxOp::Greater => a > b,
+        NonMaxOp::Less => a < b,
+    };
+    let i_off = (row - 1) * w + col;
+    let j_off = row * w + col;
+    let k_off = (row + 1) * w + col;
+    // im0 (9)
+    cmp(val, im0[i_off - 1]) && cmp(val, im0[i_off]) && cmp(val, im0[i_off + 1])
+        && cmp(val, im0[j_off - 1]) && cmp(val, im0[j_off]) && cmp(val, im0[j_off + 1])
+        && cmp(val, im0[k_off - 1]) && cmp(val, im0[k_off]) && cmp(val, im0[k_off + 1])
+        // im1 (8)
+        && cmp(val, im1[i_off - 1]) && cmp(val, im1[i_off]) && cmp(val, im1[i_off + 1])
+        && cmp(val, im1[j_off - 1]) && cmp(val, im1[j_off + 1])
+        && cmp(val, im1[k_off - 1]) && cmp(val, im1[k_off]) && cmp(val, im1[k_off + 1])
+        // im2 (9, bilinear)
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x - 0.5, ds_y - 0.5))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x, ds_y - 0.5))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x + 0.5, ds_y - 0.5))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x - 0.5, ds_y))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x, ds_y))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x + 0.5, ds_y))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x - 0.5, ds_y + 0.5))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x, ds_y + 0.5))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x + 0.5, ds_y + 0.5))
+}
+
+fn extract_features_coarse_octave_pair(
+    out: &mut Vec<DoGFeaturePoint>,
+    im0: &Matrix<f32>,
+    im1: &Matrix<f32>,
+    im2: &Matrix<f32>,
+    octave: i32,
+    scale: i32,
+    pyramid: &GaussianScaleSpacePyramid,
+    lap_sqr_threshold: f32,
+) {
+    // im0 double size (previous finer octave); im1/im2 at this octave.
+    let w = im1.cols;
+    let h = im1.rows;
+    if w < 3 || h < 3 {
+        return;
+    }
+    let d1 = im1.as_slice();
+    let d2 = im2.as_slice();
+
+    for row in 1..(h - 1) {
+        for col in 1..(w - 1) {
+            let value = d1[row * w + col];
+            if value * value < lap_sqr_threshold {
+                continue;
+            }
+
+            let us_x = (col << 1) as f32 + 0.5;
+            let us_y = (row << 1) as f32 + 0.5;
+
+            let extrema = nonmax_coarse_octave(
+                NonMaxOp::Greater,
+                value,
+                im0,
+                d1,
+                d2,
+                w,
+                row,
+                col,
+                us_x,
+                us_y,
+            ) || nonmax_coarse_octave(
+                NonMaxOp::Less,
+                value,
+                im0,
+                d1,
+                d2,
+                w,
+                row,
+                col,
+                us_x,
+                us_y,
+            );
+            if extrema {
+                push_extremum(out, pyramid, octave, scale, col as f32, row as f32, value);
+            }
+        }
+    }
+}
+
+#[inline]
+fn nonmax_coarse_octave(
+    op: NonMaxOp,
+    val: f32,
+    im0: &Matrix<f32>,
+    im1: &[f32],
+    im2: &[f32],
+    w: usize,
+    row: usize,
+    col: usize,
+    us_x: f32,
+    us_y: f32,
+) -> bool {
+    let cmp = |a: f32, b: f32| match op {
+        NonMaxOp::Greater => a > b,
+        NonMaxOp::Less => a < b,
+    };
+    let i_off = (row - 1) * w + col;
+    let j_off = row * w + col;
+    let k_off = (row + 1) * w + col;
+    // im1 (8)
+    cmp(val, im1[i_off - 1]) && cmp(val, im1[i_off]) && cmp(val, im1[i_off + 1])
+        && cmp(val, im1[j_off - 1]) && cmp(val, im1[j_off + 1])
+        && cmp(val, im1[k_off - 1]) && cmp(val, im1[k_off]) && cmp(val, im1[k_off + 1])
+        // im2 (9)
+        && cmp(val, im2[i_off - 1]) && cmp(val, im2[i_off]) && cmp(val, im2[i_off + 1])
+        && cmp(val, im2[j_off - 1]) && cmp(val, im2[j_off]) && cmp(val, im2[j_off + 1])
+        && cmp(val, im2[k_off - 1]) && cmp(val, im2[k_off]) && cmp(val, im2[k_off + 1])
+        // im0 (9, bilinear at double-scale)
+        && cmp(val, bilinear_interpolate_f32(im0, us_x - 2.0, us_y - 2.0))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x, us_y - 2.0))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x + 2.0, us_y - 2.0))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x - 2.0, us_y))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x, us_y))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x + 2.0, us_y))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x - 2.0, us_y + 2.0))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x, us_y + 2.0))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x + 2.0, us_y + 2.0))
+}
+
+#[inline]
+fn push_extremum(
+    out: &mut Vec<DoGFeaturePoint>,
+    pyramid: &GaussianScaleSpacePyramid,
+    octave: i32,
+    scale: i32,
+    col: f32,
+    row: f32,
+    value: f32,
+) {
+    let (fx, fy) = bilinear_upsample_point(col, row, octave);
+    out.push(DoGFeaturePoint {
+        x: fx,
+        y: fy,
+        angle: 0.0,
+        octave,
+        scale,
+        sp_scale: scale as f32,
+        score: value,
+        sigma: pyramid.effective_sigma(octave as usize, scale as usize),
+        edge_score: 0.0,
+    });
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Sub-pixel refinement
+// ──────────────────────────────────────────────────────────────────────
+
+fn refine_subpixel_locations(
+    points: &mut Vec<DoGFeaturePoint>,
+    dog: &[Matrix<f32>],
+    pyramid: &GaussianScaleSpacePyramid,
+    laplacian_threshold: f32,
+    edge_threshold: f32,
+    max_subpixel_distance_sqr: f32,
+) {
+    let lap_sqr = laplacian_threshold * laplacian_threshold;
+    let hessian_threshold = (edge_threshold + 1.0).powi(2) / edge_threshold;
+    let fine_w = pyramid.level(0, 0).cols as f32;
+    let fine_h = pyramid.level(0, 0).rows as f32;
+
+    let mut write = 0usize;
+    for i in 0..points.len() {
+        let kp = points[i];
+        let lap_index = (kp.octave as usize) * NUM_DOG_PER_OCTAVE + (kp.scale as usize);
+
+        if lap_index == 0 || lap_index + 1 >= dog.len() {
+            continue; // need lap0 and lap2
+        }
+
+        // Downsample fine-image (x, y) to octave-local coords.
+        let (xp, yp) = bilinear_downsample_point(kp.x, kp.y, kp.octave);
+        let x = (xp + 0.5) as i32;
+        let y = (yp + 0.5) as i32;
+
+        let lap0 = &dog[lap_index - 1];
+        let lap1 = &dog[lap_index];
+        let lap2 = &dog[lap_index + 1];
+
+        if x < 1 || (x + 1) as usize >= lap1.cols || y < 1 || (y + 1) as usize >= lap1.rows {
+            continue;
+        }
+
+        let Some((a, b)) = compute_subpixel_hessian(lap0, lap1, lap2, x, y) else {
+            continue;
+        };
+
+        let Some(u) = solve_3x3(&a, &b) else {
+            continue;
+        };
+
+        if u[0] * u[0] + u[1] * u[1] > max_subpixel_distance_sqr {
+            continue;
+        }
+
+        let Some(edge_score) = compute_edge_score(&a) else {
+            continue;
+        };
+
+        // Refined DoG response: linear correction using the gradient.
+        let center_val = lap1.as_slice()[(y as usize) * lap1.cols + (x as usize)];
+        let refined_score = center_val - (b[0] * u[0] + b[1] * u[1] + b[2] * u[2]);
+
+        // Sub-pixel scale (full value, clipped to [0, num_dog]).
+        let mut sp_scale = kp.scale as f32 + u[2];
+        sp_scale = sp_scale.clamp(0.0, NUM_DOG_PER_OCTAVE as f32);
+
+        // Upsample refined location to fine-image coords.
+        let (fx, fy) = bilinear_upsample_point(xp + u[0], yp + u[1], kp.octave);
+
+        if edge_score.abs() < hessian_threshold
+            && refined_score * refined_score >= lap_sqr
+            && fx >= 0.0
+            && fx < fine_w
+            && fy >= 0.0
+            && fy < fine_h
+        {
+            let sigma = pyramid_effective_sigma_fractional(pyramid, kp.octave, sp_scale);
+            points[write] = DoGFeaturePoint {
+                x: fx,
+                y: fy,
+                angle: 0.0,
+                octave: kp.octave,
+                scale: kp.scale,
+                sp_scale,
+                score: refined_score,
+                sigma,
+                edge_score,
+            };
+            write += 1;
+        }
+    }
+    points.truncate(write);
+}
+
+/// Linearly interpolate `effective_sigma` along sub-pixel scale.
+fn pyramid_effective_sigma_fractional(
+    pyramid: &GaussianScaleSpacePyramid,
+    octave: i32,
+    sp_scale: f32,
+) -> f32 {
+    // sigma(octave, scale) = k^scale · 2^octave.
+    pyramid.kfactor.powf(sp_scale) * (1u32 << (octave as usize)) as f32
+}
+
+/// Dispatch to one of three Hessian variants based on dimension pattern.
+fn compute_subpixel_hessian(
+    lap0: &Matrix<f32>,
+    lap1: &Matrix<f32>,
+    lap2: &Matrix<f32>,
+    x: i32,
+    y: i32,
+) -> Option<([f32; 9], [f32; 3])> {
+    if lap0.cols == lap1.cols
+        && lap1.cols == lap2.cols
+        && lap0.rows == lap1.rows
+        && lap1.rows == lap2.rows
+    {
+        Some(hessian_same_octave(
+            lap0, lap1, lap2, x as usize, y as usize,
+        ))
+    } else if lap0.cols == lap1.cols
+        && (lap1.cols >> 1) == lap2.cols
+        && lap0.rows == lap1.rows
+        && (lap1.rows >> 1) == lap2.rows
+    {
+        Some(hessian_fine_octave_pair(
+            lap0, lap1, lap2, x as usize, y as usize,
+        ))
+    } else if (lap0.cols >> 1) == lap1.cols
+        && lap1.cols == lap2.cols
+        && (lap0.rows >> 1) == lap1.rows
+        && lap1.rows == lap2.rows
+    {
+        Some(hessian_coarse_octave_pair(
+            lap0, lap1, lap2, x as usize, y as usize,
+        ))
+    } else {
+        None
+    }
+}
+
+/// Spatial derivatives at (x, y) in `im` (interior pixel only).
+#[inline]
+fn spatial_derivatives(im: &Matrix<f32>, x: usize, y: usize) -> (f32, f32, f32, f32, f32) {
+    let w = im.cols;
+    let d = im.as_slice();
+    let p = d[y * w + x];
+    let p_left = d[y * w + x - 1];
+    let p_right = d[y * w + x + 1];
+    let p_up = d[(y - 1) * w + x];
+    let p_dn = d[(y + 1) * w + x];
+    let p_ul = d[(y - 1) * w + x - 1];
+    let p_ur = d[(y - 1) * w + x + 1];
+    let p_dl = d[(y + 1) * w + x - 1];
+    let p_dr = d[(y + 1) * w + x + 1];
+
+    let dx = 0.5 * (p_right - p_left);
+    let dy = 0.5 * (p_dn - p_up);
+    let dxx = p_left - 2.0 * p + p_right;
+    let dyy = p_up - 2.0 * p + p_dn;
+    let dxy = 0.25 * ((p_ul + p_dr) - (p_ur + p_dl));
+    (dx, dy, dxx, dyy, dxy)
+}
+
+fn hessian_same_octave(
+    lap0: &Matrix<f32>,
+    lap1: &Matrix<f32>,
+    lap2: &Matrix<f32>,
+    x: usize,
+    y: usize,
+) -> ([f32; 9], [f32; 3]) {
+    let (dx, dy, dxx, dyy, dxy) = spatial_derivatives(lap1, x, y);
+    let w = lap1.cols;
+    let l0 = lap0.as_slice();
+    let l2 = lap2.as_slice();
+    let l1c = lap1.as_slice()[y * w + x];
+    let l0c = l0[y * w + x];
+    let l2c = l2[y * w + x];
+    let ds = 0.5 * (l2c - l0c);
+    let dss = l0c + (-2.0 * l1c) + l2c;
+    let dxs =
+        0.25 * ((l0[y * w + x - 1] - l0[y * w + x + 1]) + (-l2[y * w + x - 1] + l2[y * w + x + 1]));
+    let dys = 0.25
+        * ((l0[(y - 1) * w + x] - l0[(y + 1) * w + x])
+            + (-l2[(y - 1) * w + x] + l2[(y + 1) * w + x]));
+    let h = [dxx, dxy, dxs, dxy, dyy, dys, dxs, dys, dss];
+    let b = [-dx, -dy, -ds];
+    (h, b)
+}
+
+fn hessian_fine_octave_pair(
+    lap0: &Matrix<f32>,
+    lap1: &Matrix<f32>,
+    lap2: &Matrix<f32>,
+    x: usize,
+    y: usize,
+) -> ([f32; 9], [f32; 3]) {
+    let (dx, dy, dxx, dyy, dxy) = spatial_derivatives(lap1, x, y);
+    let w = lap1.cols;
+    let l1c = lap1.as_slice()[y * w + x];
+
+    // lap2 is half-sized (next coarser octave).
+    let (x_div2, y_div2) = bilinear_downsample_point(x as f32, y as f32, 1);
+    let val = bilinear_interpolate_f32(lap2, x_div2, y_div2);
+
+    let l0 = lap0.as_slice();
+
+    // C++ uses lap2 (coarser octave) at (x_div2 ± 0.5, y_div2 ± 0.5).
+    let lap2_px_pos = bilinear_interpolate_f32(lap2, x_div2 + 0.5, y_div2);
+    let lap2_px_neg = bilinear_interpolate_f32(lap2, x_div2 - 0.5, y_div2);
+    let lap2_py_pos = bilinear_interpolate_f32(lap2, x_div2, y_div2 + 0.5);
+    let lap2_py_neg = bilinear_interpolate_f32(lap2, x_div2, y_div2 - 0.5);
+
+    let ds = 0.5 * (val - l0[y * w + x]);
+    let dss = l0[y * w + x] + (-2.0 * l1c) + val;
+    let dxs = 0.25 * ((l0[y * w + x - 1] + lap2_px_pos) - (l0[y * w + x + 1] + lap2_px_neg));
+    let dys = 0.25 * ((l0[(y - 1) * w + x] + lap2_py_pos) - (l0[(y + 1) * w + x] + lap2_py_neg));
+    let h = [dxx, dxy, dxs, dxy, dyy, dys, dxs, dys, dss];
+    let b = [-dx, -dy, -ds];
+    (h, b)
+}
+
+fn hessian_coarse_octave_pair(
+    lap0: &Matrix<f32>,
+    lap1: &Matrix<f32>,
+    lap2: &Matrix<f32>,
+    x: usize,
+    y: usize,
+) -> ([f32; 9], [f32; 3]) {
+    let (dx, dy, dxx, dyy, dxy) = spatial_derivatives(lap1, x, y);
+    let w = lap1.cols;
+    let l1c = lap1.as_slice()[y * w + x];
+
+    // lap0 is double-sized (previous finer octave).
+    let (x_mul2, y_mul2) = bilinear_upsample_point(x as f32, y as f32, 1);
+    let val = bilinear_interpolate_f32(lap0, x_mul2, y_mul2);
+
+    let l2 = lap2.as_slice();
+
+    let lap0_px_pos = bilinear_interpolate_f32(lap0, x_mul2 - 2.0, y_mul2);
+    let lap0_px_neg = bilinear_interpolate_f32(lap0, x_mul2 + 2.0, y_mul2);
+    let lap0_py_pos = bilinear_interpolate_f32(lap0, x_mul2, y_mul2 - 2.0);
+    let lap0_py_neg = bilinear_interpolate_f32(lap0, x_mul2, y_mul2 + 2.0);
+
+    let ds = 0.5 * (l2[y * w + x] - val);
+    let dss = val + (-2.0 * l1c) + l2[y * w + x];
+    let dxs = 0.25 * ((lap0_px_pos + l2[y * w + x + 1]) - (lap0_px_neg + l2[y * w + x - 1]));
+    let dys = 0.25 * ((lap0_py_pos + l2[(y + 1) * w + x]) - (lap0_py_neg + l2[(y - 1) * w + x]));
+    let h = [dxx, dxy, dxs, dxy, dyy, dys, dxs, dys, dss];
+    let b = [-dx, -dy, -ds];
+    (h, b)
+}
+
+/// Edge-curvature score. Returns `None` if the 2×2 determinant is zero.
+fn compute_edge_score(h: &[f32; 9]) -> Option<f32> {
+    let dxx = h[0];
+    let dxy = h[1];
+    let dyy = h[4];
+    let det = dxx * dyy - dxy * dxy;
+    if det == 0.0 {
+        return None;
+    }
+    Some((dxx + dyy).powi(2) / det)
+}
+
+/// Solve a 3×3 linear system via Gaussian elimination with partial
+/// pivoting. Returns `None` on near-singular matrices.
+fn solve_3x3(a: &[f32; 9], b: &[f32; 3]) -> Option<[f32; 3]> {
+    let mut m = [
+        [a[0], a[1], a[2], b[0]],
+        [a[3], a[4], a[5], b[1]],
+        [a[6], a[7], a[8], b[2]],
+    ];
+    // Forward elimination with pivoting.
+    for k in 0..3 {
+        // Find pivot.
+        let mut max_row = k;
+        let mut max_val = m[k][k].abs();
+        for i in (k + 1)..3 {
+            let v = m[i][k].abs();
+            if v > max_val {
+                max_val = v;
+                max_row = i;
+            }
+        }
+        if max_val < 1e-12 {
+            return None;
+        }
+        if max_row != k {
+            m.swap(k, max_row);
+        }
+        for i in (k + 1)..3 {
+            let factor = m[i][k] / m[k][k];
+            for j in k..4 {
+                m[i][j] -= factor * m[k][j];
+            }
+        }
+    }
+    // Back substitution.
+    let mut x = [0.0f32; 3];
+    for i in (0..3).rev() {
+        let mut sum = m[i][3];
+        for j in (i + 1)..3 {
+            sum -= m[i][j] * x[j];
+        }
+        x[i] = sum / m[i][i];
+    }
+    Some(x)
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Bucket pruning
+// ──────────────────────────────────────────────────────────────────────
+
+/// Distribute keypoints across an `nx × ny` spatial grid (on the
+/// fine-image coordinates) and keep the top-K per bucket where
+/// `K = max_total / (nx * ny)`.
+///
+/// C equivalent: `vision::PruneDoGFeatures` (uses `std::nth_element`
+/// per bucket).
+fn prune_features_bucketed(
+    points: Vec<DoGFeaturePoint>,
+    fine_w: usize,
+    fine_h: usize,
+    nx: usize,
+    ny: usize,
+    max_total: usize,
+) -> Vec<DoGFeaturePoint> {
+    if points.len() <= max_total {
+        return points;
+    }
+    let num_buckets = nx * ny;
+    if num_buckets == 0 {
+        return points;
+    }
+    let num_per_bucket = max_total / num_buckets;
+    if num_per_bucket == 0 {
+        return points;
+    }
+    let dx = (fine_w as f32 / nx as f32).ceil().max(1.0) as usize;
+    let dy = (fine_h as f32 / ny as f32).ceil().max(1.0) as usize;
+
+    let mut buckets: Vec<Vec<(f32, usize)>> = vec![Vec::new(); num_buckets];
+    for (i, p) in points.iter().enumerate() {
+        let bx = ((p.x as usize) / dx).min(nx - 1);
+        let by = ((p.y as usize) / dy).min(ny - 1);
+        buckets[bx * ny + by].push((p.score.abs(), i));
+    }
+
+    let mut out = Vec::with_capacity(max_total);
+    for mut bucket in buckets {
+        let bucket_len = bucket.len();
+        let n = bucket_len.min(num_per_bucket);
+        if n == 0 {
+            continue;
+        }
+        // Partial sort descending by |score|. select_nth_unstable_by
+        // partitions so that bucket[0..pivot] are all >= bucket[pivot..],
+        // where pivot = n - 1. After the call, the top-n entries occupy
+        // positions 0..n (in unspecified internal order).
+        let pivot = (n - 1).min(bucket_len - 1);
+        bucket.select_nth_unstable_by(pivot, |a, b| {
+            b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
+        });
+        for k in 0..n {
+            out.push(points[bucket[k].1]);
+        }
+    }
+    out
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Orientation assignment
+// ──────────────────────────────────────────────────────────────────────
+
+fn assign_orientations(
+    refined: Vec<DoGFeaturePoint>,
+    pyramid: &GaussianScaleSpacePyramid,
+    oa: &OrientationAssignment,
+) -> Vec<DoGFeaturePoint> {
+    let num_scales = GaussianScaleSpacePyramid::NUM_SCALES_PER_OCTAVE;
+    // Precompute gradient images for every (octave, scale).
+    let mut gradients: Vec<Matrix<f32>> = Vec::with_capacity(pyramid.num_octaves * num_scales);
+    for oct in 0..pyramid.num_octaves {
+        for scale in 0..num_scales {
+            gradients.push(compute_polar_gradient_image(pyramid.level(oct, scale)));
+        }
+    }
+
+    let mut out = Vec::with_capacity(refined.len());
+    for kp in &refined {
+        // Downsample fine-image (x, y, sigma) to octave-local for OA.
+        let inv = 1.0 / (1u32 << (kp.octave as usize)) as f32;
+        let off = 0.5 * inv - 0.5;
+        let mut x_oct = kp.x * inv + off;
+        let mut y_oct = kp.y * inv + off;
+        let sigma_oct = kp.sigma * inv;
+
+        // Clip to octave bounds.
+        let g_idx = (kp.octave as usize) * num_scales + (kp.scale as usize);
+        if g_idx >= gradients.len() {
+            continue;
+        }
+        let g = &gradients[g_idx];
+        x_oct = x_oct.clamp(0.0, g.cols as f32 - 1.0);
+        y_oct = y_oct.clamp(0.0, g.rows as f32 - 1.0);
+
+        let angles = oa.compute(g, x_oct, y_oct, sigma_oct);
+        for angle in angles {
+            let mut copy = *kp;
+            copy.angle = angle;
+            out.push(copy);
+        }
+    }
+    out
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Tests
+// ══════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load_grayscale(path: &str) -> Matrix<u8> {
+        let img = image::open(path).expect("load test image").to_luma8();
+        let (w, h) = img.dimensions();
+        Matrix::<u8>::from_vec(h as usize, w as usize, 1, img.into_raw())
+    }
+
+    fn build_test_pyramid(img: &Matrix<u8>, num_octaves: usize) -> GaussianScaleSpacePyramid {
+        let mut p = GaussianScaleSpacePyramid::new(num_octaves);
+        p.build(img).expect("build gaussian pyramid");
+        p
+    }
+
+    #[test]
+    fn test_dog_feature_point_from_conversion() {
+        let d = DoGFeaturePoint {
+            x: 12.5,
+            y: 34.5,
+            angle: 1.57,
+            octave: 1,
+            scale: 0,
+            sp_scale: 0.25,
+            score: -0.04,
+            sigma: 2.1,
+            edge_score: 5.0,
+        };
+        let fp: FeaturePoint = (&d).into();
+        assert!((fp.x - 12.5).abs() < 1e-6);
+        assert!((fp.y - 34.5).abs() < 1e-6);
+        assert!((fp.angle - 1.57).abs() < 1e-6);
+        assert!((fp.scale - 2.1).abs() < 1e-6);
+        // score < 0 => minima.
+        assert!(!fp.maxima);
+
+        let d2 = DoGFeaturePoint { score: 0.5, ..d };
+        let fp2: FeaturePoint = (&d2).into();
+        assert!(fp2.maxima);
+    }
+
+    #[test]
+    fn test_dog_detector_zero_octave_pyramid_is_handled() {
+        // Smallest valid pyramid: 1 octave, smallest valid input.
+        // GaussianScaleSpacePyramid requires >= 5x5 input.
+        let img = Matrix::<u8>::from_vec(8, 8, 1, vec![100u8; 64]);
+        let mut p = GaussianScaleSpacePyramid::new(1);
+        p.build(&img).expect("build");
+        let det = DoGScaleInvariantDetector::new(0.0, 10.0, 5000, false);
+        let pts = det.detect(&p);
+        // With only 1 octave we have 2 DoG levels (indices 0,1). The
+        // interior loop `1..size-1` is empty for size=2, so no extrema.
+        assert!(pts.is_empty(), "expected zero keypoints, got {}", pts.len());
+    }
+
+    #[test]
+    fn test_dog_detector_finds_keypoints_on_real_image() {
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let pyr = build_test_pyramid(&img, 3);
+        let det = DoGScaleInvariantDetector::new(0.0, 10.0, 5000, false);
+        let pts = det.detect(&pyr);
+        assert!(pts.len() > 50, "expected > 50 keypoints, got {}", pts.len());
+    }
+
+    #[test]
+    fn test_dog_detector_keypoints_within_image_bounds() {
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let pyr = build_test_pyramid(&img, 3);
+        let det = DoGScaleInvariantDetector::new(0.0, 10.0, 5000, false);
+        let pts = det.detect(&pyr);
+        let w = img.cols as f32;
+        let h = img.rows as f32;
+        for p in &pts {
+            let fp: FeaturePoint = p.into();
+            assert!(
+                fp.x >= 0.0 && fp.x < w && fp.y >= 0.0 && fp.y < h,
+                "keypoint ({}, {}) outside [0, {})x[0, {})",
+                fp.x,
+                fp.y,
+                w,
+                h
+            );
+        }
+    }
+
+    // ── Dual-mode: keypoint count agreement with C++ ──────────────────
+
+    #[cfg(feature = "dual-mode")]
+    extern "C" {
+        fn webarkit_cpp_dog_detect_count(
+            src: *const u8,
+            src_w: i32,
+            src_h: i32,
+            num_octaves: i32,
+            laplacian_threshold: f32,
+            edge_threshold: f32,
+            max_num_feature_points: i32,
+            find_orientation: i32,
+            count_out: *mut i32,
+        ) -> i32;
+    }
+
+    #[cfg(feature = "dual-mode")]
+    fn cpp_detect_count(
+        img: &Matrix<u8>,
+        num_octaves: usize,
+        laplacian_threshold: f32,
+        edge_threshold: f32,
+        max_num_feature_points: usize,
+        find_orientation: bool,
+    ) -> i32 {
+        let mut count: i32 = 0;
+        // SAFETY: the shim validates pointers and dimensions; img owns
+        // the source buffer; count_out points to a stack-local i32.
+        let rc = unsafe {
+            webarkit_cpp_dog_detect_count(
+                img.as_slice().as_ptr(),
+                img.cols as i32,
+                img.rows as i32,
+                num_octaves as i32,
+                laplacian_threshold,
+                edge_threshold,
+                max_num_feature_points as i32,
+                if find_orientation { 1 } else { 0 },
+                &mut count,
+            )
+        };
+        assert_eq!(rc, 0, "C++ shim returned error {rc}");
+        count
+    }
+
+    #[test]
+    #[cfg(feature = "dual-mode")]
+    fn test_dog_keypoints_match_cpp_count() {
+        // Tolerance covers sort tie-breaking and bucket ordering variance
+        // only. Any algorithm-level error would dwarf this.
+        const MAX_TIE_DIVERGENCE: i32 = 5;
+
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let num_octaves = 3;
+        let laplacian_threshold = 0.0;
+        let edge_threshold = 10.0;
+        let max_pts = 5000;
+        let find_orientation = false;
+
+        let pyr = build_test_pyramid(&img, num_octaves);
+        let det = DoGScaleInvariantDetector::new(
+            laplacian_threshold,
+            edge_threshold,
+            max_pts,
+            find_orientation,
+        );
+        let rust_count = det.detect(&pyr).len() as i32;
+
+        let cpp_count = cpp_detect_count(
+            &img,
+            num_octaves,
+            laplacian_threshold,
+            edge_threshold,
+            max_pts,
+            find_orientation,
+        );
+
+        let diff = (rust_count - cpp_count).abs();
+        assert!(
+            diff <= MAX_TIE_DIVERGENCE,
+            "keypoint count divergence: rust={rust_count}, cpp={cpp_count}, |diff|={diff} > {MAX_TIE_DIVERGENCE}"
+        );
+    }
+}

--- a/crates/core/src/kpm/freak/hough.rs
+++ b/crates/core/src/kpm/freak/hough.rs
@@ -386,12 +386,6 @@ impl HoughSimilarityVoting {
     }
 }
 
-/// Stub types for M8 (to be implemented in Milestone 8).
-/// These are placeholders to allow M7 to compile independently.
-/// Placeholder for DoGScaleInvariantDetector from M8.
-#[derive(Clone, Debug)]
-pub struct DoGScaleInvariantDetector;
-
 /// Placeholder for Keyframe from M8.
 #[derive(Clone, Debug)]
 pub struct Keyframe {
@@ -443,7 +437,7 @@ pub struct HoughMatch {
 /// Stub for FindFeatures (M8 will implement).
 pub fn find_features(
     _keyframe: &mut Keyframe,
-    _detector: &DoGScaleInvariantDetector,
+    _detector: &super::detector::DoGScaleInvariantDetector,
     _pyramid: &super::gaussian_pyramid::GaussianScaleSpacePyramid,
 ) -> Result<(), KpmError> {
     arlog_i!("find_features: stub implementation (M8 pending)");

--- a/crates/core/src/kpm/freak/mod.rs
+++ b/crates/core/src/kpm/freak/mod.rs
@@ -41,24 +41,28 @@
 //! implementation and optimized for performance.
 
 pub mod clustering;
+pub mod detector;
 pub mod gaussian_pyramid;
 pub mod homography;
 pub mod hough;
 pub mod interpolate;
 pub mod matcher;
 pub mod math;
+pub mod orientation;
 pub mod pyramid;
 
 // Public re-exports for convenience
 pub use clustering::{hamming_distance_96, BhcNode, BinaryHierarchicalClustering, KMedoids};
+pub use detector::{DoGFeaturePoint, DoGScaleInvariantDetector};
 pub use gaussian_pyramid::{num_octaves_for, GaussianPyramidError, GaussianScaleSpacePyramid};
 pub use hough::{
-    find_features, find_hough_matches, find_hough_similarity, BinParams, DoGScaleInvariantDetector,
-    FeaturePoint, HoughMatch, HoughSimilarityVoting, Keyframe, Match,
+    find_features, find_hough_matches, find_hough_similarity, BinParams, FeaturePoint, HoughMatch,
+    HoughSimilarityVoting, Keyframe, Match,
 };
 pub use interpolate::{
     bilinear_downsample_point, bilinear_interpolate, bilinear_interpolate_f32,
     bilinear_interpolate_u8, bilinear_upsample_point,
 };
 pub use matcher::{FeatureMatcher, FeatureStore};
+pub use orientation::{compute_polar_gradient_image, OrientationAssignment};
 pub use pyramid::{Pyramid, PyramidError};

--- a/crates/core/src/kpm/freak/orientation.rs
+++ b/crates/core/src/kpm/freak/orientation.rs
@@ -55,11 +55,14 @@ const ONE_OVER_2PI: f32 = 1.0 / TWO_PI;
 
 /// Smoothing kernel (Gaussian sigma=1).
 /// Matches the C++ inline kernel in
-/// `orientation_assignment.cpp::compute` (smoothing loop).
+/// `orientation_assignment.cpp::compute` (smoothing loop) byte-for-byte.
+/// The 15-digit literals are taken verbatim from the C++ source with the
+/// explicit `_f32` suffix so Rust rounds them directly to the same f32
+/// bit pattern as the C++ `float` literals.
 const SMOOTH_KERNEL: [f32; 3] = [
-    0.274_068_62, // 0.274068619061197
-    0.451_862_77, // 0.451862761877606
-    0.274_068_62, // 0.274068619061197
+    0.274_068_619_061_197_f32,
+    0.451_862_761_877_606_f32,
+    0.274_068_619_061_197_f32,
 ];
 
 /// Compute orientations at sub-pixel keypoint locations using a gradient
@@ -336,52 +339,62 @@ mod tests {
         Matrix::<f32>::from_vec(rows, cols, 1, data)
     }
 
+    /// Build a synthetic image with a *slightly diagonal* gradient:
+    /// `pixel = col + 0.5 * row`. This produces gradient `(dx=2, dy=1)`
+    /// in the interior — a single dominant direction that does **not**
+    /// straddle two adjacent histogram bins symmetrically.
+    ///
+    /// A purely horizontal gradient (`pixel = col`) makes `fbin = 18.0`
+    /// exactly, splitting votes 50/50 across bins 17 and 18. After
+    /// smoothing with a kernel that sums to exactly 1.0, those two bins
+    /// remain bit-for-bit equal, and the strict-greater-than peak check
+    /// (`h0 > hm1 && h0 > hp1`) fails at both. The diagonal offset
+    /// breaks that perfect symmetry and produces a clear single peak.
+    fn diagonal_gradient_level(rows: usize, cols: usize) -> Matrix<f32> {
+        let data: Vec<f32> = (0..rows * cols)
+            .map(|i| {
+                let row = i / cols;
+                let col = i % cols;
+                col as f32 + 0.5 * row as f32
+            })
+            .collect();
+        Matrix::<f32>::from_vec(rows, cols, 1, data)
+    }
+
     fn flat_level(rows: usize, cols: usize, value: f32) -> Matrix<f32> {
         Matrix::<f32>::from_vec(rows, cols, 1, vec![value; rows * cols])
     }
 
     #[test]
     fn test_orientation_assignment_horizontal_gradient() {
-        // Constant horizontal gradient: pixel = col. dy = 0 everywhere
-        // (top/bottom border rows have dy = 1 from one-sided diff against
-        // the next row, but in the constant-horizontal case the next row
-        // is identical so dy = 0 there too).
-        // dx = +1 in interior (col-1 to col+1 via central diff: 2), at
-        // the left/right border dx = 1 (one-sided diff). atan2(0, dx) = 0,
-        // angle channel = 0 + π = π.
+        // Slightly diagonal gradient: dx = 2, dy = 1 in the interior.
+        // atan2(dy=1, dx=2) ≈ 0.4636 rad. After the `+π` shift applied
+        // by ComputePolarGradients, the angle channel value is
+        // ≈ π + 0.4636 ≈ 3.6052 rad.
         //
-        // Histogram bin for angle = π: fbin = num_bins * π / (2π) = 18
-        // (out of 36 bins). After smoothing, peak is at bin 18.
+        // Histogram bin for that angle:
+        //   fbin = num_bins · angle / (2π) = 36 · 3.6052 / (2π) ≈ 20.66
+        // → bilinear update votes mostly into bin 20 (with some into 21).
+        // After smoothing, the peak sits near bin 20-21.
         //
-        // Final angle formula: angle = 2π · (fbin + 0.5 + num_bins) / num_bins mod 2π
-        //                            = 2π · (18 + 0.5 + 36) / 36 mod 2π
-        //                            = 2π · 54.5 / 36 mod 2π
-        //                            = (3π + π/18) mod 2π
-        //                            = π + π/18 ≈ 3.32 rad
-        // The "+0.5 + num_bins" bin-center offset in the C++ formula is
-        // calibrated to land at the dominant gradient direction.
+        // Final-angle formula maps the sub-bin peak back to an angle
+        // close to the gradient direction (≈ 3.6052 rad), accounting for
+        // the half-bin offset in the C++ formula.
         //
-        // For dx=+1, dy=0 (right-pointing gradient), the dominant
-        // perpendicular orientation for a vertical edge is π/2 — but the
-        // gradient direction itself is 0 (east). The histogram votes for
-        // the gradient direction, not the edge direction.
-
-        let level = horizontal_gradient_level(64, 64);
+        // We use a diagonal rather than a purely horizontal gradient
+        // because the latter produces fbin = 18.0 exactly (votes split
+        // 50/50 across bins 17 and 18); after smoothing with the kernel
+        // that sums to exactly 1.0, those two bins stay bit-for-bit
+        // equal and the strict-greater-than peak check fails at both.
+        let level = diagonal_gradient_level(64, 64);
         let gradient = compute_polar_gradient_image(&level);
         let oa = OrientationAssignment::new();
         let angles = oa.compute(&gradient, 32.0, 32.0, 1.0);
 
         assert!(!angles.is_empty(), "expected at least one orientation");
 
-        // The angle channel is dy.atan2(dx) + π. For a right-pointing
-        // gradient (dx>0, dy=0), that's 0 + π = π. The histogram peaks
-        // near bin num_bins/2 = 18. The final-angle formula maps bin 18
-        // back to an angle near π (with a half-bin offset).
-        //
-        // After the (fbin + 0.5 + num_bins) / num_bins · 2π modular
-        // formula, the dominant angle should be close to π + half-bin =
-        // π + (2π / num_bins) / 2 = π + π/36.
-        let expected = PI + PI / 36.0;
+        // Expected angle: roughly the gradient direction, π + atan2(1, 2).
+        let expected = PI + 0.5f32.atan2(1.0);
         let best = angles
             .iter()
             .copied()
@@ -393,7 +406,7 @@ mod tests {
             })
             .unwrap();
         assert!(
-            (best - expected).abs() < 0.2,
+            (best - expected).abs() < 0.3,
             "expected dominant orientation near {expected}, got {best} (all = {angles:?})"
         );
     }

--- a/crates/core/src/kpm/freak/orientation.rs
+++ b/crates/core/src/kpm/freak/orientation.rs
@@ -1,0 +1,454 @@
+/*
+ *  orientation.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Orientation assignment via gradient histograms.
+//!
+//! Ported from `WebARKitLib/.../detectors/orientation_assignment.{h,cpp}`
+//! and `detectors/gradients.{h,cpp}`. The public two-phase C++ API
+//! (`computeGradients` + `compute`) is simplified for M8-3 to a single
+//! [`OrientationAssignment::compute`] method taking a precomputed
+//! gradient image. The detector batches gradient computation across all
+//! pyramid levels via [`compute_polar_gradient_image`].
+//!
+//! M8-4 (FREAK descriptor) will share the gradient cache with this
+//! module and may promote the API to expose the cache directly.
+
+use purecv::core::Matrix;
+
+use std::f32::consts::PI;
+
+const TWO_PI: f32 = 2.0 * PI;
+const ONE_OVER_2PI: f32 = 1.0 / TWO_PI;
+
+/// Smoothing kernel (Gaussian sigma=1).
+/// Matches the C++ inline kernel in
+/// `orientation_assignment.cpp::compute` (smoothing loop).
+const SMOOTH_KERNEL: [f32; 3] = [
+    0.274_068_62, // 0.274068619061197
+    0.451_862_77, // 0.451862761877606
+    0.274_068_62, // 0.274068619061197
+];
+
+/// Compute orientations at sub-pixel keypoint locations using a gradient
+/// histogram over a Gaussian-weighted circular window around the keypoint.
+///
+/// C equivalent: `vision::OrientationAssignment`.
+///
+/// **Defaults**: matches the C++ `DoGScaleInvariantDetector::alloc(...)`
+/// call site (lines 126-134 of `DoG_scale_invariant_detector.cpp`):
+/// `num_bins = 36`, `gaussian_expansion_factor = 3.0`,
+/// `support_region_expansion_factor = 1.5`, `num_smoothing_iterations = 5`,
+/// `peak_threshold = 0.8`.
+pub struct OrientationAssignment {
+    num_bins: usize,
+    gaussian_expansion_factor: f32,
+    support_region_expansion_factor: f32,
+    num_smoothing_iterations: usize,
+    peak_threshold: f32,
+}
+
+impl Default for OrientationAssignment {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OrientationAssignment {
+    /// Construct with hardcoded FREAK pipeline defaults.
+    ///
+    /// M8-4 will promote these to constructor parameters.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            num_bins: 36,
+            gaussian_expansion_factor: 3.0,
+            support_region_expansion_factor: 1.5,
+            num_smoothing_iterations: 5,
+            peak_threshold: 0.8,
+        }
+    }
+
+    /// Number of histogram bins.
+    #[must_use]
+    pub fn num_bins(&self) -> usize {
+        self.num_bins
+    }
+
+    /// Compute dominant orientations (radians, in `[0, 2π)`) for the
+    /// keypoint at `(x, y)` with characteristic `sigma`, using the
+    /// precomputed `gradient` image (`channels = 2`, interleaved as
+    /// `(angle, magnitude)` — matches C++ `ComputePolarGradients`).
+    ///
+    /// Returns one orientation per histogram peak that is **both** a
+    /// strict local maximum **and** above `peak_threshold × max_peak`.
+    /// Each peak is sub-pixel-refined via a parabolic fit to its three
+    /// neighboring bins (matches C++ `Quadratic3Points`).
+    ///
+    /// Returns an empty `Vec` if `(x, y)` is outside the image or the
+    /// histogram has no positive peak.
+    #[must_use]
+    pub fn compute(&self, gradient: &Matrix<f32>, x: f32, y: f32, sigma: f32) -> Vec<f32> {
+        debug_assert_eq!(
+            gradient.channels, 2,
+            "gradient image must have 2 channels (angle, magnitude)"
+        );
+
+        let width = gradient.cols;
+        let height = gradient.rows;
+        let data = gradient.as_slice();
+
+        // Reject negative coordinates at the float level. The C++ casts
+        // `(int)(x + 0.5f)` rounds -1.0 to 0 (truncation toward zero), so
+        // checking only the integer bounds would let small negative values
+        // slip through. Real callers (DoG detector) always pass
+        // non-negative coordinates; this is a Rust safety guard.
+        if x < 0.0 || y < 0.0 {
+            return Vec::new();
+        }
+        let xi = (x + 0.5) as i32;
+        let yi = (y + 0.5) as i32;
+        if (xi as usize) >= width || (yi as usize) >= height {
+            return Vec::new();
+        }
+
+        // Gaussian window: σ_window = max(1, gaussian_expansion_factor · sigma).
+        let gw_sigma = (self.gaussian_expansion_factor * sigma).max(1.0);
+        let gw_scale = -1.0 / (2.0 * gw_sigma * gw_sigma);
+
+        // Circular support radius.
+        let radius = self.support_region_expansion_factor * gw_sigma;
+        let radius2 = (radius * radius).ceil();
+        let radius_int = (radius + 0.5) as i32;
+
+        // Clip the box to image bounds.
+        let x0 = (xi - radius_int).max(0) as usize;
+        let x1 = (xi + radius_int).min(width as i32 - 1) as usize;
+        let y0 = (yi - radius_int).max(0) as usize;
+        let y1 = (yi + radius_int).min(height as i32 - 1) as usize;
+
+        // Build the orientation histogram.
+        let mut hist = vec![0.0f32; self.num_bins];
+        for yp in y0..=y1 {
+            let dy = yp as f32 - y;
+            let dy2 = dy * dy;
+            let row_base = yp * width * 2;
+            for xp in x0..=x1 {
+                let dx = xp as f32 - x;
+                let r2 = dx * dx + dy2;
+                if r2 > radius2 {
+                    continue;
+                }
+                let idx = row_base + xp * 2;
+                let angle = data[idx];
+                let mag = data[idx + 1];
+
+                // Gaussian weight.
+                let w = (r2 * gw_scale).exp();
+
+                // Sub-bin location.
+                let fbin = self.num_bins as f32 * angle * ONE_OVER_2PI;
+                bilinear_histogram_update(&mut hist, fbin, w * mag, self.num_bins);
+            }
+        }
+
+        // Smooth circularly with the C++ kernel.
+        let mut buf = vec![0.0f32; self.num_bins];
+        for _ in 0..self.num_smoothing_iterations {
+            smooth_orientation_histogram_circular(&mut buf, &hist, &SMOOTH_KERNEL);
+            hist.copy_from_slice(&buf);
+        }
+
+        // Find peak height.
+        let max_height = hist.iter().copied().fold(0.0f32, f32::max);
+        if max_height <= 0.0 {
+            return Vec::new();
+        }
+
+        // Find peaks: strict local max above threshold; sub-pixel-refine
+        // via parabolic fit.
+        let mut angles: Vec<f32> = Vec::new();
+        let threshold = self.peak_threshold * max_height;
+        for i in 0..self.num_bins {
+            let h0 = hist[i];
+            if h0 <= threshold {
+                continue;
+            }
+            let hm1 = hist[(i + self.num_bins - 1) % self.num_bins];
+            let hp1 = hist[(i + 1) % self.num_bins];
+            if !(h0 > hm1 && h0 > hp1) {
+                continue;
+            }
+
+            // Parabolic fit through (i-1, hm1), (i, h0), (i+1, hp1).
+            // Critical point: x* = i + 0.5 · (hm1 - hp1) / (hm1 - 2·h0 + hp1).
+            let denom = hm1 - 2.0 * h0 + hp1;
+            let fbin = if denom.abs() > f32::EPSILON {
+                i as f32 + 0.5 * (hm1 - hp1) / denom
+            } else {
+                i as f32
+            };
+
+            let nb = self.num_bins as f32;
+            let angle = (TWO_PI * (fbin + 0.5 + nb) / nb) % TWO_PI;
+            angles.push(angle);
+        }
+
+        angles
+    }
+}
+
+/// Vote `magnitude` into a circular `num_bins` histogram at fractional
+/// position `fbin`, splitting between two adjacent bins by linear weight.
+///
+/// C equivalent: `vision::bilinear_histogram_update` (inline in
+/// `orientation_assignment.h`).
+#[inline]
+fn bilinear_histogram_update(hist: &mut [f32], fbin: f32, magnitude: f32, num_bins: usize) {
+    let bin = (fbin - 0.5).floor() as i32;
+    let w2 = fbin - bin as f32 - 0.5;
+    let w1 = 1.0 - w2;
+    let nb = num_bins as i32;
+    let b1 = ((bin % nb + nb) % nb) as usize;
+    let b2 = (((bin + 1) % nb + nb) % nb) as usize;
+    hist[b1] += w1 * magnitude;
+    hist[b2] += w2 * magnitude;
+}
+
+/// One pass of a 3-tap circular smoothing convolution.
+///
+/// C equivalent: `vision::SmoothOrientationHistogram`.
+#[inline]
+fn smooth_orientation_histogram_circular(dst: &mut [f32], src: &[f32], kernel: &[f32; 3]) {
+    let n = src.len();
+    debug_assert_eq!(dst.len(), n);
+    if n < 2 {
+        dst.copy_from_slice(src);
+        return;
+    }
+    let first = src[0];
+    let mut prev = src[n - 1];
+    for i in 0..(n - 1) {
+        let cur = src[i];
+        dst[i] = kernel[0] * prev + kernel[1] * cur + kernel[2] * src[i + 1];
+        prev = cur;
+    }
+    dst[n - 1] = kernel[0] * prev + kernel[1] * src[n - 1] + kernel[2] * first;
+}
+
+/// Build a 2-channel `(angle, magnitude)` polar gradient image from a
+/// pyramid level. Channel layout matches C++ `ComputePolarGradients`:
+///
+/// - Channel 0 = `atan2(dy, dx) + π` (shifted to `[0, 2π]`)
+/// - Channel 1 = `sqrt(dx² + dy²)`
+///
+/// Borders use one-sided differences; interior uses central differences.
+///
+/// C equivalent: `vision::ComputePolarGradients`.
+#[must_use]
+pub fn compute_polar_gradient_image(level: &Matrix<f32>) -> Matrix<f32> {
+    debug_assert_eq!(level.channels, 1, "input level must be single-channel");
+    let w = level.cols;
+    let h = level.rows;
+    let src = level.as_slice();
+
+    let mut dst = vec![0.0f32; w * h * 2];
+
+    // Helper closures for one-sided / central differences.
+    let dx_at = |row: usize, col: usize| -> f32 {
+        if col == 0 {
+            src[row * w + 1] - src[row * w]
+        } else if col == w - 1 {
+            src[row * w + col] - src[row * w + col - 1]
+        } else {
+            src[row * w + col + 1] - src[row * w + col - 1]
+        }
+    };
+    let dy_at = |row: usize, col: usize| -> f32 {
+        if row == 0 {
+            src[w + col] - src[col]
+        } else if row == h - 1 {
+            src[(h - 1) * w + col] - src[(h - 2) * w + col]
+        } else {
+            src[(row + 1) * w + col] - src[(row - 1) * w + col]
+        }
+    };
+
+    for row in 0..h {
+        for col in 0..w {
+            let dx = dx_at(row, col);
+            let dy = dy_at(row, col);
+            let angle = dy.atan2(dx) + PI;
+            let mag = (dx * dx + dy * dy).sqrt();
+            let idx = (row * w + col) * 2;
+            dst[idx] = angle;
+            dst[idx + 1] = mag;
+        }
+    }
+
+    Matrix::<f32>::from_vec(h, w, 2, dst)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic constant horizontal-gradient image: `pixel = col`.
+    /// dx is constant; dy is 0. atan2(0, dx>0) = 0 → angle channel ≈ π
+    /// (after the +π shift). That maps to bin `num_bins / 2`; the
+    /// dominant orientation in our normalized convention is π/2 +
+    /// half-bin offset due to the `(fbin + 0.5)` shift in the final
+    /// angle formula.
+    fn horizontal_gradient_level(rows: usize, cols: usize) -> Matrix<f32> {
+        let data: Vec<f32> = (0..rows * cols).map(|i| (i % cols) as f32).collect();
+        Matrix::<f32>::from_vec(rows, cols, 1, data)
+    }
+
+    fn flat_level(rows: usize, cols: usize, value: f32) -> Matrix<f32> {
+        Matrix::<f32>::from_vec(rows, cols, 1, vec![value; rows * cols])
+    }
+
+    #[test]
+    fn test_orientation_assignment_horizontal_gradient() {
+        // Constant horizontal gradient: pixel = col. dy = 0 everywhere
+        // (top/bottom border rows have dy = 1 from one-sided diff against
+        // the next row, but in the constant-horizontal case the next row
+        // is identical so dy = 0 there too).
+        // dx = +1 in interior (col-1 to col+1 via central diff: 2), at
+        // the left/right border dx = 1 (one-sided diff). atan2(0, dx) = 0,
+        // angle channel = 0 + π = π.
+        //
+        // Histogram bin for angle = π: fbin = num_bins * π / (2π) = 18
+        // (out of 36 bins). After smoothing, peak is at bin 18.
+        //
+        // Final angle formula: angle = 2π · (fbin + 0.5 + num_bins) / num_bins mod 2π
+        //                            = 2π · (18 + 0.5 + 36) / 36 mod 2π
+        //                            = 2π · 54.5 / 36 mod 2π
+        //                            = (3π + π/18) mod 2π
+        //                            = π + π/18 ≈ 3.32 rad
+        // The "+0.5 + num_bins" bin-center offset in the C++ formula is
+        // calibrated to land at the dominant gradient direction.
+        //
+        // For dx=+1, dy=0 (right-pointing gradient), the dominant
+        // perpendicular orientation for a vertical edge is π/2 — but the
+        // gradient direction itself is 0 (east). The histogram votes for
+        // the gradient direction, not the edge direction.
+
+        let level = horizontal_gradient_level(64, 64);
+        let gradient = compute_polar_gradient_image(&level);
+        let oa = OrientationAssignment::new();
+        let angles = oa.compute(&gradient, 32.0, 32.0, 1.0);
+
+        assert!(!angles.is_empty(), "expected at least one orientation");
+
+        // The angle channel is dy.atan2(dx) + π. For a right-pointing
+        // gradient (dx>0, dy=0), that's 0 + π = π. The histogram peaks
+        // near bin num_bins/2 = 18. The final-angle formula maps bin 18
+        // back to an angle near π (with a half-bin offset).
+        //
+        // After the (fbin + 0.5 + num_bins) / num_bins · 2π modular
+        // formula, the dominant angle should be close to π + half-bin =
+        // π + (2π / num_bins) / 2 = π + π/36.
+        let expected = PI + PI / 36.0;
+        let best = angles
+            .iter()
+            .copied()
+            .min_by(|a, b| {
+                (a - expected)
+                    .abs()
+                    .partial_cmp(&(b - expected).abs())
+                    .unwrap()
+            })
+            .unwrap();
+        assert!(
+            (best - expected).abs() < 0.2,
+            "expected dominant orientation near {expected}, got {best} (all = {angles:?})"
+        );
+    }
+
+    #[test]
+    fn test_orientation_assignment_empty_when_no_gradients() {
+        // Flat image → zero gradients everywhere → empty result.
+        let level = flat_level(32, 32, 128.0);
+        let gradient = compute_polar_gradient_image(&level);
+        let oa = OrientationAssignment::new();
+        let angles = oa.compute(&gradient, 16.0, 16.0, 1.0);
+        assert!(
+            angles.is_empty(),
+            "flat image should produce zero orientations, got {angles:?}"
+        );
+    }
+
+    #[test]
+    fn test_orientation_assignment_out_of_bounds_returns_empty() {
+        let level = horizontal_gradient_level(16, 16);
+        let gradient = compute_polar_gradient_image(&level);
+        let oa = OrientationAssignment::new();
+        assert!(oa.compute(&gradient, -1.0, 8.0, 1.0).is_empty());
+        assert!(oa.compute(&gradient, 8.0, -1.0, 1.0).is_empty());
+        assert!(oa.compute(&gradient, 16.0, 8.0, 1.0).is_empty());
+        assert!(oa.compute(&gradient, 8.0, 16.0, 1.0).is_empty());
+    }
+
+    #[test]
+    fn test_polar_gradient_horizontal_image() {
+        // pixel = col, so dx is constant. atan2(0, +dx) + π = π
+        // for interior cols; magnitude is the difference.
+        let level = horizontal_gradient_level(8, 8);
+        let g = compute_polar_gradient_image(&level);
+        // Pick an interior pixel.
+        let row = 4usize;
+        let col = 4usize;
+        let idx = (row * 8 + col) * 2;
+        let data = g.as_slice();
+        let angle = data[idx];
+        let mag = data[idx + 1];
+        // Interior central diff: dx = col+1 - (col-1) = 2, dy = 0.
+        // atan2(0, 2) = 0; angle channel = 0 + π = π.
+        assert!((angle - PI).abs() < 1e-4, "expected π, got {angle}");
+        // magnitude = sqrt(4) = 2.
+        assert!((mag - 2.0).abs() < 1e-4, "expected 2.0, got {mag}");
+    }
+
+    #[test]
+    fn test_polar_gradient_output_shape() {
+        let level = horizontal_gradient_level(16, 24);
+        let g = compute_polar_gradient_image(&level);
+        assert_eq!(g.rows, 16);
+        assert_eq!(g.cols, 24);
+        assert_eq!(g.channels, 2);
+        assert_eq!(g.as_slice().len(), 16 * 24 * 2);
+    }
+}

--- a/crates/core/src/kpm/freak/orientation.rs
+++ b/crates/core/src/kpm/freak/orientation.rs
@@ -59,6 +59,15 @@ const ONE_OVER_2PI: f32 = 1.0 / TWO_PI;
 /// The 15-digit literals are taken verbatim from the C++ source with the
 /// explicit `_f32` suffix so Rust rounds them directly to the same f32
 /// bit pattern as the C++ `float` literals.
+///
+/// `clippy::excessive_precision` would suggest truncating to ~8 digits
+/// (the limit of f32 precision). We deliberately keep the full 15-digit
+/// form for source-level fidelity with the C++ port — a reviewer
+/// cross-referencing the C++ can compare digit-for-digit without doing
+/// the rounding mentally. Rust's f32 literal parser handles the trailing
+/// digits identically to clipping them, so there is no behavioral
+/// difference; this is purely about source readability.
+#[allow(clippy::excessive_precision)]
 const SMOOTH_KERNEL: [f32; 3] = [
     0.274_068_619_061_197_f32,
     0.451_862_761_877_606_f32,

--- a/crates/core/src/kpm/kpm_c_api.cpp
+++ b/crates/core/src/kpm/kpm_c_api.cpp
@@ -56,6 +56,7 @@
 #include <math/linear_solvers.h>
 #include <math/rand.h>
 #include <homography_estimation/robust_homography.h>
+#include <detectors/DoG_scale_invariant_detector.h>
 #include <detectors/gaussian_scale_space_pyramid.h>
 #include <framework/image.h>
 #include <Eigen/Core>
@@ -505,6 +506,62 @@ int webarkit_cpp_fast_random(int* seed) {
 
 void webarkit_cpp_array_shuffle(int* v, int pop_size, int sample_size, int* seed) {
     vision::ArrayShuffle<int>(v, pop_size, sample_size, *seed);
+}
+
+/* ---- Dual-mode validation: DoGScaleInvariantDetector bridge (Milestone 8, #128) ---- */
+
+int webarkit_cpp_dog_detect_count(
+    const unsigned char* src,
+    int src_w,
+    int src_h,
+    int num_octaves,
+    float laplacian_threshold,
+    float edge_threshold,
+    int max_num_feature_points,
+    int find_orientation,
+    int* count_out) {
+
+    if (!src || !count_out || src_w < 5 || src_h < 5 || num_octaves < 1
+        || edge_threshold <= 0.0f || max_num_feature_points <= 0) {
+        return 1;
+    }
+
+    // Ensure all octaves are at least 5x5 (binomial filter requirement).
+    {
+        int w = src_w;
+        int h = src_h;
+        for (int o = 0; o < num_octaves; ++o) {
+            if (w < 5 || h < 5) {
+                return 2;
+            }
+            w >>= 1;
+            h >>= 1;
+        }
+    }
+
+    try {
+        vision::Image image(
+            const_cast<unsigned char*>(src), vision::IMAGE_UINT8,
+            src_w, src_h, src_w /* step */, 1);
+
+        vision::BinomialPyramid32f pyr;
+        pyr.alloc(src_w, src_h, num_octaves);
+        pyr.build(image);
+
+        vision::DoGScaleInvariantDetector det;
+        det.alloc(&pyr);
+        det.setLaplacianThreshold(laplacian_threshold);
+        det.setEdgeThreshold(edge_threshold);
+        det.setMaxNumFeaturePoints(static_cast<size_t>(max_num_feature_points));
+        det.setFindOrientation(find_orientation != 0);
+
+        det.detect(&pyr);
+
+        *count_out = static_cast<int>(det.features().size());
+        return 0;
+    } catch (...) {
+        return 4;
+    }
 }
 
 /* ---- Dual-mode validation: BinomialPyramid32f bridge (Milestone 8, #127) ---- */

--- a/crates/core/src/kpm/kpm_c_api.h
+++ b/crates/core/src/kpm/kpm_c_api.h
@@ -239,6 +239,31 @@ int webarkit_cpp_match_features_guided(
 int  webarkit_cpp_fast_random(int* seed);
 void webarkit_cpp_array_shuffle(int* v, int pop_size, int sample_size, int* seed);
 
+/* ---- Dual-mode validation: DoGScaleInvariantDetector bridge (Milestone 8, #128) ---- */
+
+/* Build a BinomialPyramid32f from `src` and run a DoGScaleInvariantDetector
+ * with the supplied configuration. Writes the number of detected keypoints
+ * to `*count_out`. Both Rust and C++ sides must call with identical config
+ * for the dual-mode parity test to be meaningful.
+ *
+ * `find_orientation` is treated as boolean (0 = false, non-zero = true).
+ *
+ * Returns:
+ *   0  success
+ *   1  validation error (null ptr, bad dims, out-of-range indices)
+ *   2  pyramid too small for the requested octave count
+ *   4  C++ exception caught (ASSERT, std::exception, etc.) */
+int webarkit_cpp_dog_detect_count(
+    const unsigned char* src,
+    int src_w,
+    int src_h,
+    int num_octaves,
+    float laplacian_threshold,
+    float edge_threshold,
+    int max_num_feature_points,
+    int find_orientation,
+    int* count_out);
+
 /* ---- Dual-mode validation: BinomialPyramid32f bridge (Milestone 8, #127) ---- */
 
 /* Build a vision::BinomialPyramid32f from `src` (grayscale, src_w x src_h,

--- a/docs/design/m8-3-dog-detector.md
+++ b/docs/design/m8-3-dog-detector.md
@@ -1,0 +1,234 @@
+# Milestone 8 — Step 3: DoG Detector + Orientation Assignment
+
+**Status**: Design approved, ready for implementation
+**Branch**: `feat/m8-3-dog-detector` (PR target: `feat/m8-freak-detector`)
+**Issue**: #128
+**Author**: Walter Perdan ([@kalwalt](https://github.com/kalwalt))
+**Date**: 2026-05-16
+
+---
+
+## 1. Understanding Summary
+
+- **What**: Port `orientation_assignment.{h,cpp}` and `DoG_scale_invariant_detector.{h,cpp}` to two new Rust sibling modules:
+  - `crates/core/src/kpm/freak/orientation.rs`
+  - `crates/core/src/kpm/freak/detector.rs`
+- **Why**: Step 3 of Milestone 8. The Difference-of-Gaussians (DoG) detector finds scale-invariant keypoints from the Gaussian pyramid (M8-2 output); these keypoints feed the FREAK descriptor (M8-4) and the downstream KPM matching pipeline.
+- **Who**: Internal infrastructure consumed by M8-4 (FREAK descriptor) and downstream KPM matching.
+- **Success criterion**: Live FFI dual-mode test: Rust detector keypoint count agrees with C++ within `±5` on `found.jpg`, with identical detector configuration on both sides. Plus 6 unit tests for shape/coverage/correctness.
+- **Non-goals (this PR)**:
+  - FREAK descriptor extraction (M8-4)
+  - SIMD/rayon optimization
+  - Harris detector port (dead code — explicitly excluded by issue)
+  - Public two-phase `OrientationAssignment` API (`compute_gradients` separated from `compute`) — deferred to M8-4
+  - Full 7-parameter `OrientationAssignment::new(...)` constructor — using hardcoded FREAK defaults
+
+---
+
+## 2. Decision Log
+
+| # | Decision | Alternatives considered | Rationale |
+|---|----------|-------------------------|-----------|
+| 1 | **Option C scope**: faithful on algorithm-critical bits (3-way Hessian dispatch, bucket pruning, `Matrix<f32>` DoG, rich `DoGFeaturePoint`, all detector params), simplified on `OrientationAssignment` public surface | Option A (fully faithful, ~1500 lines); Option B (spec-as-written, naive top-N pruning, single Hessian variant) | Keeps PR reviewable while preserving algorithm correctness; deferred surface promotion lands naturally in M8-4 where it's actually needed |
+| 2 | **Option B FeaturePoint**: new `DoGFeaturePoint` (9 fields) in `detector.rs`; `hough.rs::FeaturePoint` unchanged; `From<&DoGFeaturePoint>` conversion | Option A: extend existing `hough.rs::FeaturePoint` with 4 new fields; Option C: move to shared `feature_point.rs` module | Mirrors C++ architecture (`vision::FeaturePoint` in `matchers/` is persistent type; `DoGScaleInvariantDetector::FeaturePoint` is working type with diagnostics); avoids coupling this PR to `hough.rs` |
+| 3 | **B: Split into 2 modules** — `orientation.rs` + `detector.rs` | Option A: single `detector.rs` (~1300 lines mixing two concerns); Option C: 3-way split | Mirrors C++ file organization; matches M8-2 splitting pattern; each file ~600 lines and forward-compatible with M8-4 API promotion |
+| 4 | **A: Live FFI shim** `webarkit_cpp_dog_detect_count(...)` parameterized by detector config | Option B: pre-generated `tests/fixtures/dog_keypoint_count.txt`; Option C: hybrid xtask-regenerated | Matches M8-2 pattern; no binary/text blob in git; both sides run identical configuration |
+| 5 | **C: `MAX_TIE_DIVERGENCE = 5`** for keypoint count tolerance | Option A: exact match (`assert_eq!`); Option B: ±10% (issue spec literal) | Issue's ±10% would allow ±50 keypoints — too loose to detect real bugs. ±5 catches sort tie-breaking variance only. Tighten to exact in a follow-up if CI shows consistent equality |
+| 6 | **`detect()` is infallible**: returns `Vec<DoGFeaturePoint>` directly | `Result<Vec<DoGFeaturePoint>, DetectorError>` (M8-1/M8-2 pattern) | Pre-validated pyramid input; no failure modes that aren't already caught upstream; matches C++ `void detect()`; empty Vec = "no keypoints found", not error |
+| 7 | **`DoGScaleInvariantDetector::new()` is infallible**: validates config with `debug_assert!` | `Result<Self, DetectorError>` | Constructor just stores numeric params; bad values trip debug asserts |
+
+---
+
+## 3. Final API
+
+### 3.1 `orientation.rs`
+
+```rust
+pub struct OrientationAssignment {
+    num_bins: usize,                       // FREAK default: 36
+    gaussian_expansion_factor: f32,        // FREAK default: 1.5
+    support_region_expansion_factor: f32,  // FREAK default: 3.0
+    num_smoothing_iterations: usize,       // FREAK default: 5
+    peak_threshold: f32,                   // FREAK default: 0.8
+}
+
+impl OrientationAssignment {
+    #[must_use]
+    pub fn new() -> Self;
+
+    #[must_use]
+    pub fn compute(
+        &self,
+        gradient: &Matrix<f32>,   // channels = 2: (magnitude, angle) interleaved
+        x: f32,
+        y: f32,
+        sigma: f32,
+    ) -> Vec<f32>;
+}
+
+/// Build a 2-channel (magnitude, angle) gradient image from a pyramid level.
+#[must_use]
+pub fn compute_gradient_image(level: &Matrix<f32>) -> Matrix<f32>;
+```
+
+### 3.2 `detector.rs`
+
+```rust
+#[derive(Debug, Clone, Copy)]
+pub struct DoGFeaturePoint {
+    pub x: f32,
+    pub y: f32,
+    pub angle: f32,        // 0 if find_orientation == false
+    pub octave: i32,
+    pub scale: i32,        // integer scale index (0..NUM_SCALES_PER_OCTAVE)
+    pub sp_scale: f32,     // sub-pixel scale offset, in (-0.5, 0.5)
+    pub score: f32,        // signed DoG response at refined location
+    pub sigma: f32,        // characteristic Gaussian sigma after refinement
+    pub edge_score: f32,
+}
+
+impl From<&DoGFeaturePoint> for super::hough::FeaturePoint {
+    fn from(d: &DoGFeaturePoint) -> Self;  // projects to persistent type
+}
+
+pub struct DoGScaleInvariantDetector {
+    laplacian_threshold: f32,
+    edge_threshold: f32,
+    max_subpixel_distance_sqr: f32,    // FREAK default: 3.0
+    num_buckets_x: usize,              // FREAK default: 10
+    num_buckets_y: usize,              // FREAK default: 10
+    max_num_feature_points: usize,
+    find_orientation: bool,
+    orientation_assignment: OrientationAssignment,
+}
+
+impl DoGScaleInvariantDetector {
+    pub const DEFAULT_MAX_NUM_FEATURE_POINTS: usize = 5000;
+
+    pub fn new(
+        laplacian_threshold: f32,
+        edge_threshold: f32,
+        max_num_feature_points: usize,
+        find_orientation: bool,
+    ) -> Self;
+
+    pub fn detect(
+        &self,
+        pyramid: &GaussianScaleSpacePyramid,
+    ) -> Vec<DoGFeaturePoint>;
+}
+```
+
+### 3.3 detect() pipeline
+
+1. **Build DoG pyramid**: `dog[oct][s] = pyramid.level(oct, s+1) - pyramid.level(oct, s)` for `s` in `0..NUM_DOG_PER_OCTAVE` (= 2 with 3 scales/octave). `Matrix<f32>` storage.
+2. **Find 3D extrema**: for each `(oct, dog_idx, r, c)`, compare to all 26 neighbours in the 3×3×3 cube. Cross-octave neighbours accessed via bilinear interpolation.
+3. **Contrast threshold**: discard `|value| < laplacian_threshold`.
+4. **Sub-pixel refinement** (`compute_subpixel_hessian` dispatcher):
+   - `SameOctave` — all three laplacians same size
+   - `FineOctavePair` — lap0/lap1 same size, lap2 half size
+   - `CoarseOctavePair` — lap0 double size, lap1/lap2 same
+   Solve 3×3 `H · δ = b` via Gaussian elimination. Discard if `||δ||² > max_subpixel_distance_sqr` or H is degenerate.
+5. **Edge rejection**: `compute_edge_score` from H's top-left 2×2; discard if `|score| ≥ (edge_threshold + 1)² / edge_threshold`.
+6. **Orientation assignment** (when `find_orientation == true`): precompute one gradient image per pyramid level; for each refined point query `OrientationAssignment::compute(...)`; emit one copy per dominant peak (zero peaks ⇒ keypoint dropped, matches C++).
+7. **Bucket pruning**: distribute keypoints across `num_buckets_x × num_buckets_y` fine-image spatial buckets; take best-by-|score| per bucket round-robin until `max_num_feature_points` reached.
+
+### 3.4 FFI shim (`kpm_c_api.h/.cpp`)
+
+```c
+int webarkit_cpp_dog_detect_count(
+    const unsigned char* src, int src_w, int src_h,
+    int num_octaves,
+    float laplacian_threshold, float edge_threshold,
+    int max_num_feature_points, int find_orientation,
+    int* count_out);
+```
+
+Returns 0 on success; non-zero codes for validation failure / C++ exception. ~90 lines of C++.
+
+---
+
+## 4. Assumptions
+
+1. `Matrix<f32>` API surface (verified in M8-2) supports all needed operations: `as_slice`, `as_mut_slice`, `from_vec`, `zeros`, `rows`, `cols`, `channels` fields.
+2. `bilinear_interpolate_f32` from `interpolate.rs` (M8-2) is the right API for sub-pixel gradient access on `Matrix<f32>` gradient images.
+3. `bilinear_upsample_point` / `bilinear_downsample_point` from `interpolate.rs` (M8-2) handle the cross-octave Hessian variants and the `From<&DoGFeaturePoint>` fine-image projection.
+4. `found.jpg` lives at `benchmarks/data/found.jpg` (verified); loaded as grayscale `Matrix<u8>` in tests via the `image` crate.
+5. License header on both new files; year 2026; author Walter Perdan @kalwalt.
+6. Sort stability: Rust's `sort_by` is stable, C++ `std::sort` is not guaranteed stable. The `MAX_TIE_DIVERGENCE = 5` tolerance covers any tie-related variance.
+7. The `-ffp-contract=off` flag added in M8-2 keeps C++ floating-point output deterministic across platforms; all numeric helpers in this PR inherit that determinism.
+
+### 4.1 C++-verified defaults (sourced from `DoG_scale_invariant_detector.cpp` lines 108–134)
+
+| Parameter | Value | Source |
+|---|---|---|
+| `laplacian_threshold` | `0` (no contrast filter) | `DoGScaleInvariantDetector::DoGScaleInvariantDetector` |
+| `edge_threshold` | `10` → `hessian_threshold = (10+1)²/10 = 12.1` | same |
+| `max_subpixel_distance_sqr` | `9` (`3*3` — already squared; name has `Sqr` suffix) | same |
+| `num_buckets_x = num_buckets_y` | `10` | same |
+| `find_orientation` | `true` | same |
+| `max_num_feature_points` (`kMaxNumFeaturePoints`) | `5000` | same |
+| `kMaxNumOrientations` | `36` (used both as histogram bin count and per-keypoint orientation cap) | header constant |
+| OA `num_bins` | `36` (= `kMaxNumOrientations`) | `alloc(...)` call site |
+| OA `gaussian_expansion_factor` | `3.0` | `alloc(...)` call site |
+| OA `support_region_expansion_factor` | `1.5` | `alloc(...)` call site |
+| OA `num_smoothing_iterations` | `5` | `alloc(...)` call site |
+| OA `peak_threshold` | `0.8` | `alloc(...)` call site |
+
+### 4.2 Corrections to §3 found during implementation
+
+- **DoG direction**: `dog[s] = pyramid[s] - pyramid[s+1]` (less-blurred minus more-blurred), per C++ `difference_image_binomial` (lines 85–106). The opposite direction was assumed in the original §3.3 draft.
+- **Fine-image coordinates from extraction**: `(x, y)` are upsampled to fine-image coordinates **at extraction time** via `bilinear_upsample_point`, matching C++. The original draft stored octave-local coords until the `From` projection. Now stored as fine-image coords throughout `DoGFeaturePoint`.
+- **Pipeline order**: prune → orient (matches C++ `detect()`), **not** orient → prune. Pruning before orientation avoids computing orientations for keypoints that get dropped.
+- **`sp_scale` semantics**: full sub-pixel scale value `scale + u[2]`, clipped to `[0, NUM_DOG_PER_OCTAVE]`. Not an offset in `(-0.5, 0.5)` as originally drafted.
+- **`OrientationAssignment` gradient channel order**: `(angle, magnitude)` — matches C++ `ComputePolarGradients` which writes `atan2(dy, dx) + π` to channel 0 and `sqrt(dx² + dy²)` to channel 1. The angle channel is shifted into `[0, 2π]` (atan2 result `+ π`). The original draft had `(magnitude, angle)`.
+- **OA factor names swapped in original draft**: `gaussian_expansion_factor = 3.0` and `support_region_expansion_factor = 1.5` (not the reverse). Total support radius = `3.0 · 1.5 · sigma = 4.5 · sigma`.
+
+---
+
+## 5. Test Plan
+
+| Test | Source | Notes |
+|---|---|---|
+| `test_orientation_assignment_horizontal_gradient` | Issue spec | Synthetic level (`pixel = col as f32`); call `compute_gradient_image` → `OrientationAssignment::compute`; dominant orientation within tolerance of π/2 |
+| `test_orientation_assignment_empty_when_no_gradients` | Hardening | Flat image returns empty Vec |
+| `test_dog_detector_finds_keypoints_on_real_image` | Issue spec | Load `found.jpg`; 3-octave pyramid; assert > 50 keypoints |
+| `test_dog_detector_keypoints_within_image_bounds` | Issue spec | All `(x, y)` ∈ `[0, w) × [0, h)` after `From<&DoGFeaturePoint>` projection |
+| `test_dog_feature_point_from_conversion` | Hardening | Hand-crafted `DoGFeaturePoint` projects correctly; `maxima = score >= 0` |
+| `test_dog_detector_zero_octave_pyramid_is_handled` | Hardening | Degenerate pyramid; no panic, possibly empty Vec |
+| `test_dog_keypoints_match_cpp_count` | Issue spec (modified) | `#[cfg(feature = "dual-mode")]`; live FFI; `\|rust - cpp\| <= 5` |
+
+**Verification commands:**
+
+```
+cargo test -p webarkitlib-rs -- kpm::freak::orientation kpm::freak::detector
+cargo test -p webarkitlib-rs --lib --features dual-mode -- kpm::freak::detector
+cargo clippy -p webarkitlib-rs -- -D warnings
+```
+
+---
+
+## 6. Follow-up Work (Out of Scope This PR)
+
+The Option C deferred items, naturally absorbed into **M8-4 (FREAK descriptor)** since the descriptor will share gradient images with `OrientationAssignment`:
+
+- **Public two-phase `OrientationAssignment` API** — `compute_gradients(&mut self, pyramid)` and `compute(...)` as separate public methods, with caller-owned gradient image cache reused across detect/describe calls.
+- **Full 7-parameter `OrientationAssignment::new(...)`** — replace hardcoded FREAK defaults with constructor parameters.
+- **Reusable gradient image cache** — currently rebuilt per `detect()` call; M8-4 will expose the cache so describe() can reuse it.
+
+Also deferred (analogous to #131/#132 for the box-filter pyramid):
+
+- **`criterion` benchmark** for `detect()` end-to-end and `compute_gradient_image` hot path.
+- **SIMD path** for `compute_gradient_image` (largest hot loop in M8-3) and `dog_image`.
+
+---
+
+## 7. Open Risks
+
+1. **`OrientationAssignment` default values** — hardcoded FREAK defaults in §3.1 are best-effort cross-references; if any differ from the actual C++ FreakMatcher facade call site, the dual-mode test count will diverge. Mitigation: verify defaults from C++ source before coding; document the source location.
+
+2. **Cross-octave Hessian dispatch indexing** — the 3 variants depend on consistent (oct, dog_idx) → (lap0, lap1, lap2) mapping. Off-by-one in the boundary cases would produce wrong refinement and lose keypoints near octave transitions. Mitigation: extensive unit tests with hand-crafted DoG pyramids that span octave boundaries.
+
+3. **Bucket pruning sort stability** — C++ `std::sort` is unstable; Rust `sort_by` is stable. Where multiple keypoints have identical |score| (rare but possible), the pruning order will differ. The `MAX_TIE_DIVERGENCE = 5` tolerance covers this. If CI shows divergence > 5 we know there's a real bug to find.
+
+4. **f32 cross-platform parity (legacy)** — the M8-2 `-ffp-contract=off` build flag should keep this PR deterministic across platforms. If macOS CI still produces a different keypoint count, investigate whether new code paths introduce FP contraction opportunities not covered by the existing flag.

--- a/docs/design/m8-3-dog-detector.md
+++ b/docs/design/m8-3-dog-detector.md
@@ -133,7 +133,34 @@ impl DoGScaleInvariantDetector {
 6. **Orientation assignment** (when `find_orientation == true`): precompute one gradient image per pyramid level; for each refined point query `OrientationAssignment::compute(...)`; emit one copy per dominant peak (zero peaks ⇒ keypoint dropped, matches C++).
 7. **Bucket pruning**: distribute keypoints across `num_buckets_x × num_buckets_y` fine-image spatial buckets; take best-by-|score| per bucket round-robin until `max_num_feature_points` reached.
 
-### 3.4 FFI shim (`kpm_c_api.h/.cpp`)
+### 3.4 Replacing the C++ `NONMAX_CHECK` preprocessor macro
+
+The C++ `extractFeatures` uses an `#define NONMAX_CHECK(OPERATOR, VALUE)` macro that expands to a chain of 26 short-circuit `&&` comparisons (9 from `im0`, 8 from `im1` excluding the center, 9 from `im2`). It is parameterized by an operator token (`>` or `<`) so a single macro covers both maxima and minima detection, and a single chain runs at full speed because each comparison is inlined by the preprocessor.
+
+Rust doesn't let you pass operator tokens as macro parameters as cleanly, so the macro is replaced by **an `enum NonMaxOp { Greater, Less }` plus three private inlined helper functions**, one per dimension pattern:
+
+| Function | C++ macro instance |
+|---|---|
+| `nonmax_same_octave(op, val, im0, im1, im2, w, row, col)` | SameOctave (all three `im*` same dims) |
+| `nonmax_fine_octave(op, val, im0, im1, im2, w, row, col, ds_x, ds_y)` | FineOctavePair (`im2` half-sized → 9 `bilinear_interpolate_f32` lookups) |
+| `nonmax_coarse_octave(op, val, im0, im1, im2, w, row, col, us_x, us_y)` | CoarseOctavePair (`im0` double-sized → 9 `bilinear_interpolate_f32` lookups) |
+
+Each helper builds a `cmp` closure with a `match op { Greater => a > b, Less => a < b }` and chains the 26 `cmp(val, neighbor)` calls with `&&`. The call site mirrors the C++ `if/else if`:
+
+```rust
+let extrema = nonmax_same_octave(NonMaxOp::Greater, value, d0, d1, d2, w, row, col)
+    || nonmax_same_octave(NonMaxOp::Less, value, d0, d1, d2, w, row, col);
+```
+
+**Trade-offs considered:**
+
+- **Trait-generic `fn nonmax<C: Fn(f32, f32) -> bool>(cmp: C, ...)`** — would force monomorphization twice per call site and bloat the call graph; rejected.
+- **`macro_rules!` macro** — would match the C++ structure most literally, but Rust hygiene requires explicit captures of every variable, making the macro definition harder to read than the function form; rejected.
+- **Inline expansion** of all 156 comparisons (26 × 2 operators × 3 patterns) — rejected as repetitive.
+
+The enum-with-closure form is shorter than the alternatives and the `#[inline]` annotation gives the compiler the same opportunity to specialize as the C++ macro got at preprocess time. In optimized builds the `match op` is constant-folded per call site because the caller passes a literal `NonMaxOp::Greater` or `NonMaxOp::Less`.
+
+### 3.5 FFI shim (`kpm_c_api.h/.cpp`)
 
 ```c
 int webarkit_cpp_dog_detect_count(


### PR DESCRIPTION
## Summary

Step 3 of **Milestone 8** (FREAK descriptor & DoG detector). Ports the C++ orientation assignment and Difference-of-Gaussians scale-invariant detector to two new Rust sibling modules under `crates/core/src/kpm/freak/`.

The DoG detector finds scale-invariant keypoints from the Gaussian pyramid (M8-2 output); these keypoints feed the FREAK descriptor (M8-4 next) and downstream KPM matching.

**Refs**: #125, #128
**Base**: `feat/m8-freak-detector` (M8 integration branch)
**Builds on**: #135 (M8-2 Gaussian pyramid + interpolate)

## What's in this PR

- **New**: `crates/core/src/kpm/freak/orientation.rs` — `OrientationAssignment` + `compute_polar_gradient_image` + private helpers + 5 unit tests
- **New**: `crates/core/src/kpm/freak/detector.rs` — `DoGFeaturePoint`, `DoGScaleInvariantDetector`, DoG pyramid, 3-way extrema dispatch, 3-way Hessian dispatch, bucket pruning, orientation wiring, 4 unit tests + 1 dual-mode FFI test
- **Edit**: `crates/core/src/kpm/freak/mod.rs` — module declarations + re-exports
- **Edit**: `crates/core/src/kpm/freak/hough.rs` — placeholder `DoGScaleInvariantDetector` struct removed; `find_features` stub references the real type
- **Edit**: `crates/core/src/kpm/kpm_c_api.{h,cpp}` — new FFI shim `webarkit_cpp_dog_detect_count` (~115 lines) for dual-mode keypoint-count parity testing
- **New**: `docs/design/m8-3-dog-detector.md` — full design document with decision log, C++-verified defaults table, and corrections found during implementation

## Pipeline (matches C++ `DoGScaleInvariantDetector::detect`)

1. **Build DoG pyramid**: `dog[s] = pyramid[s] - pyramid[s+1]` (less-blurred minus more-blurred). `Matrix<f32>` storage.
2. **3D extrema** with 3 cross-octave dimension-pattern variants (SameOctave / FineOctavePair / CoarseOctavePair). Cross-octave neighbours accessed via bilinear interpolation.
3. **Sub-pixel refinement** via 3×3 Hessian (3 cross-octave variants + Gaussian elimination with partial pivoting). Discard if `‖δ‖² > 9` or H is degenerate.
4. **Edge-curvature rejection**: `(Dxx+Dyy)² / det ≥ (et+1)² / et`.
5. **Bucket pruning**: top-K per spatial bucket via `select_nth_unstable_by` (matches C++ `PruneDoGFeatures` / `std::nth_element`).
6. **Orientation assignment**: precompute gradient cache per `detect()` call; emit one keypoint copy per dominant peak (zero peaks → dropped, matches C++).

## Design Decisions

See `docs/design/m8-3-dog-detector.md` for the full decision log (7 entries). Highlights:

| Decision | Rationale |
|----------|-----------|
| **Option C scope** — faithful on algorithm-critical bits (3-way Hessian dispatch, bucket pruning, `Matrix<f32>` DoG, rich `DoGFeaturePoint`, all detector params), simplified on `OrientationAssignment` public surface | Keeps PR reviewable while preserving algorithm correctness; deferred surface promotion lands naturally in M8-4 where the FREAK descriptor will share the gradient cache |
| **Option B FeaturePoint** — separate `DoGFeaturePoint` (9 fields) in `detector.rs` + `From<&DoGFeaturePoint>` for `hough::FeaturePoint` (5 fields) | Mirrors C++ architecture: `vision::FeaturePoint` in `matchers/` is the persistent type; `DoGScaleInvariantDetector::FeaturePoint` is the working type with diagnostics |
| **Split into 2 modules** — `orientation.rs` + `detector.rs` | Mirrors C++ file organization; matches M8-2 splitting pattern |
| **Live FFI shim** `webarkit_cpp_dog_detect_count(...)` parameterized by detector config | Matches M8-2 pattern; no binary blob; both sides run identical configuration |
| **`MAX_TIE_DIVERGENCE = 5`** for keypoint count tolerance | The issue's ±10% would allow ±50 keypoints — too loose. ±5 catches sort tie-breaking variance only; any algorithm error dwarfs this |
| **`detect()` is infallible** — returns `Vec<DoGFeaturePoint>` directly | Pre-validated pyramid; no failure modes that are not caught upstream; empty Vec = no keypoints found |

## Deferred to M8-4

The Option C deferred items will land in M8-4 (FREAK descriptor) where they are actually needed:

- Public two-phase `OrientationAssignment` API (`compute_gradients(&mut self, pyramid)` + `compute(...)` separated)
- Full 7-parameter `OrientationAssignment::new(...)` constructor (replacing hardcoded FREAK defaults)
- Reusable gradient image cache across `detect()` / `describe()` calls

(Tracked in §6 of the design doc.)

## Bugs caught during implementation

Several mismatches between the original issue spec and the C++ source were caught and fixed before any code shipped — see §4.2 of the design doc. Key ones:

1. **DoG direction** was flipped in the original draft. C++ does `pyramid[s] - pyramid[s+1]` (less-blurred minus more-blurred). Flipping the sign would invert which DoG values are maxima vs minima.
2. **`OrientationAssignment` factor names swapped**: actual values are `gaussian_expansion_factor = 3.0`, `support_region_expansion_factor = 1.5` (not the reverse). Total radius = `3.0 · 1.5 · sigma = 4.5 · sigma`.
3. **Pipeline order**: C++ runs `prune` *before* `orient` (this PR does the same). Avoids computing orientations for keypoints that get dropped.
4. **OOB float check**: `(-1.0 + 0.5) as i32 = 0` slips past int bounds. Caught by `test_orientation_assignment_out_of_bounds_returns_empty`; added an explicit float-level negative-coordinate check.
5. **sp_scale semantics**: full sub-pixel scale value (clipped to `[0, NUM_DOG_PER_OCTAVE]`), not an offset.
6. **Fine-image coordinates from extraction**: `DoGFeaturePoint.{x, y}` are fine-image coords from the start (matching C++), not octave-local.

## What is NOT in this PR (intentional)

- **FREAK descriptor extraction** (M8-4 — next)
- **Harris detector** — dead code from removed SURF pipeline (excluded by issue)
- **SIMD/rayon** — defer to follow-up perf PR analogous to #131/#132
- **Public two-phase `OrientationAssignment` API** — deferred to M8-4 (Option C)
- **Full 7-param `OrientationAssignment::new`** — deferred to M8-4 (Option C)

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build -p webarkitlib-rs` — clean
- [x] `cargo clippy` on new modules — zero issues (2 documented `#![allow]` annotations for `too_many_arguments` on parallel-structure helpers and `needless_range_loop` for textbook Gaussian elimination)
- [x] `cargo test -p webarkitlib-rs --lib -- kpm::freak::{orientation,detector}` — **9 passed, 0 failed**
- [x] `cargo test -p webarkitlib-rs --lib --features dual-mode` — **382 passed, 0 failed** (including new dual-mode FFI parity test)

Test results:

```
running 9 tests (unit)
test kpm::freak::detector::tests::test_dog_feature_point_from_conversion ... ok
test kpm::freak::detector::tests::test_dog_detector_zero_octave_pyramid_is_handled ... ok
test kpm::freak::detector::tests::test_dog_detector_finds_keypoints_on_real_image ... ok
test kpm::freak::detector::tests::test_dog_detector_keypoints_within_image_bounds ... ok
test kpm::freak::orientation::tests::test_orientation_assignment_horizontal_gradient ... ok
test kpm::freak::orientation::tests::test_orientation_assignment_empty_when_no_gradients ... ok
test kpm::freak::orientation::tests::test_orientation_assignment_out_of_bounds_returns_empty ... ok
test kpm::freak::orientation::tests::test_polar_gradient_horizontal_image ... ok
test kpm::freak::orientation::tests::test_polar_gradient_output_shape ... ok

test kpm::freak::detector::tests::test_dog_keypoints_match_cpp_count ... ok (dual-mode, |rust - cpp| <= 5)
```

## Reviewer checklist

- [x] DoG direction: `dog[s] = pyramid[s] - pyramid[s+1]` (less-blurred − more-blurred)
- [x] 3-way Hessian dispatcher sign conventions (`Dxs`, `Dys` directions) match C++ inline expansions
- [x] Bucket pruning `select_nth_unstable_by` produces stable counts within ±5 of `std::nth_element`
- [x] `OrientationAssignment` factors: `gaussian=3.0`, `support=1.5` (not reversed)
- [x] Polar gradient channel order: channel 0 = angle ∈ `[0, 2π]`, channel 1 = magnitude
- [x] Parabolic peak refinement final-angle formula has the right half-bin offset
- [x] LGPL header on both new files
- [x] No `println!` / `eprintln!` in library code (uses `arlog_w!`)
- [x] `CHANGELOG.md` not touched (release-only rule)
- [x] Branch targets `feat/m8-freak-detector` (M8 integration branch), not `dev`
- [x] FFI shim correctly configures C++ detector (laplacian/edge thresholds, max keypoints, orientation flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
