### PR TITLE
feat(kpm): port FREAK descriptor + Keyframe to Rust (M8 step 4)

### DIFF
--- a/crates/core/src/kpm/freak/descriptor.rs
+++ b/crates/core/src/kpm/freak/descriptor.rs
@@ -1,0 +1,511 @@
+/*
+ *  descriptor.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! FREAK (Fast Retina Keypoint) descriptor extraction.
+//!
+//! Ported from `WebARKitLib/.../matchers/freak.{h,cpp}` and `matchers/freak84-inline.h`.
+//!
+//! The descriptor samples the Gaussian scale-space pyramid at a rotated set of receptors
+//! (6 rings × 6 points + 1 center = 37 receptors), compares all `C(37, 2) = 666` pairs,
+//! and packs the bits into a 96-byte slot. The first 84 bytes carry the packed bits;
+//! the trailing 12 bytes are zero padding. The padding matches the C++
+//! `BinaryFeatureStore` layout used by M7's `hamming_distance_96`.
+//!
+//! C equivalent: `vision::FREAKExtractor::extract`, `ExtractFREAK84`,
+//! `SamplePyramidFREAK84`, `CompareFREAK84`.
+
+use super::gaussian_pyramid::GaussianScaleSpacePyramid;
+use super::hough::FeaturePoint;
+use super::interpolate::{bilinear_downsample_point, bilinear_interpolate_f32};
+
+// ─────────────────────────────────────────────────────────────────────
+// Public constants
+// ─────────────────────────────────────────────────────────────────────
+
+/// Storage size in bytes per FREAK descriptor.
+///
+/// Matches C++ `setNumBytesPerFeature(96)` in `FREAKExtractor::extract`.
+/// Of these 96 bytes, the first [`FREAK_DESCRIPTOR_DATA_BYTES`] = 84 carry
+/// the packed bits (`C(37, 2) = 666` pairwise comparisons, LSB-first);
+/// the trailing 12 bytes are zero padding required for compatibility with
+/// M7's `hamming_distance_96` and the C++ `BinaryFeatureStore` layout.
+pub const FREAK_DESCRIPTOR_BYTES: usize = 96;
+
+// ─────────────────────────────────────────────────────────────────────
+// Private constants
+// ─────────────────────────────────────────────────────────────────────
+
+/// Number of bytes that carry actual descriptor data within each 96-byte
+/// slot. Bytes `FREAK_DESCRIPTOR_DATA_BYTES..FREAK_DESCRIPTOR_BYTES` are
+/// zero padding.
+const FREAK_DESCRIPTOR_DATA_BYTES: usize = 84;
+
+/// Number of (sample[i] < sample[j]) comparisons per descriptor.
+/// Matches the C++ `ASSERT(pos == 666, "...")` in `CompareFREAK84`.
+const FREAK_NUM_PAIRS: usize = 666; // = 37 * 36 / 2
+
+/// Number of receptors per descriptor: 1 center + 6 rings × 6 points.
+const FREAK_NUM_RECEPTORS: usize = 37;
+
+/// Scale multiplier applied to keypoint scale to obtain the similarity
+/// transform scale. Matches C++ `mExpansionFactor = 7` in
+/// `FREAKExtractor::FREAKExtractor()`.
+const FREAK_EXPANSION_FACTOR: f32 = 7.0;
+
+/// Sigma values for the center receptor and each of the 6 rings.
+/// Ported verbatim from `freak84-inline.h`.
+const FREAK_SIGMA_CENTER: f32 = 0.100_000;
+const FREAK_SIGMA_RING0: f32 = 0.175_000;
+const FREAK_SIGMA_RING1: f32 = 0.250_000;
+const FREAK_SIGMA_RING2: f32 = 0.325_000;
+const FREAK_SIGMA_RING3: f32 = 0.400_000;
+const FREAK_SIGMA_RING4: f32 = 0.475_000;
+const FREAK_SIGMA_RING5: f32 = 0.550_000;
+
+/// `(x, y)` coordinates for the 6 receptors in each ring, in canonical
+/// (pre-similarity-transform) units. Each ring has 6 receptors × 2 coords
+/// = 12 floats. Ported verbatim from `freak84-inline.h`.
+const FREAK_POINTS_RING0: [f32; 12] = [
+    0.000_000, 0.362_783, -0.314_179, 0.181_391, -0.314_179, -0.181_391, -0.000_000, -0.362_783,
+    0.314_179, -0.181_391, 0.314_179, 0.181_391,
+];
+const FREAK_POINTS_RING1: [f32; 12] = [
+    -0.595_502, 0.000_000, -0.297_751, -0.515_720, 0.297_751, -0.515_720, 0.595_502, -0.000_000,
+    0.297_751, 0.515_720, -0.297_751, 0.515_720,
+];
+const FREAK_POINTS_RING2: [f32; 12] = [
+    -0.000_000, -0.741_094, 0.641_806, -0.370_547, 0.641_806, 0.370_547, 0.000_000, 0.741_094,
+    -0.641_806, 0.370_547, -0.641_806, -0.370_547,
+];
+const FREAK_POINTS_RING3: [f32; 12] = [
+    0.847_306, -0.000_000, 0.423_653, 0.733_789, -0.423_653, 0.733_789, -0.847_306, 0.000_000,
+    -0.423_653, -0.733_789, 0.423_653, -0.733_789,
+];
+const FREAK_POINTS_RING4: [f32; 12] = [
+    0.000_000, 0.930_969, -0.806_243, 0.465_485, -0.806_243, -0.465_485, -0.000_000, -0.930_969,
+    0.806_243, -0.465_485, 0.806_243, 0.465_485,
+];
+const FREAK_POINTS_RING5: [f32; 12] = [
+    -1.000_000, 0.000_000, -0.500_000, -0.866_025, 0.500_000, -0.866_025, 1.000_000, -0.000_000,
+    0.500_000, 0.866_025, -0.500_000, 0.866_025,
+];
+
+// ─────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────
+
+/// Compute FREAK descriptors for each keypoint and append to `out`.
+///
+/// After the call, `out.len()` has grown by
+/// `keypoints.len() * FREAK_DESCRIPTOR_BYTES`. Each 96-byte slot is
+/// zero-initialized; the first 84 bytes are filled with 666 packed bit
+/// comparisons; bytes 84..96 remain zero (matches C++
+/// `BinaryFeatureStore` layout).
+///
+/// Caller responsibility: `keypoint.angle` should be set by
+/// `OrientationAssignment` (M8-3 via `DoGScaleInvariantDetector::detect`
+/// with `find_orientation = true`). If `angle == 0.0`, the descriptor is
+/// rotation-variant.
+///
+/// C equivalent: `vision::FREAKExtractor::extract` →
+/// `ExtractFREAK84` (per-keypoint) → `SamplePyramidFREAK84` +
+/// `CompareFREAK84`.
+pub fn extract_freak_descriptors(
+    pyramid: &GaussianScaleSpacePyramid,
+    keypoints: &[FeaturePoint],
+    out: &mut Vec<u8>,
+) {
+    out.reserve(keypoints.len() * FREAK_DESCRIPTOR_BYTES);
+
+    let mut samples = [0.0f32; FREAK_NUM_RECEPTORS];
+
+    for kp in keypoints {
+        sample_pyramid_freak84(&mut samples, pyramid, kp);
+
+        // Reserve the 96-byte slot, zero-initialized.
+        let start = out.len();
+        out.resize(start + FREAK_DESCRIPTOR_BYTES, 0);
+        // Pack 666 bits into the first 84 bytes. Bytes 84..96 stay zero.
+        let desc = &mut out[start..start + FREAK_DESCRIPTOR_DATA_BYTES];
+        let mut pos = 0usize;
+        for i in 0..FREAK_NUM_RECEPTORS {
+            for j in (i + 1)..FREAK_NUM_RECEPTORS {
+                if samples[i] < samples[j] {
+                    desc[pos / 8] |= 1u8 << (pos % 8);
+                }
+                pos += 1;
+            }
+        }
+        debug_assert_eq!(pos, FREAK_NUM_PAIRS);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Private helpers
+// ─────────────────────────────────────────────────────────────────────
+
+/// Sample the 37 receptors for one keypoint. Matches the C++ sample order
+/// `ring5 → ring4 → ring3 → ring2 → ring1 → ring0 → center` from
+/// `SamplePyramidFREAK84`. Reordering would produce a fundamentally
+/// different bit pattern incompatible with the C++ baseline.
+fn sample_pyramid_freak84(
+    samples: &mut [f32; FREAK_NUM_RECEPTORS],
+    pyramid: &GaussianScaleSpacePyramid,
+    kp: &FeaturePoint,
+) {
+    // Similarity transform: clamped at 1.0 to match C++.
+    let raw_scale = kp.scale * FREAK_EXPANSION_FACTOR;
+    let transform_scale = if raw_scale < 1.0 { 1.0 } else { raw_scale };
+    let cs = transform_scale * kp.angle.cos();
+    let sn = transform_scale * kp.angle.sin();
+
+    // Transform sigmas.
+    let sc = FREAK_SIGMA_CENTER * transform_scale;
+    let s0 = FREAK_SIGMA_RING0 * transform_scale;
+    let s1 = FREAK_SIGMA_RING1 * transform_scale;
+    let s2 = FREAK_SIGMA_RING2 * transform_scale;
+    let s3 = FREAK_SIGMA_RING3 * transform_scale;
+    let s4 = FREAK_SIGMA_RING4 * transform_scale;
+    let s5 = FREAK_SIGMA_RING5 * transform_scale;
+
+    // Sample in C++ order (ring5 → ring4 → … → ring0 → center).
+    sample_ring(
+        &mut samples[0..6],
+        pyramid,
+        s5,
+        &FREAK_POINTS_RING5,
+        kp,
+        cs,
+        sn,
+    );
+    sample_ring(
+        &mut samples[6..12],
+        pyramid,
+        s4,
+        &FREAK_POINTS_RING4,
+        kp,
+        cs,
+        sn,
+    );
+    sample_ring(
+        &mut samples[12..18],
+        pyramid,
+        s3,
+        &FREAK_POINTS_RING3,
+        kp,
+        cs,
+        sn,
+    );
+    sample_ring(
+        &mut samples[18..24],
+        pyramid,
+        s2,
+        &FREAK_POINTS_RING2,
+        kp,
+        cs,
+        sn,
+    );
+    sample_ring(
+        &mut samples[24..30],
+        pyramid,
+        s1,
+        &FREAK_POINTS_RING1,
+        kp,
+        cs,
+        sn,
+    );
+    sample_ring(
+        &mut samples[30..36],
+        pyramid,
+        s0,
+        &FREAK_POINTS_RING0,
+        kp,
+        cs,
+        sn,
+    );
+
+    // Center receptor: single sample at the (untransformed) keypoint location.
+    let (octave_c, scale_c) = pyramid.locate(sc);
+    samples[36] = sample_pyramid_at(pyramid, kp.x, kp.y, octave_c, scale_c);
+}
+
+/// Sample the 6 receptors of one ring. All 6 share the same `(octave, scale)`
+/// determined by `pyramid.locate(sigma)` (matches C++ — locating per receptor
+/// would risk landing different receptors of the same ring at different
+/// octaves due to FP variance, breaking C++ parity).
+fn sample_ring(
+    out: &mut [f32],
+    pyramid: &GaussianScaleSpacePyramid,
+    sigma: f32,
+    ring: &[f32; 12],
+    kp: &FeaturePoint,
+    cs: f32,
+    sn: f32,
+) {
+    let (octave, scale_idx) = pyramid.locate(sigma);
+    for i in 0..6 {
+        let px = ring[i * 2];
+        let py = ring[i * 2 + 1];
+        // S · (px, py): [cs·px − sn·py + kp.x ; sn·px + cs·py + kp.y]
+        let rx = kp.x + cs * px - sn * py;
+        let ry = kp.y + sn * px + cs * py;
+        out[i] = sample_pyramid_at(pyramid, rx, ry, octave, scale_idx);
+    }
+}
+
+/// Downsample fine-image `(x, y)` to octave-local coordinates, clip to
+/// `[0, w-2] × [0, h-2]` (matches C++ `SampleReceptorBilinear`), and
+/// sample with bilinear interpolation on the Gaussian pyramid level.
+fn sample_pyramid_at(
+    pyramid: &GaussianScaleSpacePyramid,
+    x: f32,
+    y: f32,
+    octave: usize,
+    scale: usize,
+) -> f32 {
+    let level = pyramid.level(octave, scale);
+    let (xp, yp) = bilinear_downsample_point(x, y, octave as i32);
+    let xc = xp.clamp(0.0, (level.cols as f32) - 2.0);
+    let yc = yp.clamp(0.0, (level.rows as f32) - 2.0);
+    bilinear_interpolate_f32(level, xc, yc)
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Tests
+// ═════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use purecv::core::Matrix;
+
+    fn load_grayscale(path: &str) -> Matrix<u8> {
+        let img = image::open(path).expect("load test image").to_luma8();
+        let (w, h) = img.dimensions();
+        Matrix::<u8>::from_vec(h as usize, w as usize, 1, img.into_raw())
+    }
+
+    fn build_pyramid(img: &Matrix<u8>) -> GaussianScaleSpacePyramid {
+        let mut p = GaussianScaleSpacePyramid::new(3);
+        p.build(img).expect("build pyramid");
+        p
+    }
+
+    fn synthetic_keypoint(x: f32, y: f32, sigma: f32) -> FeaturePoint {
+        FeaturePoint {
+            x,
+            y,
+            angle: 0.0,
+            scale: sigma,
+            maxima: true,
+        }
+    }
+
+    // ── Length / shape ────────────────────────────────────────────────
+
+    #[test]
+    fn test_freak_descriptor_length_one_keypoint() {
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let pyr = build_pyramid(&img);
+        let kps = vec![synthetic_keypoint(100.0, 100.0, 1.5)];
+        let mut out = Vec::<u8>::new();
+        extract_freak_descriptors(&pyr, &kps, &mut out);
+        assert_eq!(out.len(), FREAK_DESCRIPTOR_BYTES);
+        assert_eq!(out.len(), 96);
+    }
+
+    #[test]
+    fn test_freak_descriptor_length_multiple_keypoints() {
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let pyr = build_pyramid(&img);
+        let kps: Vec<_> = (0..5)
+            .map(|i| synthetic_keypoint(50.0 + 30.0 * i as f32, 100.0, 1.5))
+            .collect();
+        let mut out = Vec::<u8>::new();
+        extract_freak_descriptors(&pyr, &kps, &mut out);
+        assert_eq!(out.len(), 5 * FREAK_DESCRIPTOR_BYTES);
+        assert_eq!(out.len(), 480);
+    }
+
+    #[test]
+    fn test_freak_descriptor_padding_bytes_are_zero() {
+        // Bytes 84..96 of each descriptor must be zero (matches C++ store layout).
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let pyr = build_pyramid(&img);
+        let kps = vec![synthetic_keypoint(150.0, 150.0, 1.5)];
+        let mut out = Vec::<u8>::new();
+        extract_freak_descriptors(&pyr, &kps, &mut out);
+        for (i, &b) in out[FREAK_DESCRIPTOR_DATA_BYTES..FREAK_DESCRIPTOR_BYTES]
+            .iter()
+            .enumerate()
+        {
+            assert_eq!(
+                b,
+                0,
+                "padding byte at offset {} must be zero",
+                FREAK_DESCRIPTOR_DATA_BYTES + i
+            );
+        }
+    }
+
+    #[test]
+    fn test_freak_descriptor_empty_input() {
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let pyr = build_pyramid(&img);
+        let mut out = Vec::<u8>::new();
+        extract_freak_descriptors(&pyr, &[], &mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_freak_descriptor_is_reproducible() {
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let pyr = build_pyramid(&img);
+        let kps = vec![
+            synthetic_keypoint(100.0, 100.0, 1.5),
+            synthetic_keypoint(200.0, 150.0, 2.0),
+        ];
+        let mut a = Vec::<u8>::new();
+        let mut b = Vec::<u8>::new();
+        extract_freak_descriptors(&pyr, &kps, &mut a);
+        extract_freak_descriptors(&pyr, &kps, &mut b);
+        assert_eq!(a, b, "extraction must be reproducible byte-for-byte");
+    }
+
+    // ── Dual-mode: per-descriptor Hamming distance vs C++ ─────────────
+
+    #[cfg(feature = "dual-mode")]
+    extern "C" {
+        fn webarkit_cpp_extract_freak_descriptors(
+            src: *const u8,
+            src_w: i32,
+            src_h: i32,
+            num_octaves: i32,
+            keypoints: *const f32,
+            num_keypoints: i32,
+            dst_out: *mut u8,
+            dst_capacity_bytes: i32,
+        ) -> i32;
+    }
+
+    #[cfg(feature = "dual-mode")]
+    fn cpp_extract_freak_descriptors(
+        img: &Matrix<u8>,
+        num_octaves: usize,
+        keypoints: &[FeaturePoint],
+    ) -> Vec<u8> {
+        let kp_flat: Vec<f32> = keypoints
+            .iter()
+            .flat_map(|p| [p.x, p.y, p.angle, p.scale])
+            .collect();
+        let mut dst = vec![0u8; keypoints.len() * FREAK_DESCRIPTOR_BYTES];
+        // SAFETY: pointers are valid for declared lengths; shim validates
+        // dst_capacity_bytes >= num_keypoints * 96.
+        let rc = unsafe {
+            webarkit_cpp_extract_freak_descriptors(
+                img.as_slice().as_ptr(),
+                img.cols as i32,
+                img.rows as i32,
+                num_octaves as i32,
+                kp_flat.as_ptr(),
+                keypoints.len() as i32,
+                dst.as_mut_ptr(),
+                dst.len() as i32,
+            )
+        };
+        assert_eq!(rc, 0, "C++ shim returned error {rc}");
+        dst
+    }
+
+    #[cfg(feature = "dual-mode")]
+    fn hamming_distance(a: &[u8], b: &[u8]) -> u32 {
+        a.iter().zip(b).map(|(x, y)| (x ^ y).count_ones()).sum()
+    }
+
+    #[test]
+    #[cfg(feature = "dual-mode")]
+    fn test_freak_descriptors_match_cpp_baseline() {
+        use crate::kpm::freak::detector::DoGScaleInvariantDetector;
+
+        // Tolerance allows for ~2 bits of libm/FMA cross-platform variance
+        // across 666 sign decisions per descriptor (~0.3%).
+        //
+        // Empirical local result (Windows MSVC, clean rebuild): all 10
+        // descriptors match C++ byte-for-byte (Hamming = 0). The
+        // tolerance is kept at 2 to absorb potential cross-platform
+        // variance (Linux GCC / macOS Apple clang) before tightening
+        // to exact match in a follow-up if CI shows consistent equality.
+        const MAX_HAMMING_PER_DESCRIPTOR: u32 = 2;
+
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let num_octaves = 3;
+        let pyr = build_pyramid(&img);
+        let det = DoGScaleInvariantDetector::new(0.0, 10.0, 5000, true);
+
+        // 1. Run Rust detection.
+        let dog_points = det.detect(&pyr);
+        let points: Vec<FeaturePoint> = dog_points.iter().map(FeaturePoint::from).collect();
+
+        // 2. Take top-10 by |raw DoG score| (before projection).
+        let mut indexed: Vec<(usize, f32)> = dog_points
+            .iter()
+            .enumerate()
+            .map(|(i, p)| (i, p.score.abs()))
+            .collect();
+        indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        let top10: Vec<FeaturePoint> = indexed.iter().take(10).map(|&(i, _)| points[i]).collect();
+        assert_eq!(top10.len(), 10, "expected >= 10 keypoints on found.jpg");
+
+        // 3. Rust descriptors.
+        let mut rust_descs = Vec::<u8>::new();
+        extract_freak_descriptors(&pyr, &top10, &mut rust_descs);
+
+        // 4. C++ descriptors via FFI shim (Rust supplies the keypoints).
+        let cpp_descs = cpp_extract_freak_descriptors(&img, num_octaves, &top10);
+
+        // 5. Per-descriptor Hamming distance.
+        assert_eq!(rust_descs.len(), cpp_descs.len());
+        for i in 0..10 {
+            let rs = &rust_descs[i * FREAK_DESCRIPTOR_BYTES..(i + 1) * FREAK_DESCRIPTOR_BYTES];
+            let cs = &cpp_descs[i * FREAK_DESCRIPTOR_BYTES..(i + 1) * FREAK_DESCRIPTOR_BYTES];
+            let h = hamming_distance(rs, cs);
+            assert!(
+                h <= MAX_HAMMING_PER_DESCRIPTOR,
+                "keypoint #{i}: Hamming distance {h} > {MAX_HAMMING_PER_DESCRIPTOR}"
+            );
+        }
+    }
+}

--- a/crates/core/src/kpm/freak/hough.rs
+++ b/crates/core/src/kpm/freak/hough.rs
@@ -386,12 +386,6 @@ impl HoughSimilarityVoting {
     }
 }
 
-/// Placeholder for Keyframe from M8.
-#[derive(Clone, Debug)]
-pub struct Keyframe {
-    pub features: Vec<FeaturePoint>,
-}
-
 /// A feature point with position, orientation, scale, and extremum type.
 /// C equivalent: vision::FeaturePoint
 #[derive(Clone, Debug, Copy)]
@@ -434,13 +428,39 @@ pub struct HoughMatch {
     pub distance: f32,
 }
 
-/// Stub for FindFeatures (M8 will implement).
+/// Detect keypoints in the Gaussian pyramid and extract FREAK descriptors
+/// into `keyframe.store`.
+///
+/// Caller responsibilities:
+/// - `pyramid` is already built (via `pyramid.build(image)?`).
+/// - `detector` is configured with `find_orientation = true`. Otherwise
+///   keypoints have `angle = 0.0` and the resulting FREAK descriptors are
+///   rotation-variant, defeating the FREAK design.
+///
+/// C equivalent: `vision::FindFeatures` (`visual_database.h` lines 207–239).
 pub fn find_features(
-    _keyframe: &mut Keyframe,
-    _detector: &super::detector::DoGScaleInvariantDetector,
-    _pyramid: &super::gaussian_pyramid::GaussianScaleSpacePyramid,
+    keyframe: &mut super::keyframe::Keyframe,
+    pyramid: &super::gaussian_pyramid::GaussianScaleSpacePyramid,
+    detector: &super::detector::DoGScaleInvariantDetector,
 ) -> Result<(), KpmError> {
-    arlog_i!("find_features: stub implementation (M8 pending)");
+    // 1. Detect keypoints (M8-3).
+    let dog_points = detector.detect(pyramid);
+
+    // 2. Project rich DoG keypoints to persistent FeaturePoint (M8-3 From impl).
+    let points: Vec<FeaturePoint> = dog_points.iter().map(FeaturePoint::from).collect();
+
+    // 3. Extract FREAK descriptors as a flat Vec<u8>.
+    let mut buf =
+        Vec::<u8>::with_capacity(points.len() * super::descriptor::FREAK_DESCRIPTOR_BYTES);
+    super::descriptor::extract_freak_descriptors(pyramid, &points, &mut buf);
+
+    // 4. Populate the keyframe's FeatureStore.
+    for (i, point) in points.iter().enumerate() {
+        let start = i * super::descriptor::FREAK_DESCRIPTOR_BYTES;
+        let desc = &buf[start..start + super::descriptor::FREAK_DESCRIPTOR_BYTES];
+        keyframe.store.add(*point, desc)?;
+    }
+
     Ok(())
 }
 

--- a/crates/core/src/kpm/freak/keyframe.rs
+++ b/crates/core/src/kpm/freak/keyframe.rs
@@ -1,0 +1,121 @@
+/*
+ *  keyframe.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Per-frame container holding FREAK descriptors and feature points.
+//!
+//! Mirrors C++ `vision::Keyframe<96>` from `keyframe.h`. The C++ template
+//! parameter `NUM_BYTES_PER_FEATURE = 96` matches our
+//! [`super::descriptor::FREAK_DESCRIPTOR_BYTES`].
+//!
+//! Keyframe is a **passive container**: it stores the per-frame results
+//! but does not run the detection / extraction pipeline itself. The
+//! orchestration that populates this container lives in
+//! [`super::hough::find_features`] (mirroring C++ `vision::FindFeatures`
+//! in `visual_database.h`).
+//!
+//! The C++ Keyframe also holds a `BinaryHierarchicalClustering` index for
+//! fast nearest-neighbour matching. That index is **not** built here —
+//! downstream KPM matching (already in main from M7) constructs its own
+//! index when needed.
+
+use crate::kpm::backend::KpmError;
+
+use super::descriptor::FREAK_DESCRIPTOR_BYTES;
+use super::matcher::FeatureStore;
+
+/// Per-frame container holding FREAK descriptors and feature points.
+///
+/// C equivalent: `vision::Keyframe<96>`.
+pub struct Keyframe {
+    /// FREAK descriptors and their associated feature points.
+    /// `bytes_per_feature` is fixed at [`FREAK_DESCRIPTOR_BYTES`] = 96.
+    pub store: FeatureStore,
+    /// Width of the source image.
+    pub width: i32,
+    /// Height of the source image.
+    pub height: i32,
+}
+
+impl Keyframe {
+    /// Create an empty Keyframe sized for `(width, height)` source images.
+    /// The internal [`FeatureStore`] is configured for 96-byte descriptors.
+    pub fn new(width: i32, height: i32) -> Result<Self, KpmError> {
+        Ok(Self {
+            store: FeatureStore::new(FREAK_DESCRIPTOR_BYTES)?,
+            width,
+            height,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kpm::freak::detector::DoGScaleInvariantDetector;
+    use crate::kpm::freak::gaussian_pyramid::GaussianScaleSpacePyramid;
+    use crate::kpm::freak::hough::find_features;
+    use purecv::core::Matrix;
+
+    fn load_grayscale(path: &str) -> Matrix<u8> {
+        let img = image::open(path).expect("load test image").to_luma8();
+        let (w, h) = img.dimensions();
+        Matrix::<u8>::from_vec(h as usize, w as usize, 1, img.into_raw())
+    }
+
+    #[test]
+    fn test_keyframe_new_stores_dimensions() {
+        let kf = Keyframe::new(640, 480).unwrap();
+        assert_eq!(kf.width, 640);
+        assert_eq!(kf.height, 480);
+        assert_eq!(kf.store.num_features(), 0);
+    }
+
+    #[test]
+    fn test_find_features_populates_keyframe() {
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let mut pyr = GaussianScaleSpacePyramid::new(3);
+        pyr.build(&img).unwrap();
+        let det = DoGScaleInvariantDetector::new(0.0, 10.0, 5000, true);
+
+        let mut kf = Keyframe::new(img.cols as i32, img.rows as i32).unwrap();
+        find_features(&mut kf, &pyr, &det).expect("find_features");
+        assert!(
+            kf.store.num_features() > 50,
+            "expected > 50 features on found.jpg, got {}",
+            kf.store.num_features()
+        );
+    }
+}

--- a/crates/core/src/kpm/freak/mod.rs
+++ b/crates/core/src/kpm/freak/mod.rs
@@ -41,11 +41,13 @@
 //! implementation and optimized for performance.
 
 pub mod clustering;
+pub mod descriptor;
 pub mod detector;
 pub mod gaussian_pyramid;
 pub mod homography;
 pub mod hough;
 pub mod interpolate;
+pub mod keyframe;
 pub mod matcher;
 pub mod math;
 pub mod orientation;
@@ -53,16 +55,18 @@ pub mod pyramid;
 
 // Public re-exports for convenience
 pub use clustering::{hamming_distance_96, BhcNode, BinaryHierarchicalClustering, KMedoids};
+pub use descriptor::{extract_freak_descriptors, FREAK_DESCRIPTOR_BYTES};
 pub use detector::{DoGFeaturePoint, DoGScaleInvariantDetector};
 pub use gaussian_pyramid::{num_octaves_for, GaussianPyramidError, GaussianScaleSpacePyramid};
 pub use hough::{
     find_features, find_hough_matches, find_hough_similarity, BinParams, FeaturePoint, HoughMatch,
-    HoughSimilarityVoting, Keyframe, Match,
+    HoughSimilarityVoting, Match,
 };
 pub use interpolate::{
     bilinear_downsample_point, bilinear_interpolate, bilinear_interpolate_f32,
     bilinear_interpolate_u8, bilinear_upsample_point,
 };
+pub use keyframe::Keyframe;
 pub use matcher::{FeatureMatcher, FeatureStore};
 pub use orientation::{compute_polar_gradient_image, OrientationAssignment};
 pub use pyramid::{Pyramid, PyramidError};

--- a/crates/core/src/kpm/kpm_c_api.cpp
+++ b/crates/core/src/kpm/kpm_c_api.cpp
@@ -59,6 +59,7 @@
 #include <detectors/DoG_scale_invariant_detector.h>
 #include <detectors/gaussian_scale_space_pyramid.h>
 #include <framework/image.h>
+#include <matchers/freak.h>
 #include <Eigen/Core>
 #include <unsupported/Eigen/MatrixFunctions>
 
@@ -506,6 +507,72 @@ int webarkit_cpp_fast_random(int* seed) {
 
 void webarkit_cpp_array_shuffle(int* v, int pop_size, int sample_size, int* seed) {
     vision::ArrayShuffle<int>(v, pop_size, sample_size, *seed);
+}
+
+/* ---- Dual-mode validation: FREAKExtractor bridge (Milestone 8, #129) ---- */
+
+int webarkit_cpp_extract_freak_descriptors(
+    const unsigned char* src,
+    int src_w,
+    int src_h,
+    int num_octaves,
+    const float* keypoints,
+    int num_keypoints,
+    unsigned char* dst_out,
+    int dst_capacity_bytes) {
+
+    if (!src || (!keypoints && num_keypoints > 0) || !dst_out
+        || src_w < 5 || src_h < 5 || num_octaves < 1 || num_keypoints < 0) {
+        return 1;
+    }
+    // Verify all octaves fit the binomial filter (M8-2 invariant: each octave >= 5x5).
+    {
+        int w = src_w;
+        int h = src_h;
+        for (int o = 0; o < num_octaves; ++o) {
+            if (w < 5 || h < 5) {
+                return 2;
+            }
+            w >>= 1;
+            h >>= 1;
+        }
+    }
+    if (dst_capacity_bytes < num_keypoints * 96) {
+        return 3;
+    }
+
+    try {
+        vision::Image image(
+            const_cast<unsigned char*>(src), vision::IMAGE_UINT8,
+            src_w, src_h, src_w /* step */, 1);
+
+        vision::BinomialPyramid32f pyr;
+        pyr.alloc(src_w, src_h, num_octaves);
+        pyr.build(image);
+
+        std::vector<vision::FeaturePoint> points;
+        points.reserve(static_cast<size_t>(num_keypoints));
+        for (int i = 0; i < num_keypoints; ++i) {
+            const float* k = &keypoints[i * 4];
+            // maxima is unused by FREAK extraction; pass true.
+            points.emplace_back(k[0], k[1], k[2], k[3], /*maxima=*/true);
+        }
+
+        vision::BinaryFeatureStore store;
+        // store.setNumBytesPerFeature(96) is called inside extract().
+        vision::FREAKExtractor extractor;
+        extractor.extract(store, &pyr, points);
+
+        if (num_keypoints > 0) {
+            std::memcpy(
+                dst_out,
+                store.feature(0),
+                static_cast<size_t>(num_keypoints) * 96);
+        }
+        return 0;
+    } catch (...) {
+        return 4;
+    }
 }
 
 /* ---- Dual-mode validation: DoGScaleInvariantDetector bridge (Milestone 8, #128) ---- */

--- a/crates/core/src/kpm/kpm_c_api.h
+++ b/crates/core/src/kpm/kpm_c_api.h
@@ -239,6 +239,41 @@ int webarkit_cpp_match_features_guided(
 int  webarkit_cpp_fast_random(int* seed);
 void webarkit_cpp_array_shuffle(int* v, int pop_size, int sample_size, int* seed);
 
+/* ---- Dual-mode validation: FREAKExtractor bridge (Milestone 8, #129) ---- */
+
+/* Build a vision::BinomialPyramid32f from `src`, then run
+ * vision::FREAKExtractor::extract at the caller-supplied keypoints.
+ * Writes `num_keypoints * 96` bytes to `dst_out` (84 bytes of FREAK
+ * descriptor data + 12 bytes zero padding per feature, matching the
+ * C++ BinaryFeatureStore layout).
+ *
+ * `keypoints` is a flat float array of 4 floats per keypoint:
+ * [x0, y0, angle0, scale0, x1, y1, angle1, scale1, ...]. The `maxima`
+ * flag of vision::FeaturePoint is unused by the FREAK descriptor
+ * algorithm so it is omitted from the serialization.
+ *
+ * Both sides must use identical config (`num_octaves` and the same
+ * source image) for the dual-mode parity test to be meaningful. Rust
+ * supplies the keypoints (it has already run its own detection), so
+ * this shim tests the descriptor algorithm in isolation from the
+ * detection pipeline.
+ *
+ * Returns:
+ *   0  success
+ *   1  validation error (null ptr, bad dims, negative count)
+ *   2  pyramid too small for the requested octave count
+ *   3  dst_capacity_bytes < num_keypoints * 96
+ *   4  C++ exception caught (ASSERT, std::exception, etc.) */
+int webarkit_cpp_extract_freak_descriptors(
+    const unsigned char* src,
+    int src_w,
+    int src_h,
+    int num_octaves,
+    const float* keypoints,
+    int num_keypoints,
+    unsigned char* dst_out,
+    int dst_capacity_bytes);
+
 /* ---- Dual-mode validation: DoGScaleInvariantDetector bridge (Milestone 8, #128) ---- */
 
 /* Build a BinomialPyramid32f from `src` and run a DoGScaleInvariantDetector

--- a/docs/design/m8-4-freak-descriptor.md
+++ b/docs/design/m8-4-freak-descriptor.md
@@ -1,0 +1,179 @@
+# Milestone 8 — Step 4: FREAK Descriptor + Keyframe
+
+**Status**: Design approved, ready for implementation
+**Branch**: `feat/m8-4-freak-descriptor` (PR target: `feat/m8-freak-detector`)
+**Issue**: #129
+**Author**: Walter Perdan ([@kalwalt](https://github.com/kalwalt))
+**Date**: 2026-05-17
+
+---
+
+## 1. Understanding Summary
+
+- **What**: Port `freak.h` + `freak.cpp` + `keyframe.h` to two new Rust sibling modules:
+  - `crates/core/src/kpm/freak/descriptor.rs` — FREAK extraction (84-byte data in a 96-byte slot)
+  - `crates/core/src/kpm/freak/keyframe.rs` — passive container (mirrors C++ `Keyframe<96>`)
+- Plus: replace the M7 `find_features` stub in `hough.rs` with a real `vision::FindFeatures`-style orchestrator.
+- **Why**: Final step of Milestone 8. Closes the FREAK pipeline (pyramid → DoG detector → FREAK descriptor → `FeatureStore`). Makes the M7 KPM matching pipeline end-to-end-runnable in pure Rust.
+- **Who**: Internal infrastructure consumed by KPM matching (already in main from M7).
+- **Success criterion**: Live FFI dual-mode test — Rust descriptor bytes match C++ within `MAX_HAMMING_PER_DESCRIPTOR = 2` for the top-10 keypoints on `found.jpg`. Plus unit tests for descriptor length, padding, reproducibility, and Keyframe population.
+- **Non-goals (this PR)**:
+  - Public two-phase `OrientationAssignment` API + 7-param ctor + reusable gradient cache — these M8-3-deferred items have no real consumer in M8-4 (the FREAK descriptor doesn't read gradient images). Tracked in #138.
+  - FREAK matching itself (already in M7 via `FeatureMatcher`)
+  - SIMD/rayon for the descriptor inner loop (follow-up)
+  - Harris detector (still dead code)
+
+---
+
+## 2. Decision Log
+
+| # | Decision | Alternatives considered | Rationale |
+|---|----------|-------------------------|-----------|
+| 1 | **Faithful C++ port** — 96-byte storage layout (84 data + 12 zero padding), `samples[i] < samples[j]` comparison, `bitstring_set_bit` LSB-first packing, 666 pairs from 37 receptors | "spec-as-written" with 96 actual descriptor bytes; hybrid | Required for byte-for-byte parity in the dual-mode Hamming-distance test; matches M7's `hamming_distance_96` |
+| 2 | **Defer M8-3 OA items indefinitely** — tracked in #138 | Absorb in M8-4 (was the original plan) | YAGNI: FREAK descriptor samples the Gaussian pyramid directly; no real consumer for the two-phase OA API or gradient cache. Documented in corrections on #128 + #129 |
+| 3 | **Split into 2 modules** — `descriptor.rs` + `keyframe.rs` | Single file; 3-way split | Mirrors C++ file organization (`freak.{h,cpp}` vs `keyframe.h`); matches M8-2/M8-3 pattern |
+| 4 | **Live FFI shim, Rust supplies keypoints** (option A.1) — `webarkit_cpp_extract_freak_descriptors(...)` | Pre-generated fixture file (issue spec literal); hybrid | Matches M8-2/M8-3 pattern; no binary blob; **isolates descriptor algorithm from detection variance** (descriptor parity is tested independently) |
+| 5 | **`MAX_HAMMING_PER_DESCRIPTOR = 2`** for top-10 keypoint dual-mode test | Exact match (0); larger tolerance (≥ 5) | Issue spec says 0; we allow up to 2 bits / 666 (~0.3%) for libm/FMA cross-platform variance in sign decisions. Tight enough to catch real algorithm bugs |
+| 6 | **Caller-owns model** with free `find_features` mirroring C++ `vision::FindFeatures` | `Keyframe::build(image, detector, pyramid)` (user prompt) | Faithful to C++ (Keyframe is a passive container; orchestration is a free function in `visual_database.h`). Fills the M7 `find_features` stub |
+| 7 | **Free function `extract_freak_descriptors(pyramid, keypoints, &mut Vec<u8>)`** | Marker struct `FreakDescriptor::compute(...)` (user prompt); stateful `FreakExtractor` (C++ literal) | C++ "state" is all constants — naturally `const` at module scope in Rust. Free function is idiomatic; raw-bytes output decouples descriptor from `FeatureStore` and improves testability |
+| 8 | **96-byte storage with 84 bytes of descriptor data + 12 zero padding** | 84-byte descriptors (initial draft) | C++ `FREAKExtractor::extract` calls `store.setNumBytesPerFeature(96)` then writes 84 bytes via `ExtractFREAK84`; bytes 84..96 stay zero. M7's `hamming_distance_96` assumes 96-byte descriptors |
+
+---
+
+## 3. Final API
+
+### 3.1 `descriptor.rs`
+
+```rust
+/// Storage size per FREAK descriptor (matches C++ `setNumBytesPerFeature(96)`).
+/// Bytes 0..84 carry 666 packed bits; bytes 84..96 are zero padding.
+pub const FREAK_DESCRIPTOR_BYTES: usize = 96;
+
+/// Compute FREAK descriptors for each keypoint and append to `out`.
+///
+/// After: `out.len()` has grown by `keypoints.len() * FREAK_DESCRIPTOR_BYTES`.
+/// Each 96-byte slot is zero-initialized and 84 bytes are filled with
+/// packed bit comparisons; bytes 84..96 remain zero.
+///
+/// Caller responsibility: `keypoint.angle` should be set by
+/// `OrientationAssignment` (M8-3) — otherwise descriptors use `angle = 0.0`
+/// and become rotation-variant.
+pub fn extract_freak_descriptors(
+    pyramid: &GaussianScaleSpacePyramid,
+    keypoints: &[FeaturePoint],
+    out: &mut Vec<u8>,
+);
+```
+
+### 3.2 `keyframe.rs`
+
+```rust
+pub struct Keyframe {
+    pub store: FeatureStore,  // bytes_per_feature = 96
+    pub width: i32,
+    pub height: i32,
+}
+
+impl Keyframe {
+    pub fn new(width: i32, height: i32) -> Result<Self, KpmError>;
+}
+```
+
+### 3.3 Orchestration (`hough.rs` — replaces M7 stub)
+
+```rust
+pub fn find_features(
+    keyframe: &mut Keyframe,
+    pyramid: &GaussianScaleSpacePyramid,
+    detector: &DoGScaleInvariantDetector,
+) -> Result<(), KpmError> {
+    // 1. dog_points = detector.detect(pyramid)
+    // 2. points: Vec<FeaturePoint> = dog_points.iter().map(Into::into).collect()
+    // 3. extract_freak_descriptors(pyramid, &points, &mut buf)
+    // 4. for (point, desc_slice) in zip(points, buf.chunks_exact(96)): keyframe.store.add(*point, desc_slice)?
+}
+```
+
+### 3.4 Algorithm (per keypoint)
+
+1. **Similarity transform** with `transform_scale = max(keypoint.scale · 7.0, 1.0)`; precompute `cs = transform_scale · cos(angle)`, `sn = transform_scale · sin(angle)`.
+2. **Transform sigmas**: `s_n = sigma_n · transform_scale` for each ring (and center).
+3. **Sample 6 rings** in C++ order (ring5 → ring4 → … → ring0 → center):
+   - Per ring: `pyramid.locate(s_n)` → `(octave, scale_idx)`
+   - Per receptor: apply transform `(rx, ry) = (kp.x + cs·px − sn·py, kp.y + sn·px + cs·py)`, sample via `bilinear_interpolate_f32` on `pyramid.level(octave, scale_idx)` after `bilinear_downsample_point`.
+4. **Pack 666 pairwise comparisons** `samples[i] < samples[j]` (for `0 ≤ i < j < 37`) into the first 84 bytes via LSB-first `desc[pos/8] |= 1 << (pos%8)`.
+5. Bytes 84..96 stay zero (from `out.resize(start + 96, 0)`).
+
+### 3.5 FFI shim (`kpm_c_api.h/.cpp`)
+
+```c
+int webarkit_cpp_extract_freak_descriptors(
+    const unsigned char* src, int src_w, int src_h,
+    int num_octaves,
+    const float* keypoints,    /* 4 floats per keypoint: x, y, angle, scale */
+    int num_keypoints,
+    unsigned char* dst_out,
+    int dst_capacity_bytes);
+```
+
+C++ implementation: build `BinomialPyramid32f`, construct `std::vector<vision::FeaturePoint>` from Rust-supplied data, instantiate `FREAKExtractor`, call `extract(store, pyramid, points)`, `memcpy` `num_keypoints * 96` bytes out. Returns 0 on success; non-zero codes for validation / capacity / exception.
+
+---
+
+## 4. Assumptions
+
+1. The 7 sigma constants and 6 ring arrays from `freak84-inline.h` are ported verbatim as Rust `const f32` values at module scope in `descriptor.rs`. `mExpansionFactor = 7.0` is also a `const`.
+2. The Rust `FeaturePoint` (5 fields from `hough.rs`) matches C++ `vision::FeaturePoint` layout for our purposes; the `maxima` field is unused by FREAK extraction.
+3. `pyramid.locate(sigma) -> (usize, usize)` from M8-2, `bilinear_downsample_point` + `bilinear_interpolate_f32` from M8-2, `From<&DoGFeaturePoint> for FeaturePoint` from M8-3 — all reused as-is.
+4. `FeatureStore::new(96)` (M7-3) accepts 96 as `bytes_per_feature` and exposes `add(point, &[u8])`.
+5. The existing `Keyframe` placeholder in `hough.rs:395–398` and the M7 `find_features` stub are removed/replaced. Mirrors the M8-2 / M8-3 placeholder-cleanup pattern.
+6. License header on both new files; year 2026; author Walter Perdan @kalwalt.
+7. `found.jpg` at `benchmarks/data/found.jpg` is the dual-mode test input.
+8. `-ffp-contract=off` from M8-2 still applies to the C++ build, so libm/FMA cross-platform variance is bounded to ~1–2 ULPs per arithmetic op. The 666-bit descriptor allows for ~2 bit flips due to this variance, hence `MAX_HAMMING_PER_DESCRIPTOR = 2`.
+
+---
+
+## 5. Test Plan
+
+### 5.1 `descriptor.rs` (5 unit + 1 dual-mode)
+
+| Test | Source | Notes |
+|---|---|---|
+| `test_freak_descriptor_length_one_keypoint` | Issue spec | 1 keypoint → `out.len() == 96` |
+| `test_freak_descriptor_length_multiple_keypoints` | Issue spec | 5 keypoints → 480 bytes |
+| `test_freak_descriptor_padding_bytes_are_zero` | Hardening | `out[84..96] == [0; 12]` |
+| `test_freak_descriptor_empty_input` | Hardening | Empty input doesn't panic; `out` unchanged |
+| `test_freak_descriptor_is_reproducible` | Issue spec | Two runs on identical inputs → byte-equal outputs |
+| `test_freak_descriptors_match_cpp_baseline` (`#[cfg(feature = "dual-mode")]`) | Issue spec (modified to live FFI) | Top-10 keypoints (Rust-selected) → C++ shim describes the same keypoints → Hamming distance ≤ 2 per descriptor |
+
+### 5.2 `keyframe.rs` (2 unit)
+
+| Test | Source | Notes |
+|---|---|---|
+| `test_keyframe_new_stores_dimensions` | Hardening | Constructor wiring; `bytes_per_feature == 96` |
+| `test_find_features_populates_keyframe` | Issue spec (renamed) | On `found.jpg` → `keyframe.store.num_features() > 50` |
+
+**Verification commands:**
+
+```
+cargo test -p webarkitlib-rs -- kpm::freak::descriptor kpm::freak::keyframe
+cargo test -p webarkitlib-rs --lib --features dual-mode -- kpm::freak::descriptor
+cargo clippy -p webarkitlib-rs -- -D warnings
+```
+
+---
+
+## 6. Follow-up Work (Out of Scope This PR)
+
+- **#138** — Promote `OrientationAssignment` API surface when a real consumer surfaces (multi-frame matcher, tuning experiments, external callers).
+- **Performance** — `criterion` benchmark for `extract_freak_descriptors`; SIMD path for the 666-pair packing loop (analogous to #131/#132).
+- **Reference-image building** — the `BinaryHierarchicalClustering` index that C++ `Keyframe<96>::buildIndex()` constructs is not built here. M7's KPM matching builds its own index when needed; this remains decoupled.
+
+---
+
+## 7. Open Risks
+
+1. **C++ libm / FMA cross-platform variance** — the 666 sign decisions are sensitive to ULP-level FP variance in `sin`, `cos`, and `bilinear_interpolate_f32`. The `MAX_HAMMING_PER_DESCRIPTOR = 2` tolerance accommodates this. If macOS/Linux CI shows ≤ 2 consistently we can tighten to 0 in a follow-up.
+2. **`pyramid.locate(sigma)` boundary behavior** — at very small or large sigmas, `locate` may clamp to a different `(octave, scale)` than C++. M8-2 verified the clamp matches C++ but the dual-mode count test (find_orientation = true) showed 0 divergence, suggesting `locate` is faithful. Worth re-verifying when M8-4 dual-mode runs.
+3. **Sample ordering** — C++ samples in ring5 → ring4 → … → center order. Reordering would produce a fundamentally different bit pattern incompatible with the C++ baseline. The Rust port preserves the C++ order explicitly.
+4. **`store.feature(0)` pointer arithmetic in the FFI shim** — relies on `BinaryFeatureStore` storing features contiguously with no inter-feature padding. C++ source confirms this layout (`feature(i)` is computed as `&data[i * bytes_per_feature]`).


### PR DESCRIPTION
## Summary

**Final step of Milestone 8.** Ports the C++ FREAK descriptor + Keyframe + FindFeatures orchestration to Rust. The FREAK pipeline is now end-to-end runnable in pure Rust: pyramid → DoG detector → FREAK descriptor → FeatureStore.

**Refs**: #125, #129
**Base**: `feat/m8-freak-detector` (M8 integration branch)
**Builds on**: #130 (M8-1), #135 (M8-2), #137 (M8-3) — all merged into the M8 integration branch

## What's in this PR

- **New**: `crates/core/src/kpm/freak/descriptor.rs` — FREAK constants, `extract_freak_descriptors` + private helpers + 5 unit tests + 1 dual-mode FFI test
- **New**: `crates/core/src/kpm/freak/keyframe.rs` — passive `Keyframe` container + 2 unit tests
- **Edit**: `crates/core/src/kpm/freak/mod.rs` — module declarations + re-exports
- **Edit**: `crates/core/src/kpm/freak/hough.rs` — removed `Keyframe` placeholder; replaced M7 `find_features` stub with real `vision::FindFeatures`-style orchestrator
- **Edit**: `crates/core/src/kpm/kpm_c_api.{h,cpp}` — new FFI shim `webarkit_cpp_extract_freak_descriptors` (~95 lines) for dual-mode Hamming-distance parity testing
- **New**: `docs/design/m8-4-freak-descriptor.md` — full design doc with 8-entry decision log

## Algorithm (matches C++ `FREAKExtractor::extract`)

Per keypoint:

1. **Similarity transform** `S = (x, y, angle, scale · 7.0)` (clamped at min 1.0)
2. **Transform sigmas**: `s_n = sigma_n · transform_scale` for 6 rings + center
3. **Sample 37 receptors** in C++ order (`ring5 → ring4 → … → ring0 → center`):
   - Per ring: `pyramid.locate(s_n)` → `(octave, scale_idx)`
   - Per receptor: apply transform, sample via `bilinear_interpolate_f32` on `pyramid.level(octave, scale_idx)` after `bilinear_downsample_point`
4. **Pack 666 pairwise comparisons** `samples[i] < samples[j]` (`0 ≤ i < j < 37`) into the first 84 bytes via LSB-first `desc[pos/8] |= 1 << (pos%8)`
5. Bytes 84..96 stay zero (matches C++ `BinaryFeatureStore` layout for `setNumBytesPerFeature(96)`)

## Design Decisions

See `docs/design/m8-4-freak-descriptor.md` for the full 8-entry decision log. Highlights:

| Decision | Rationale |
|----------|-----------|
| **Faithful C++ port** — 96-byte storage (84 data + 12 zero padding), `<` comparison, LSB-first packing | Required for byte-for-byte parity with C++; matches M7's `hamming_distance_96` |
| **Defer M8-3 OA items indefinitely** (tracked in #138) | YAGNI: FREAK descriptor samples Gaussian pyramid directly, not gradient images |
| **Split into 2 modules** — `descriptor.rs` + `keyframe.rs` | Mirrors C++ file organization; matches M8-2/M8-3 pattern |
| **Live FFI shim, Rust supplies keypoints** | Matches M8-2/M8-3; isolates descriptor algorithm from detection variance |
| **`MAX_HAMMING_PER_DESCRIPTOR = 2`** | Conservative tolerance for libm/FMA cross-platform variance (empirical: 0 on Windows) |
| **Caller-owns model** — free `find_features` in `hough.rs` | Faithful to C++ `vision::FindFeatures` (Keyframe is a passive container) |
| **Free function** `extract_freak_descriptors(... &mut Vec<u8>)` | C++ "state" is all constants — naturally `const` in Rust |
| **96-byte storage with 84 data + 12 zero padding** | Critical finding from C++ source: `setNumBytesPerFeature(96)` despite `CompareFREAK84` writing 84 bytes |

## Headline result

**Bit-for-bit C++ parity on every descriptor** on `found.jpg`.

When the dual-mode test tolerance is tightened to `MAX_HAMMING_PER_DESCRIPTOR = 0`, all 10 top-keypoint descriptors still pass. The Rust output is byte-identical to the C++ `FREAKExtractor` output, including every one of the 666 sign decisions per descriptor.

The test ships at tolerance = 2 for cross-platform headroom (Linux GCC / macOS Apple clang might show 1–2 bits of libm/FMA variance); CI will reveal whether we can tighten to 0 across all platforms.

## Bugs caught during brainstorming/implementation

Documented in `docs/design/m8-4-freak-descriptor.md` §2 and in the [#129 pre-flight comment](https://github.com/webarkit/WebARKitLib-rs/issues/129#issuecomment-4470982240):

1. **84 vs 96 bytes**: C++ writes 84 *data* bytes into a *96-byte slot*. The "96-byte descriptor" terminology in the issue refers to the storage layout, not the descriptor data size. Critical for M7's `hamming_distance_96` compatibility.
2. **Comparison direction**: C++ uses `samples[i] < samples[j]`, not `>` as the issue's prose suggested.
3. **Sample order**: `ring5 → ring4 → … → ring0 → center` (NOT `ring0 → ring1 → …`). Reordering would produce a different bit pattern incompatible with the C++ baseline.
4. **Bit-packing LSB-first**: `desc[pos/8] |= 1 << (pos%8)` — confirmed from `vision::bitstring_set_bit`.
5. **6 ring arrays + 7 sigmas + 1 expansion factor** (not a single lookup table as the issue suggested).
6. **`Matrix<f32>` sampling, not `Matrix<u8>`**: the Gaussian pyramid stores `Matrix<f32>` (M8-2 decision); FREAK uses `bilinear_interpolate_f32`.
7. **Keyframe is a passive container** in C++ — no `build()` method. Orchestration lives in `vision::FindFeatures`. The M7 `find_features` stub in `hough.rs` was the natural Rust home for it.
8. **`maxima` field of `FeaturePoint` is unused** by FREAK extraction. The FFI shim serializes only 4 floats per keypoint (`x, y, angle, scale`).

## What's NOT in this PR (intentional)

- **Public two-phase `OrientationAssignment` API** + 7-param ctor + reusable gradient cache — tracked in #138 (no real consumer in M8-4; YAGNI)
- **FREAK matching** — already in main from M7 via `FeatureMatcher` / `hamming_distance_96`
- **`BinaryHierarchicalClustering` index building** — C++ `Keyframe::buildIndex` is not ported. M7's matching builds its own index when needed.
- **Harris detector** — dead code, excluded by every M8 issue
- **SIMD/rayon** for the descriptor inner loop — follow-up perf PR analogous to #131/#132

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build -p webarkitlib-rs` — clean (zero warnings in new files)
- [x] `cargo clippy` on new modules — zero issues
- [x] `cargo test -p webarkitlib-rs --lib -- kpm::freak::{descriptor,keyframe}` — **7 passed, 0 failed**
- [x] `cargo test -p webarkitlib-rs --lib --features dual-mode` — **391 passed, 0 failed**
- [x] Dual-mode probe at `MAX_HAMMING_PER_DESCRIPTOR = 0` — passed (Hamming = 0 on all 10 descriptors)

Test results:

```
running 7 tests (unit)
test kpm::freak::descriptor::tests::test_freak_descriptor_padding_bytes_are_zero ... ok
test kpm::freak::descriptor::tests::test_freak_descriptor_empty_input ... ok
test kpm::freak::descriptor::tests::test_freak_descriptor_is_reproducible ... ok
test kpm::freak::descriptor::tests::test_freak_descriptor_length_one_keypoint ... ok
test kpm::freak::descriptor::tests::test_freak_descriptor_length_multiple_keypoints ... ok
test kpm::freak::keyframe::tests::test_keyframe_new_stores_dimensions ... ok
test kpm::freak::keyframe::tests::test_find_features_populates_keyframe ... ok

test kpm::freak::descriptor::tests::test_freak_descriptors_match_cpp_baseline ... ok (dual-mode, Hamming <= 2)
```

## Reviewer checklist

- [x] FREAK ring/sigma constants byte-identical to `freak84-inline.h`
- [x] Sample order: `ring5 → ring4 → … → ring0 → center` (matches C++)
- [x] Bit packing: LSB-first, 666 pairs in `(i, j)` order with `i < j`
- [x] Comparison: `samples[i] < samples[j]` (less-than)
- [x] Storage: 96 bytes per descriptor with bytes 84..96 zero
- [x] Similarity transform: `transform_scale = max(scale · 7.0, 1.0)`; rotation by `angle`
- [x] `pyramid.locate(sigma)` invoked once per ring (not per receptor)
- [x] LGPL header on both new files
- [x] No `println!` / `eprintln!` in library code
- [x] `CHANGELOG.md` not touched (release-only rule)
- [x] Branch targets `feat/m8-freak-detector` (M8 integration branch), not `dev`
- [x] `find_features` mirrors C++ `vision::FindFeatures` signature (with the `(keyframe, pyramid, detector)` parameter order matching the data flow)
- [x] FFI shim correctly serializes keypoints (4 floats per keypoint; `maxima` unused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
