### PR TITLE
feat(kpm): Milestone 8 — FREAK descriptor & DoG detector in pure Rust

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -44,6 +44,7 @@ imageproc = "0.26.0"
 byteorder = "1.5.0"
 jpeg-decoder = "0.3"
 log = "0.4.0"
+purecv = "0.4.0"
 rand = "0.9"
 rayon = "1.12"
 

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -115,6 +115,21 @@ fn build_freak_matcher() {
     if !target.contains("msvc") {
         build.flag("-Wno-unused-parameter");
         build.flag("-Wno-sign-compare");
+        // Disable floating-point contraction (fused multiply-add).
+        //
+        // Apple clang on ARM64 emits FMA instructions for `a + b*c`
+        // patterns by default. Linux GCC and MSVC do not. The FMA path is
+        // *more* precise (no intermediate rounding) and produces
+        // platform-dependent f32 output that drifts from the non-FMA path
+        // by up to several ULPs. This breaks dual-mode tests that assert
+        // byte-for-byte parity between the C++ baseline and the Rust port
+        // (which does not use FMA).
+        //
+        // -ffp-contract=off forces all FP additions/multiplications to be
+        // emitted as separate non-fused instructions, restoring
+        // deterministic cross-platform output. Both clang and GCC support
+        // this flag. See M8-2 design doc §7 and the discussion on PR #135.
+        build.flag("-ffp-contract=off");
     }
 
     for src in &cpp_sources {

--- a/crates/core/src/kpm/freak/descriptor.rs
+++ b/crates/core/src/kpm/freak/descriptor.rs
@@ -1,0 +1,511 @@
+/*
+ *  descriptor.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! FREAK (Fast Retina Keypoint) descriptor extraction.
+//!
+//! Ported from `WebARKitLib/.../matchers/freak.{h,cpp}` and `matchers/freak84-inline.h`.
+//!
+//! The descriptor samples the Gaussian scale-space pyramid at a rotated set of receptors
+//! (6 rings × 6 points + 1 center = 37 receptors), compares all `C(37, 2) = 666` pairs,
+//! and packs the bits into a 96-byte slot. The first 84 bytes carry the packed bits;
+//! the trailing 12 bytes are zero padding. The padding matches the C++
+//! `BinaryFeatureStore` layout used by M7's `hamming_distance_96`.
+//!
+//! C equivalent: `vision::FREAKExtractor::extract`, `ExtractFREAK84`,
+//! `SamplePyramidFREAK84`, `CompareFREAK84`.
+
+use super::gaussian_pyramid::GaussianScaleSpacePyramid;
+use super::hough::FeaturePoint;
+use super::interpolate::{bilinear_downsample_point, bilinear_interpolate_f32};
+
+// ─────────────────────────────────────────────────────────────────────
+// Public constants
+// ─────────────────────────────────────────────────────────────────────
+
+/// Storage size in bytes per FREAK descriptor.
+///
+/// Matches C++ `setNumBytesPerFeature(96)` in `FREAKExtractor::extract`.
+/// Of these 96 bytes, the first [`FREAK_DESCRIPTOR_DATA_BYTES`] = 84 carry
+/// the packed bits (`C(37, 2) = 666` pairwise comparisons, LSB-first);
+/// the trailing 12 bytes are zero padding required for compatibility with
+/// M7's `hamming_distance_96` and the C++ `BinaryFeatureStore` layout.
+pub const FREAK_DESCRIPTOR_BYTES: usize = 96;
+
+// ─────────────────────────────────────────────────────────────────────
+// Private constants
+// ─────────────────────────────────────────────────────────────────────
+
+/// Number of bytes that carry actual descriptor data within each 96-byte
+/// slot. Bytes `FREAK_DESCRIPTOR_DATA_BYTES..FREAK_DESCRIPTOR_BYTES` are
+/// zero padding.
+const FREAK_DESCRIPTOR_DATA_BYTES: usize = 84;
+
+/// Number of (sample[i] < sample[j]) comparisons per descriptor.
+/// Matches the C++ `ASSERT(pos == 666, "...")` in `CompareFREAK84`.
+const FREAK_NUM_PAIRS: usize = 666; // = 37 * 36 / 2
+
+/// Number of receptors per descriptor: 1 center + 6 rings × 6 points.
+const FREAK_NUM_RECEPTORS: usize = 37;
+
+/// Scale multiplier applied to keypoint scale to obtain the similarity
+/// transform scale. Matches C++ `mExpansionFactor = 7` in
+/// `FREAKExtractor::FREAKExtractor()`.
+const FREAK_EXPANSION_FACTOR: f32 = 7.0;
+
+/// Sigma values for the center receptor and each of the 6 rings.
+/// Ported verbatim from `freak84-inline.h`.
+const FREAK_SIGMA_CENTER: f32 = 0.100_000;
+const FREAK_SIGMA_RING0: f32 = 0.175_000;
+const FREAK_SIGMA_RING1: f32 = 0.250_000;
+const FREAK_SIGMA_RING2: f32 = 0.325_000;
+const FREAK_SIGMA_RING3: f32 = 0.400_000;
+const FREAK_SIGMA_RING4: f32 = 0.475_000;
+const FREAK_SIGMA_RING5: f32 = 0.550_000;
+
+/// `(x, y)` coordinates for the 6 receptors in each ring, in canonical
+/// (pre-similarity-transform) units. Each ring has 6 receptors × 2 coords
+/// = 12 floats. Ported verbatim from `freak84-inline.h`.
+const FREAK_POINTS_RING0: [f32; 12] = [
+    0.000_000, 0.362_783, -0.314_179, 0.181_391, -0.314_179, -0.181_391, -0.000_000, -0.362_783,
+    0.314_179, -0.181_391, 0.314_179, 0.181_391,
+];
+const FREAK_POINTS_RING1: [f32; 12] = [
+    -0.595_502, 0.000_000, -0.297_751, -0.515_720, 0.297_751, -0.515_720, 0.595_502, -0.000_000,
+    0.297_751, 0.515_720, -0.297_751, 0.515_720,
+];
+const FREAK_POINTS_RING2: [f32; 12] = [
+    -0.000_000, -0.741_094, 0.641_806, -0.370_547, 0.641_806, 0.370_547, 0.000_000, 0.741_094,
+    -0.641_806, 0.370_547, -0.641_806, -0.370_547,
+];
+const FREAK_POINTS_RING3: [f32; 12] = [
+    0.847_306, -0.000_000, 0.423_653, 0.733_789, -0.423_653, 0.733_789, -0.847_306, 0.000_000,
+    -0.423_653, -0.733_789, 0.423_653, -0.733_789,
+];
+const FREAK_POINTS_RING4: [f32; 12] = [
+    0.000_000, 0.930_969, -0.806_243, 0.465_485, -0.806_243, -0.465_485, -0.000_000, -0.930_969,
+    0.806_243, -0.465_485, 0.806_243, 0.465_485,
+];
+const FREAK_POINTS_RING5: [f32; 12] = [
+    -1.000_000, 0.000_000, -0.500_000, -0.866_025, 0.500_000, -0.866_025, 1.000_000, -0.000_000,
+    0.500_000, 0.866_025, -0.500_000, 0.866_025,
+];
+
+// ─────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────
+
+/// Compute FREAK descriptors for each keypoint and append to `out`.
+///
+/// After the call, `out.len()` has grown by
+/// `keypoints.len() * FREAK_DESCRIPTOR_BYTES`. Each 96-byte slot is
+/// zero-initialized; the first 84 bytes are filled with 666 packed bit
+/// comparisons; bytes 84..96 remain zero (matches C++
+/// `BinaryFeatureStore` layout).
+///
+/// Caller responsibility: `keypoint.angle` should be set by
+/// `OrientationAssignment` (M8-3 via `DoGScaleInvariantDetector::detect`
+/// with `find_orientation = true`). If `angle == 0.0`, the descriptor is
+/// rotation-variant.
+///
+/// C equivalent: `vision::FREAKExtractor::extract` →
+/// `ExtractFREAK84` (per-keypoint) → `SamplePyramidFREAK84` +
+/// `CompareFREAK84`.
+pub fn extract_freak_descriptors(
+    pyramid: &GaussianScaleSpacePyramid,
+    keypoints: &[FeaturePoint],
+    out: &mut Vec<u8>,
+) {
+    out.reserve(keypoints.len() * FREAK_DESCRIPTOR_BYTES);
+
+    let mut samples = [0.0f32; FREAK_NUM_RECEPTORS];
+
+    for kp in keypoints {
+        sample_pyramid_freak84(&mut samples, pyramid, kp);
+
+        // Reserve the 96-byte slot, zero-initialized.
+        let start = out.len();
+        out.resize(start + FREAK_DESCRIPTOR_BYTES, 0);
+        // Pack 666 bits into the first 84 bytes. Bytes 84..96 stay zero.
+        let desc = &mut out[start..start + FREAK_DESCRIPTOR_DATA_BYTES];
+        let mut pos = 0usize;
+        for i in 0..FREAK_NUM_RECEPTORS {
+            for j in (i + 1)..FREAK_NUM_RECEPTORS {
+                if samples[i] < samples[j] {
+                    desc[pos / 8] |= 1u8 << (pos % 8);
+                }
+                pos += 1;
+            }
+        }
+        debug_assert_eq!(pos, FREAK_NUM_PAIRS);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Private helpers
+// ─────────────────────────────────────────────────────────────────────
+
+/// Sample the 37 receptors for one keypoint. Matches the C++ sample order
+/// `ring5 → ring4 → ring3 → ring2 → ring1 → ring0 → center` from
+/// `SamplePyramidFREAK84`. Reordering would produce a fundamentally
+/// different bit pattern incompatible with the C++ baseline.
+fn sample_pyramid_freak84(
+    samples: &mut [f32; FREAK_NUM_RECEPTORS],
+    pyramid: &GaussianScaleSpacePyramid,
+    kp: &FeaturePoint,
+) {
+    // Similarity transform: clamped at 1.0 to match C++.
+    let raw_scale = kp.scale * FREAK_EXPANSION_FACTOR;
+    let transform_scale = if raw_scale < 1.0 { 1.0 } else { raw_scale };
+    let cs = transform_scale * kp.angle.cos();
+    let sn = transform_scale * kp.angle.sin();
+
+    // Transform sigmas.
+    let sc = FREAK_SIGMA_CENTER * transform_scale;
+    let s0 = FREAK_SIGMA_RING0 * transform_scale;
+    let s1 = FREAK_SIGMA_RING1 * transform_scale;
+    let s2 = FREAK_SIGMA_RING2 * transform_scale;
+    let s3 = FREAK_SIGMA_RING3 * transform_scale;
+    let s4 = FREAK_SIGMA_RING4 * transform_scale;
+    let s5 = FREAK_SIGMA_RING5 * transform_scale;
+
+    // Sample in C++ order (ring5 → ring4 → … → ring0 → center).
+    sample_ring(
+        &mut samples[0..6],
+        pyramid,
+        s5,
+        &FREAK_POINTS_RING5,
+        kp,
+        cs,
+        sn,
+    );
+    sample_ring(
+        &mut samples[6..12],
+        pyramid,
+        s4,
+        &FREAK_POINTS_RING4,
+        kp,
+        cs,
+        sn,
+    );
+    sample_ring(
+        &mut samples[12..18],
+        pyramid,
+        s3,
+        &FREAK_POINTS_RING3,
+        kp,
+        cs,
+        sn,
+    );
+    sample_ring(
+        &mut samples[18..24],
+        pyramid,
+        s2,
+        &FREAK_POINTS_RING2,
+        kp,
+        cs,
+        sn,
+    );
+    sample_ring(
+        &mut samples[24..30],
+        pyramid,
+        s1,
+        &FREAK_POINTS_RING1,
+        kp,
+        cs,
+        sn,
+    );
+    sample_ring(
+        &mut samples[30..36],
+        pyramid,
+        s0,
+        &FREAK_POINTS_RING0,
+        kp,
+        cs,
+        sn,
+    );
+
+    // Center receptor: single sample at the (untransformed) keypoint location.
+    let (octave_c, scale_c) = pyramid.locate(sc);
+    samples[36] = sample_pyramid_at(pyramid, kp.x, kp.y, octave_c, scale_c);
+}
+
+/// Sample the 6 receptors of one ring. All 6 share the same `(octave, scale)`
+/// determined by `pyramid.locate(sigma)` (matches C++ — locating per receptor
+/// would risk landing different receptors of the same ring at different
+/// octaves due to FP variance, breaking C++ parity).
+fn sample_ring(
+    out: &mut [f32],
+    pyramid: &GaussianScaleSpacePyramid,
+    sigma: f32,
+    ring: &[f32; 12],
+    kp: &FeaturePoint,
+    cs: f32,
+    sn: f32,
+) {
+    let (octave, scale_idx) = pyramid.locate(sigma);
+    for i in 0..6 {
+        let px = ring[i * 2];
+        let py = ring[i * 2 + 1];
+        // S · (px, py): [cs·px − sn·py + kp.x ; sn·px + cs·py + kp.y]
+        let rx = kp.x + cs * px - sn * py;
+        let ry = kp.y + sn * px + cs * py;
+        out[i] = sample_pyramid_at(pyramid, rx, ry, octave, scale_idx);
+    }
+}
+
+/// Downsample fine-image `(x, y)` to octave-local coordinates, clip to
+/// `[0, w-2] × [0, h-2]` (matches C++ `SampleReceptorBilinear`), and
+/// sample with bilinear interpolation on the Gaussian pyramid level.
+fn sample_pyramid_at(
+    pyramid: &GaussianScaleSpacePyramid,
+    x: f32,
+    y: f32,
+    octave: usize,
+    scale: usize,
+) -> f32 {
+    let level = pyramid.level(octave, scale);
+    let (xp, yp) = bilinear_downsample_point(x, y, octave as i32);
+    let xc = xp.clamp(0.0, (level.cols as f32) - 2.0);
+    let yc = yp.clamp(0.0, (level.rows as f32) - 2.0);
+    bilinear_interpolate_f32(level, xc, yc)
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Tests
+// ═════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use purecv::core::Matrix;
+
+    fn load_grayscale(path: &str) -> Matrix<u8> {
+        let img = image::open(path).expect("load test image").to_luma8();
+        let (w, h) = img.dimensions();
+        Matrix::<u8>::from_vec(h as usize, w as usize, 1, img.into_raw())
+    }
+
+    fn build_pyramid(img: &Matrix<u8>) -> GaussianScaleSpacePyramid {
+        let mut p = GaussianScaleSpacePyramid::new(3);
+        p.build(img).expect("build pyramid");
+        p
+    }
+
+    fn synthetic_keypoint(x: f32, y: f32, sigma: f32) -> FeaturePoint {
+        FeaturePoint {
+            x,
+            y,
+            angle: 0.0,
+            scale: sigma,
+            maxima: true,
+        }
+    }
+
+    // ── Length / shape ────────────────────────────────────────────────
+
+    #[test]
+    fn test_freak_descriptor_length_one_keypoint() {
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let pyr = build_pyramid(&img);
+        let kps = vec![synthetic_keypoint(100.0, 100.0, 1.5)];
+        let mut out = Vec::<u8>::new();
+        extract_freak_descriptors(&pyr, &kps, &mut out);
+        assert_eq!(out.len(), FREAK_DESCRIPTOR_BYTES);
+        assert_eq!(out.len(), 96);
+    }
+
+    #[test]
+    fn test_freak_descriptor_length_multiple_keypoints() {
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let pyr = build_pyramid(&img);
+        let kps: Vec<_> = (0..5)
+            .map(|i| synthetic_keypoint(50.0 + 30.0 * i as f32, 100.0, 1.5))
+            .collect();
+        let mut out = Vec::<u8>::new();
+        extract_freak_descriptors(&pyr, &kps, &mut out);
+        assert_eq!(out.len(), 5 * FREAK_DESCRIPTOR_BYTES);
+        assert_eq!(out.len(), 480);
+    }
+
+    #[test]
+    fn test_freak_descriptor_padding_bytes_are_zero() {
+        // Bytes 84..96 of each descriptor must be zero (matches C++ store layout).
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let pyr = build_pyramid(&img);
+        let kps = vec![synthetic_keypoint(150.0, 150.0, 1.5)];
+        let mut out = Vec::<u8>::new();
+        extract_freak_descriptors(&pyr, &kps, &mut out);
+        for (i, &b) in out[FREAK_DESCRIPTOR_DATA_BYTES..FREAK_DESCRIPTOR_BYTES]
+            .iter()
+            .enumerate()
+        {
+            assert_eq!(
+                b,
+                0,
+                "padding byte at offset {} must be zero",
+                FREAK_DESCRIPTOR_DATA_BYTES + i
+            );
+        }
+    }
+
+    #[test]
+    fn test_freak_descriptor_empty_input() {
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let pyr = build_pyramid(&img);
+        let mut out = Vec::<u8>::new();
+        extract_freak_descriptors(&pyr, &[], &mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_freak_descriptor_is_reproducible() {
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let pyr = build_pyramid(&img);
+        let kps = vec![
+            synthetic_keypoint(100.0, 100.0, 1.5),
+            synthetic_keypoint(200.0, 150.0, 2.0),
+        ];
+        let mut a = Vec::<u8>::new();
+        let mut b = Vec::<u8>::new();
+        extract_freak_descriptors(&pyr, &kps, &mut a);
+        extract_freak_descriptors(&pyr, &kps, &mut b);
+        assert_eq!(a, b, "extraction must be reproducible byte-for-byte");
+    }
+
+    // ── Dual-mode: per-descriptor Hamming distance vs C++ ─────────────
+
+    #[cfg(feature = "dual-mode")]
+    extern "C" {
+        fn webarkit_cpp_extract_freak_descriptors(
+            src: *const u8,
+            src_w: i32,
+            src_h: i32,
+            num_octaves: i32,
+            keypoints: *const f32,
+            num_keypoints: i32,
+            dst_out: *mut u8,
+            dst_capacity_bytes: i32,
+        ) -> i32;
+    }
+
+    #[cfg(feature = "dual-mode")]
+    fn cpp_extract_freak_descriptors(
+        img: &Matrix<u8>,
+        num_octaves: usize,
+        keypoints: &[FeaturePoint],
+    ) -> Vec<u8> {
+        let kp_flat: Vec<f32> = keypoints
+            .iter()
+            .flat_map(|p| [p.x, p.y, p.angle, p.scale])
+            .collect();
+        let mut dst = vec![0u8; keypoints.len() * FREAK_DESCRIPTOR_BYTES];
+        // SAFETY: pointers are valid for declared lengths; shim validates
+        // dst_capacity_bytes >= num_keypoints * 96.
+        let rc = unsafe {
+            webarkit_cpp_extract_freak_descriptors(
+                img.as_slice().as_ptr(),
+                img.cols as i32,
+                img.rows as i32,
+                num_octaves as i32,
+                kp_flat.as_ptr(),
+                keypoints.len() as i32,
+                dst.as_mut_ptr(),
+                dst.len() as i32,
+            )
+        };
+        assert_eq!(rc, 0, "C++ shim returned error {rc}");
+        dst
+    }
+
+    #[cfg(feature = "dual-mode")]
+    fn hamming_distance(a: &[u8], b: &[u8]) -> u32 {
+        a.iter().zip(b).map(|(x, y)| (x ^ y).count_ones()).sum()
+    }
+
+    #[test]
+    #[cfg(feature = "dual-mode")]
+    fn test_freak_descriptors_match_cpp_baseline() {
+        use crate::kpm::freak::detector::DoGScaleInvariantDetector;
+
+        // Tolerance allows for ~2 bits of libm/FMA cross-platform variance
+        // across 666 sign decisions per descriptor (~0.3%).
+        //
+        // Empirical local result (Windows MSVC, clean rebuild): all 10
+        // descriptors match C++ byte-for-byte (Hamming = 0). The
+        // tolerance is kept at 2 to absorb potential cross-platform
+        // variance (Linux GCC / macOS Apple clang) before tightening
+        // to exact match in a follow-up if CI shows consistent equality.
+        const MAX_HAMMING_PER_DESCRIPTOR: u32 = 2;
+
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let num_octaves = 3;
+        let pyr = build_pyramid(&img);
+        let det = DoGScaleInvariantDetector::new(0.0, 10.0, 5000, true);
+
+        // 1. Run Rust detection.
+        let dog_points = det.detect(&pyr);
+        let points: Vec<FeaturePoint> = dog_points.iter().map(FeaturePoint::from).collect();
+
+        // 2. Take top-10 by |raw DoG score| (before projection).
+        let mut indexed: Vec<(usize, f32)> = dog_points
+            .iter()
+            .enumerate()
+            .map(|(i, p)| (i, p.score.abs()))
+            .collect();
+        indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        let top10: Vec<FeaturePoint> = indexed.iter().take(10).map(|&(i, _)| points[i]).collect();
+        assert_eq!(top10.len(), 10, "expected >= 10 keypoints on found.jpg");
+
+        // 3. Rust descriptors.
+        let mut rust_descs = Vec::<u8>::new();
+        extract_freak_descriptors(&pyr, &top10, &mut rust_descs);
+
+        // 4. C++ descriptors via FFI shim (Rust supplies the keypoints).
+        let cpp_descs = cpp_extract_freak_descriptors(&img, num_octaves, &top10);
+
+        // 5. Per-descriptor Hamming distance.
+        assert_eq!(rust_descs.len(), cpp_descs.len());
+        for i in 0..10 {
+            let rs = &rust_descs[i * FREAK_DESCRIPTOR_BYTES..(i + 1) * FREAK_DESCRIPTOR_BYTES];
+            let cs = &cpp_descs[i * FREAK_DESCRIPTOR_BYTES..(i + 1) * FREAK_DESCRIPTOR_BYTES];
+            let h = hamming_distance(rs, cs);
+            assert!(
+                h <= MAX_HAMMING_PER_DESCRIPTOR,
+                "keypoint #{i}: Hamming distance {h} > {MAX_HAMMING_PER_DESCRIPTOR}"
+            );
+        }
+    }
+}

--- a/crates/core/src/kpm/freak/detector.rs
+++ b/crates/core/src/kpm/freak/detector.rs
@@ -1196,6 +1196,11 @@ mod tests {
     fn test_dog_keypoints_match_cpp_count() {
         // Tolerance covers sort tie-breaking and bucket ordering variance
         // only. Any algorithm-level error would dwarf this.
+        //
+        // Empirical local result (Windows MSVC, clean rebuild): |diff| = 0.
+        // The tolerance is kept at 5 to absorb potential cross-platform
+        // FP variance (Linux GCC / macOS Apple clang) before tightening
+        // to exact match in a follow-up if CI shows consistent equality.
         const MAX_TIE_DIVERGENCE: i32 = 5;
 
         let img = load_grayscale("../../benchmarks/data/found.jpg");
@@ -1227,6 +1232,68 @@ mod tests {
         assert!(
             diff <= MAX_TIE_DIVERGENCE,
             "keypoint count divergence: rust={rust_count}, cpp={cpp_count}, |diff|={diff} > {MAX_TIE_DIVERGENCE}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "dual-mode")]
+    fn test_dog_keypoints_match_cpp_count_with_orientation() {
+        // Companion to `test_dog_keypoints_match_cpp_count` with
+        // `find_orientation = true`, exercising the OrientationAssignment
+        // gradient-histogram step.
+        //
+        // Why the tolerance is wider (10 vs 5):
+        //   1. Each keypoint can produce *multiple* DoGFeaturePoint copies
+        //      (one per dominant orientation peak >= 0.8 · max_height).
+        //      Tie-breaking at the peak threshold boundary multiplies any
+        //      f32 rounding variance.
+        //   2. The orientation smoothing kernel
+        //      `[0.274068619061197, 0.451862761877606, ...]` sums to
+        //      exactly 1.0 in f64 but its f32 representation may differ
+        //      by 1 ULP between platforms. Five smoothing iterations
+        //      compound that variance.
+        //   3. Bucket pruning runs before orientation in C++, so the
+        //      pre-orientation count is bounded by max_pts. Post-
+        //      orientation, the count can exceed max_pts (each keypoint
+        //      contributing 1..N orientations).
+        //
+        // Empirical local result (Windows MSVC, clean rebuild): |diff| = 0.
+        // The orientation step did NOT introduce any divergence on this
+        // image, contrary to the speculative concern that the 1-ULP
+        // SMOOTH_KERNEL change might shift peak detection. The tolerance
+        // is set to 10 (vs 5 for orientation-off) to absorb potential
+        // cross-platform variance in the orientation gradient histogram.
+        const MAX_TIE_DIVERGENCE: i32 = 10;
+
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let num_octaves = 3;
+        let laplacian_threshold = 0.0;
+        let edge_threshold = 10.0;
+        let max_pts = 5000;
+        let find_orientation = true;
+
+        let pyr = build_test_pyramid(&img, num_octaves);
+        let det = DoGScaleInvariantDetector::new(
+            laplacian_threshold,
+            edge_threshold,
+            max_pts,
+            find_orientation,
+        );
+        let rust_count = det.detect(&pyr).len() as i32;
+
+        let cpp_count = cpp_detect_count(
+            &img,
+            num_octaves,
+            laplacian_threshold,
+            edge_threshold,
+            max_pts,
+            find_orientation,
+        );
+
+        let diff = (rust_count - cpp_count).abs();
+        assert!(
+            diff <= MAX_TIE_DIVERGENCE,
+            "with-orientation keypoint count divergence: rust={rust_count}, cpp={cpp_count}, |diff|={diff} > {MAX_TIE_DIVERGENCE}"
         );
     }
 }

--- a/crates/core/src/kpm/freak/detector.rs
+++ b/crates/core/src/kpm/freak/detector.rs
@@ -1,0 +1,1232 @@
+/*
+ *  detector.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Scale-invariant keypoint detector based on the Difference-of-Gaussians
+//! (DoG) of the Gaussian scale-space pyramid.
+//!
+//! Ported from `WebARKitLib/.../detectors/DoG_scale_invariant_detector.{h,cpp}`.
+//! Uses 3D extrema in the DoG scale-space, Lowe-style sub-pixel refinement
+//! via the 3×3 Hessian (with cross-octave variants when extrema straddle
+//! octave boundaries), edge-curvature rejection, bucket-based spatial
+//! pruning for keypoint diversity, and gradient-histogram orientation
+//! assignment.
+//!
+//! ## Pipeline (matches C++ `DoGScaleInvariantDetector::detect`)
+//!
+//! 1. Build DoG pyramid: `dog[s] = pyramid[s] - pyramid[s+1]` (less-blurred
+//!    minus more-blurred).
+//! 2. 3D extrema across the DoG flat-indexed image stack (3 spatial-pattern
+//!    variants for cross-octave neighbours).
+//! 3. Sub-pixel refinement via 3×3 Hessian solve, with cross-octave
+//!    variants.
+//! 4. Edge-curvature rejection (`(Dxx+Dyy)² / det`).
+//! 5. Bucket-based spatial pruning (best-K per bucket).
+//! 6. Orientation assignment via [`OrientationAssignment`] (only if
+//!    `find_orientation == true`).
+
+// Private extrema-extraction helpers below take many parameters by design:
+// they receive the three laplacian slices, dimension context, and dispatch
+// metadata. Grouping into a struct would obscure the parallel structure
+// with the three C++ inline expansions of `NONMAX_CHECK`.
+#![allow(clippy::too_many_arguments)]
+// solve_3x3 implements Gaussian elimination on a 3×3 augmented matrix.
+// Index-based iteration mirrors standard textbook formulations and stays
+// clearer than iterator-based equivalents for this size.
+#![allow(clippy::needless_range_loop)]
+
+use crate::arlog_w;
+use purecv::core::Matrix;
+
+use super::gaussian_pyramid::GaussianScaleSpacePyramid;
+use super::hough::FeaturePoint;
+use super::interpolate::{
+    bilinear_downsample_point, bilinear_interpolate_f32, bilinear_upsample_point,
+};
+use super::orientation::{compute_polar_gradient_image, OrientationAssignment};
+
+/// Number of DoG levels per octave. With 3 Gaussian scales per octave,
+/// adjacent pairs produce `3 - 1 = 2` DoG levels.
+pub const NUM_DOG_PER_OCTAVE: usize = GaussianScaleSpacePyramid::NUM_SCALES_PER_OCTAVE - 1;
+
+/// A keypoint detected by [`DoGScaleInvariantDetector`].
+///
+/// This is the detector's working type, carrying refinement diagnostics
+/// the FREAK descriptor (M8-4) needs to sample the right pyramid level.
+/// For storage in the visual database (Hough voting, FREAK matching), use
+/// the [`From<&DoGFeaturePoint>`] projection to [`FeaturePoint`].
+///
+/// C equivalent: `vision::DoGScaleInvariantDetector::FeaturePoint`.
+///
+/// Note: `(x, y)` are stored in **fine-image** coordinates (after
+/// `bilinear_upsample_point`), matching C++ `mFeaturePoints[i].x/y`.
+#[derive(Debug, Clone, Copy)]
+pub struct DoGFeaturePoint {
+    /// Sub-pixel x in the fine image.
+    pub x: f32,
+    /// Sub-pixel y in the fine image.
+    pub y: f32,
+    /// Dominant orientation in radians, in [0, 2π). Zero if
+    /// `find_orientation == false` at detection time.
+    pub angle: f32,
+    /// Octave index in the source pyramid.
+    pub octave: i32,
+    /// Integer DoG-scale index within the octave (0..NUM_DOG_PER_OCTAVE).
+    pub scale: i32,
+    /// Sub-pixel scale value: `scale + u[2]` from refinement, clipped to
+    /// `[0, NUM_DOG_PER_OCTAVE]`. Matches C++ `kp.sp_scale`.
+    pub sp_scale: f32,
+    /// Refined DoG response (signed). `score >= 0` ⇒ local maximum,
+    /// `score < 0` ⇒ local minimum.
+    pub score: f32,
+    /// Characteristic Gaussian sigma after refinement:
+    /// `effective_sigma(octave, sp_scale)`.
+    pub sigma: f32,
+    /// Edge-curvature score from `compute_edge_score`. Lower magnitude =
+    /// more corner-like; rejected if `|edge_score| ≥ (et + 1)² / et`.
+    pub edge_score: f32,
+}
+
+impl From<&DoGFeaturePoint> for FeaturePoint {
+    fn from(d: &DoGFeaturePoint) -> Self {
+        FeaturePoint {
+            x: d.x,
+            y: d.y,
+            angle: d.angle,
+            scale: d.sigma, // persistent type holds characteristic radius
+            maxima: d.score >= 0.0,
+        }
+    }
+}
+
+/// Scale-invariant keypoint detector.
+///
+/// C equivalent: `vision::DoGScaleInvariantDetector`.
+///
+/// **Defaults**: matches the C++ constructor (lines 108-119 of
+/// `DoG_scale_invariant_detector.cpp`):
+/// - `laplacian_threshold = 0` (no contrast filter by default)
+/// - `edge_threshold = 10` (Hessian threshold = `(10+1)²/10 = 12.1`)
+/// - `max_subpixel_distance_sqr = 9` (`3*3`; reject if `‖δ‖² > 9`)
+/// - `num_buckets_x = num_buckets_y = 10`
+/// - `find_orientation = true`
+/// - `max_num_feature_points = 5000`
+pub struct DoGScaleInvariantDetector {
+    laplacian_threshold: f32,
+    edge_threshold: f32,
+    max_subpixel_distance_sqr: f32,
+    num_buckets_x: usize,
+    num_buckets_y: usize,
+    max_num_feature_points: usize,
+    find_orientation: bool,
+    orientation_assignment: OrientationAssignment,
+}
+
+impl DoGScaleInvariantDetector {
+    /// Maximum keypoint cap; matches C++ `kMaxNumFeaturePoints = 5000`.
+    pub const DEFAULT_MAX_NUM_FEATURE_POINTS: usize = 5000;
+
+    /// Construct with config. Other parameters take FREAK defaults.
+    #[must_use]
+    pub fn new(
+        laplacian_threshold: f32,
+        edge_threshold: f32,
+        max_num_feature_points: usize,
+        find_orientation: bool,
+    ) -> Self {
+        debug_assert!(edge_threshold > 0.0, "edge_threshold must be positive");
+        Self {
+            laplacian_threshold,
+            edge_threshold,
+            max_subpixel_distance_sqr: 9.0, // C++ 3*3
+            num_buckets_x: 10,
+            num_buckets_y: 10,
+            max_num_feature_points,
+            find_orientation,
+            orientation_assignment: OrientationAssignment::new(),
+        }
+    }
+
+    /// Detect scale-invariant feature points in the Gaussian pyramid.
+    #[must_use]
+    pub fn detect(&self, pyramid: &GaussianScaleSpacePyramid) -> Vec<DoGFeaturePoint> {
+        if pyramid.num_octaves == 0 {
+            arlog_w!("DoGScaleInvariantDetector::detect: pyramid has zero octaves");
+            return Vec::new();
+        }
+
+        // (a) Build the DoG pyramid (flat-indexed).
+        let dog = build_dog_pyramid_flat(pyramid);
+        if dog.len() < 3 {
+            // Need at least one interior DoG index for 3D extrema.
+            return Vec::new();
+        }
+
+        // (b) Extract minima/maxima with cross-octave dimension dispatch.
+        let mut points = extract_features(&dog, pyramid, self.laplacian_threshold);
+
+        // (c, d, e) Sub-pixel refinement + edge rejection.
+        refine_subpixel_locations(
+            &mut points,
+            &dog,
+            pyramid,
+            self.laplacian_threshold,
+            self.edge_threshold,
+            self.max_subpixel_distance_sqr,
+        );
+
+        // (f) Bucket pruning (BEFORE orientation, matches C++).
+        let fine_w = pyramid.level(0, 0).cols;
+        let fine_h = pyramid.level(0, 0).rows;
+        let points = prune_features_bucketed(
+            points,
+            fine_w,
+            fine_h,
+            self.num_buckets_x,
+            self.num_buckets_y,
+            self.max_num_feature_points,
+        );
+
+        // (g) Orientation assignment.
+        if self.find_orientation {
+            assign_orientations(points, pyramid, &self.orientation_assignment)
+        } else {
+            points
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// DoG pyramid construction
+// ──────────────────────────────────────────────────────────────────────
+
+/// Build the flat-indexed DoG pyramid.
+///
+/// `dog[octave * NUM_DOG_PER_OCTAVE + s]` for `s` in
+/// `0..NUM_DOG_PER_OCTAVE`. Each entry is a `Matrix<f32>` with the same
+/// dimensions as the source octave.
+///
+/// **DoG direction**: `dog[s] = pyramid[s] - pyramid[s+1]` (less-blurred
+/// minus more-blurred), matching C++ `difference_image_binomial`.
+fn build_dog_pyramid_flat(pyramid: &GaussianScaleSpacePyramid) -> Vec<Matrix<f32>> {
+    let mut dog = Vec::with_capacity(pyramid.num_octaves * NUM_DOG_PER_OCTAVE);
+    for oct in 0..pyramid.num_octaves {
+        for s in 0..NUM_DOG_PER_OCTAVE {
+            dog.push(dog_image(pyramid.level(oct, s), pyramid.level(oct, s + 1)));
+        }
+    }
+    dog
+}
+
+/// Per-pixel difference image: `dst = a - b`.
+fn dog_image(a: &Matrix<f32>, b: &Matrix<f32>) -> Matrix<f32> {
+    debug_assert!(a.rows == b.rows && a.cols == b.cols);
+    let data: Vec<f32> = a
+        .as_slice()
+        .iter()
+        .zip(b.as_slice().iter())
+        .map(|(av, bv)| av - bv)
+        .collect();
+    Matrix::<f32>::from_vec(a.rows, a.cols, 1, data)
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Extrema extraction
+// ──────────────────────────────────────────────────────────────────────
+
+fn extract_features(
+    dog: &[Matrix<f32>],
+    pyramid: &GaussianScaleSpacePyramid,
+    laplacian_threshold: f32,
+) -> Vec<DoGFeaturePoint> {
+    let lap_sqr_threshold = laplacian_threshold * laplacian_threshold;
+    let mut out: Vec<DoGFeaturePoint> = Vec::new();
+
+    for i in 1..(dog.len() - 1) {
+        let im0 = &dog[i - 1];
+        let im1 = &dog[i];
+        let im2 = &dog[i + 1];
+
+        let octave = (i / NUM_DOG_PER_OCTAVE) as i32;
+        let scale = (i % NUM_DOG_PER_OCTAVE) as i32;
+
+        let same = im0.cols == im1.cols
+            && im0.cols == im2.cols
+            && im0.rows == im1.rows
+            && im0.rows == im2.rows;
+        let fine_octave_pair = im0.cols == im1.cols
+            && (im1.cols >> 1) == im2.cols
+            && im0.rows == im1.rows
+            && (im1.rows >> 1) == im2.rows;
+        let coarse_octave_pair = (im0.cols >> 1) == im1.cols
+            && im1.cols == im2.cols
+            && (im0.rows >> 1) == im1.rows
+            && im1.rows == im2.rows;
+
+        if same {
+            extract_features_same_octave(
+                &mut out,
+                im0,
+                im1,
+                im2,
+                octave,
+                scale,
+                pyramid,
+                lap_sqr_threshold,
+            );
+        } else if fine_octave_pair {
+            extract_features_fine_octave_pair(
+                &mut out,
+                im0,
+                im1,
+                im2,
+                octave,
+                scale,
+                pyramid,
+                lap_sqr_threshold,
+            );
+        } else if coarse_octave_pair {
+            extract_features_coarse_octave_pair(
+                &mut out,
+                im0,
+                im1,
+                im2,
+                octave,
+                scale,
+                pyramid,
+                lap_sqr_threshold,
+            );
+        } else {
+            arlog_w!("extract_features: inconsistent DoG dimensions at index {i}; skipping");
+        }
+    }
+
+    out
+}
+
+#[inline]
+fn nonmax_same_octave(
+    op: NonMaxOp,
+    val: f32,
+    im0: &[f32],
+    im1: &[f32],
+    im2: &[f32],
+    w: usize,
+    row: usize,
+    col: usize,
+) -> bool {
+    let i0 = (row - 1) * w + col - 1;
+    let i1 = (row - 1) * w + col;
+    let i2 = (row - 1) * w + col + 1;
+    let j0 = row * w + col - 1;
+    let j1 = row * w + col;
+    let j2 = row * w + col + 1;
+    let k0 = (row + 1) * w + col - 1;
+    let k1 = (row + 1) * w + col;
+    let k2 = (row + 1) * w + col + 1;
+    let cmp = |a: f32, b: f32| match op {
+        NonMaxOp::Greater => a > b,
+        NonMaxOp::Less => a < b,
+    };
+    // im0 (9)
+    cmp(val, im0[i0]) && cmp(val, im0[i1]) && cmp(val, im0[i2])
+        && cmp(val, im0[j0]) && cmp(val, im0[j1]) && cmp(val, im0[j2])
+        && cmp(val, im0[k0]) && cmp(val, im0[k1]) && cmp(val, im0[k2])
+        // im1 (8, skip center)
+        && cmp(val, im1[i0]) && cmp(val, im1[i1]) && cmp(val, im1[i2])
+        && cmp(val, im1[j0]) && cmp(val, im1[j2])
+        && cmp(val, im1[k0]) && cmp(val, im1[k1]) && cmp(val, im1[k2])
+        // im2 (9)
+        && cmp(val, im2[i0]) && cmp(val, im2[i1]) && cmp(val, im2[i2])
+        && cmp(val, im2[j0]) && cmp(val, im2[j1]) && cmp(val, im2[j2])
+        && cmp(val, im2[k0]) && cmp(val, im2[k1]) && cmp(val, im2[k2])
+}
+
+#[derive(Copy, Clone)]
+enum NonMaxOp {
+    Greater,
+    Less,
+}
+
+fn extract_features_same_octave(
+    out: &mut Vec<DoGFeaturePoint>,
+    im0: &Matrix<f32>,
+    im1: &Matrix<f32>,
+    im2: &Matrix<f32>,
+    octave: i32,
+    scale: i32,
+    pyramid: &GaussianScaleSpacePyramid,
+    lap_sqr_threshold: f32,
+) {
+    let w = im1.cols;
+    let h = im1.rows;
+    if w < 3 || h < 3 {
+        return;
+    }
+    let d0 = im0.as_slice();
+    let d1 = im1.as_slice();
+    let d2 = im2.as_slice();
+    for row in 1..(h - 1) {
+        for col in 1..(w - 1) {
+            let value = d1[row * w + col];
+            if value * value < lap_sqr_threshold {
+                continue;
+            }
+            let extrema = nonmax_same_octave(NonMaxOp::Greater, value, d0, d1, d2, w, row, col)
+                || nonmax_same_octave(NonMaxOp::Less, value, d0, d1, d2, w, row, col);
+            if extrema {
+                push_extremum(out, pyramid, octave, scale, col as f32, row as f32, value);
+            }
+        }
+    }
+}
+
+fn extract_features_fine_octave_pair(
+    out: &mut Vec<DoGFeaturePoint>,
+    im0: &Matrix<f32>,
+    im1: &Matrix<f32>,
+    im2: &Matrix<f32>,
+    octave: i32,
+    scale: i32,
+    pyramid: &GaussianScaleSpacePyramid,
+    lap_sqr_threshold: f32,
+) {
+    // im0/im1 same size as octave; im2 half size (next coarser octave).
+    let w = im1.cols;
+    let h = im1.rows;
+    if w < 3 || h < 3 {
+        return;
+    }
+    let d0 = im0.as_slice();
+    let d1 = im1.as_slice();
+    // C++ loop bounds: end_x = floor(((im2.width-1) - 0.5) * 2 + 0.5), same for y.
+    // Conservative: stop at w-2 / h-2 (interior).
+    let end_x = (((im2.cols as f32 - 1.0) - 0.5) * 2.0 + 0.5).floor() as usize;
+    let end_y = (((im2.rows as f32 - 1.0) - 0.5) * 2.0 + 0.5).floor() as usize;
+    let end_x = end_x.min(w - 1);
+    let end_y = end_y.min(h - 1);
+
+    for row in 2..end_y {
+        for col in 2..end_x {
+            let value = d1[row * w + col];
+            if value * value < lap_sqr_threshold {
+                continue;
+            }
+
+            let ds_x = col as f32 * 0.5 - 0.25;
+            let ds_y = row as f32 * 0.5 - 0.25;
+
+            let extrema = nonmax_fine_octave(
+                NonMaxOp::Greater,
+                value,
+                d0,
+                d1,
+                im2,
+                w,
+                row,
+                col,
+                ds_x,
+                ds_y,
+            ) || nonmax_fine_octave(
+                NonMaxOp::Less,
+                value,
+                d0,
+                d1,
+                im2,
+                w,
+                row,
+                col,
+                ds_x,
+                ds_y,
+            );
+            if extrema {
+                push_extremum(out, pyramid, octave, scale, col as f32, row as f32, value);
+            }
+        }
+    }
+}
+
+#[inline]
+fn nonmax_fine_octave(
+    op: NonMaxOp,
+    val: f32,
+    im0: &[f32],
+    im1: &[f32],
+    im2: &Matrix<f32>,
+    w: usize,
+    row: usize,
+    col: usize,
+    ds_x: f32,
+    ds_y: f32,
+) -> bool {
+    let cmp = |a: f32, b: f32| match op {
+        NonMaxOp::Greater => a > b,
+        NonMaxOp::Less => a < b,
+    };
+    let i_off = (row - 1) * w + col;
+    let j_off = row * w + col;
+    let k_off = (row + 1) * w + col;
+    // im0 (9)
+    cmp(val, im0[i_off - 1]) && cmp(val, im0[i_off]) && cmp(val, im0[i_off + 1])
+        && cmp(val, im0[j_off - 1]) && cmp(val, im0[j_off]) && cmp(val, im0[j_off + 1])
+        && cmp(val, im0[k_off - 1]) && cmp(val, im0[k_off]) && cmp(val, im0[k_off + 1])
+        // im1 (8)
+        && cmp(val, im1[i_off - 1]) && cmp(val, im1[i_off]) && cmp(val, im1[i_off + 1])
+        && cmp(val, im1[j_off - 1]) && cmp(val, im1[j_off + 1])
+        && cmp(val, im1[k_off - 1]) && cmp(val, im1[k_off]) && cmp(val, im1[k_off + 1])
+        // im2 (9, bilinear)
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x - 0.5, ds_y - 0.5))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x, ds_y - 0.5))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x + 0.5, ds_y - 0.5))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x - 0.5, ds_y))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x, ds_y))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x + 0.5, ds_y))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x - 0.5, ds_y + 0.5))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x, ds_y + 0.5))
+        && cmp(val, bilinear_interpolate_f32(im2, ds_x + 0.5, ds_y + 0.5))
+}
+
+fn extract_features_coarse_octave_pair(
+    out: &mut Vec<DoGFeaturePoint>,
+    im0: &Matrix<f32>,
+    im1: &Matrix<f32>,
+    im2: &Matrix<f32>,
+    octave: i32,
+    scale: i32,
+    pyramid: &GaussianScaleSpacePyramid,
+    lap_sqr_threshold: f32,
+) {
+    // im0 double size (previous finer octave); im1/im2 at this octave.
+    let w = im1.cols;
+    let h = im1.rows;
+    if w < 3 || h < 3 {
+        return;
+    }
+    let d1 = im1.as_slice();
+    let d2 = im2.as_slice();
+
+    for row in 1..(h - 1) {
+        for col in 1..(w - 1) {
+            let value = d1[row * w + col];
+            if value * value < lap_sqr_threshold {
+                continue;
+            }
+
+            let us_x = (col << 1) as f32 + 0.5;
+            let us_y = (row << 1) as f32 + 0.5;
+
+            let extrema = nonmax_coarse_octave(
+                NonMaxOp::Greater,
+                value,
+                im0,
+                d1,
+                d2,
+                w,
+                row,
+                col,
+                us_x,
+                us_y,
+            ) || nonmax_coarse_octave(
+                NonMaxOp::Less,
+                value,
+                im0,
+                d1,
+                d2,
+                w,
+                row,
+                col,
+                us_x,
+                us_y,
+            );
+            if extrema {
+                push_extremum(out, pyramid, octave, scale, col as f32, row as f32, value);
+            }
+        }
+    }
+}
+
+#[inline]
+fn nonmax_coarse_octave(
+    op: NonMaxOp,
+    val: f32,
+    im0: &Matrix<f32>,
+    im1: &[f32],
+    im2: &[f32],
+    w: usize,
+    row: usize,
+    col: usize,
+    us_x: f32,
+    us_y: f32,
+) -> bool {
+    let cmp = |a: f32, b: f32| match op {
+        NonMaxOp::Greater => a > b,
+        NonMaxOp::Less => a < b,
+    };
+    let i_off = (row - 1) * w + col;
+    let j_off = row * w + col;
+    let k_off = (row + 1) * w + col;
+    // im1 (8)
+    cmp(val, im1[i_off - 1]) && cmp(val, im1[i_off]) && cmp(val, im1[i_off + 1])
+        && cmp(val, im1[j_off - 1]) && cmp(val, im1[j_off + 1])
+        && cmp(val, im1[k_off - 1]) && cmp(val, im1[k_off]) && cmp(val, im1[k_off + 1])
+        // im2 (9)
+        && cmp(val, im2[i_off - 1]) && cmp(val, im2[i_off]) && cmp(val, im2[i_off + 1])
+        && cmp(val, im2[j_off - 1]) && cmp(val, im2[j_off]) && cmp(val, im2[j_off + 1])
+        && cmp(val, im2[k_off - 1]) && cmp(val, im2[k_off]) && cmp(val, im2[k_off + 1])
+        // im0 (9, bilinear at double-scale)
+        && cmp(val, bilinear_interpolate_f32(im0, us_x - 2.0, us_y - 2.0))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x, us_y - 2.0))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x + 2.0, us_y - 2.0))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x - 2.0, us_y))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x, us_y))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x + 2.0, us_y))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x - 2.0, us_y + 2.0))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x, us_y + 2.0))
+        && cmp(val, bilinear_interpolate_f32(im0, us_x + 2.0, us_y + 2.0))
+}
+
+#[inline]
+fn push_extremum(
+    out: &mut Vec<DoGFeaturePoint>,
+    pyramid: &GaussianScaleSpacePyramid,
+    octave: i32,
+    scale: i32,
+    col: f32,
+    row: f32,
+    value: f32,
+) {
+    let (fx, fy) = bilinear_upsample_point(col, row, octave);
+    out.push(DoGFeaturePoint {
+        x: fx,
+        y: fy,
+        angle: 0.0,
+        octave,
+        scale,
+        sp_scale: scale as f32,
+        score: value,
+        sigma: pyramid.effective_sigma(octave as usize, scale as usize),
+        edge_score: 0.0,
+    });
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Sub-pixel refinement
+// ──────────────────────────────────────────────────────────────────────
+
+fn refine_subpixel_locations(
+    points: &mut Vec<DoGFeaturePoint>,
+    dog: &[Matrix<f32>],
+    pyramid: &GaussianScaleSpacePyramid,
+    laplacian_threshold: f32,
+    edge_threshold: f32,
+    max_subpixel_distance_sqr: f32,
+) {
+    let lap_sqr = laplacian_threshold * laplacian_threshold;
+    let hessian_threshold = (edge_threshold + 1.0).powi(2) / edge_threshold;
+    let fine_w = pyramid.level(0, 0).cols as f32;
+    let fine_h = pyramid.level(0, 0).rows as f32;
+
+    let mut write = 0usize;
+    for i in 0..points.len() {
+        let kp = points[i];
+        let lap_index = (kp.octave as usize) * NUM_DOG_PER_OCTAVE + (kp.scale as usize);
+
+        if lap_index == 0 || lap_index + 1 >= dog.len() {
+            continue; // need lap0 and lap2
+        }
+
+        // Downsample fine-image (x, y) to octave-local coords.
+        let (xp, yp) = bilinear_downsample_point(kp.x, kp.y, kp.octave);
+        let x = (xp + 0.5) as i32;
+        let y = (yp + 0.5) as i32;
+
+        let lap0 = &dog[lap_index - 1];
+        let lap1 = &dog[lap_index];
+        let lap2 = &dog[lap_index + 1];
+
+        if x < 1 || (x + 1) as usize >= lap1.cols || y < 1 || (y + 1) as usize >= lap1.rows {
+            continue;
+        }
+
+        let Some((a, b)) = compute_subpixel_hessian(lap0, lap1, lap2, x, y) else {
+            continue;
+        };
+
+        let Some(u) = solve_3x3(&a, &b) else {
+            continue;
+        };
+
+        if u[0] * u[0] + u[1] * u[1] > max_subpixel_distance_sqr {
+            continue;
+        }
+
+        let Some(edge_score) = compute_edge_score(&a) else {
+            continue;
+        };
+
+        // Refined DoG response: linear correction using the gradient.
+        let center_val = lap1.as_slice()[(y as usize) * lap1.cols + (x as usize)];
+        let refined_score = center_val - (b[0] * u[0] + b[1] * u[1] + b[2] * u[2]);
+
+        // Sub-pixel scale (full value, clipped to [0, num_dog]).
+        let mut sp_scale = kp.scale as f32 + u[2];
+        sp_scale = sp_scale.clamp(0.0, NUM_DOG_PER_OCTAVE as f32);
+
+        // Upsample refined location to fine-image coords.
+        let (fx, fy) = bilinear_upsample_point(xp + u[0], yp + u[1], kp.octave);
+
+        if edge_score.abs() < hessian_threshold
+            && refined_score * refined_score >= lap_sqr
+            && fx >= 0.0
+            && fx < fine_w
+            && fy >= 0.0
+            && fy < fine_h
+        {
+            let sigma = pyramid_effective_sigma_fractional(pyramid, kp.octave, sp_scale);
+            points[write] = DoGFeaturePoint {
+                x: fx,
+                y: fy,
+                angle: 0.0,
+                octave: kp.octave,
+                scale: kp.scale,
+                sp_scale,
+                score: refined_score,
+                sigma,
+                edge_score,
+            };
+            write += 1;
+        }
+    }
+    points.truncate(write);
+}
+
+/// Linearly interpolate `effective_sigma` along sub-pixel scale.
+fn pyramid_effective_sigma_fractional(
+    pyramid: &GaussianScaleSpacePyramid,
+    octave: i32,
+    sp_scale: f32,
+) -> f32 {
+    // sigma(octave, scale) = k^scale · 2^octave.
+    pyramid.kfactor.powf(sp_scale) * (1u32 << (octave as usize)) as f32
+}
+
+/// Dispatch to one of three Hessian variants based on dimension pattern.
+fn compute_subpixel_hessian(
+    lap0: &Matrix<f32>,
+    lap1: &Matrix<f32>,
+    lap2: &Matrix<f32>,
+    x: i32,
+    y: i32,
+) -> Option<([f32; 9], [f32; 3])> {
+    if lap0.cols == lap1.cols
+        && lap1.cols == lap2.cols
+        && lap0.rows == lap1.rows
+        && lap1.rows == lap2.rows
+    {
+        Some(hessian_same_octave(
+            lap0, lap1, lap2, x as usize, y as usize,
+        ))
+    } else if lap0.cols == lap1.cols
+        && (lap1.cols >> 1) == lap2.cols
+        && lap0.rows == lap1.rows
+        && (lap1.rows >> 1) == lap2.rows
+    {
+        Some(hessian_fine_octave_pair(
+            lap0, lap1, lap2, x as usize, y as usize,
+        ))
+    } else if (lap0.cols >> 1) == lap1.cols
+        && lap1.cols == lap2.cols
+        && (lap0.rows >> 1) == lap1.rows
+        && lap1.rows == lap2.rows
+    {
+        Some(hessian_coarse_octave_pair(
+            lap0, lap1, lap2, x as usize, y as usize,
+        ))
+    } else {
+        None
+    }
+}
+
+/// Spatial derivatives at (x, y) in `im` (interior pixel only).
+#[inline]
+fn spatial_derivatives(im: &Matrix<f32>, x: usize, y: usize) -> (f32, f32, f32, f32, f32) {
+    let w = im.cols;
+    let d = im.as_slice();
+    let p = d[y * w + x];
+    let p_left = d[y * w + x - 1];
+    let p_right = d[y * w + x + 1];
+    let p_up = d[(y - 1) * w + x];
+    let p_dn = d[(y + 1) * w + x];
+    let p_ul = d[(y - 1) * w + x - 1];
+    let p_ur = d[(y - 1) * w + x + 1];
+    let p_dl = d[(y + 1) * w + x - 1];
+    let p_dr = d[(y + 1) * w + x + 1];
+
+    let dx = 0.5 * (p_right - p_left);
+    let dy = 0.5 * (p_dn - p_up);
+    let dxx = p_left - 2.0 * p + p_right;
+    let dyy = p_up - 2.0 * p + p_dn;
+    let dxy = 0.25 * ((p_ul + p_dr) - (p_ur + p_dl));
+    (dx, dy, dxx, dyy, dxy)
+}
+
+fn hessian_same_octave(
+    lap0: &Matrix<f32>,
+    lap1: &Matrix<f32>,
+    lap2: &Matrix<f32>,
+    x: usize,
+    y: usize,
+) -> ([f32; 9], [f32; 3]) {
+    let (dx, dy, dxx, dyy, dxy) = spatial_derivatives(lap1, x, y);
+    let w = lap1.cols;
+    let l0 = lap0.as_slice();
+    let l2 = lap2.as_slice();
+    let l1c = lap1.as_slice()[y * w + x];
+    let l0c = l0[y * w + x];
+    let l2c = l2[y * w + x];
+    let ds = 0.5 * (l2c - l0c);
+    let dss = l0c + (-2.0 * l1c) + l2c;
+    let dxs =
+        0.25 * ((l0[y * w + x - 1] - l0[y * w + x + 1]) + (-l2[y * w + x - 1] + l2[y * w + x + 1]));
+    let dys = 0.25
+        * ((l0[(y - 1) * w + x] - l0[(y + 1) * w + x])
+            + (-l2[(y - 1) * w + x] + l2[(y + 1) * w + x]));
+    let h = [dxx, dxy, dxs, dxy, dyy, dys, dxs, dys, dss];
+    let b = [-dx, -dy, -ds];
+    (h, b)
+}
+
+fn hessian_fine_octave_pair(
+    lap0: &Matrix<f32>,
+    lap1: &Matrix<f32>,
+    lap2: &Matrix<f32>,
+    x: usize,
+    y: usize,
+) -> ([f32; 9], [f32; 3]) {
+    let (dx, dy, dxx, dyy, dxy) = spatial_derivatives(lap1, x, y);
+    let w = lap1.cols;
+    let l1c = lap1.as_slice()[y * w + x];
+
+    // lap2 is half-sized (next coarser octave).
+    let (x_div2, y_div2) = bilinear_downsample_point(x as f32, y as f32, 1);
+    let val = bilinear_interpolate_f32(lap2, x_div2, y_div2);
+
+    let l0 = lap0.as_slice();
+
+    // C++ uses lap2 (coarser octave) at (x_div2 ± 0.5, y_div2 ± 0.5).
+    let lap2_px_pos = bilinear_interpolate_f32(lap2, x_div2 + 0.5, y_div2);
+    let lap2_px_neg = bilinear_interpolate_f32(lap2, x_div2 - 0.5, y_div2);
+    let lap2_py_pos = bilinear_interpolate_f32(lap2, x_div2, y_div2 + 0.5);
+    let lap2_py_neg = bilinear_interpolate_f32(lap2, x_div2, y_div2 - 0.5);
+
+    let ds = 0.5 * (val - l0[y * w + x]);
+    let dss = l0[y * w + x] + (-2.0 * l1c) + val;
+    let dxs = 0.25 * ((l0[y * w + x - 1] + lap2_px_pos) - (l0[y * w + x + 1] + lap2_px_neg));
+    let dys = 0.25 * ((l0[(y - 1) * w + x] + lap2_py_pos) - (l0[(y + 1) * w + x] + lap2_py_neg));
+    let h = [dxx, dxy, dxs, dxy, dyy, dys, dxs, dys, dss];
+    let b = [-dx, -dy, -ds];
+    (h, b)
+}
+
+fn hessian_coarse_octave_pair(
+    lap0: &Matrix<f32>,
+    lap1: &Matrix<f32>,
+    lap2: &Matrix<f32>,
+    x: usize,
+    y: usize,
+) -> ([f32; 9], [f32; 3]) {
+    let (dx, dy, dxx, dyy, dxy) = spatial_derivatives(lap1, x, y);
+    let w = lap1.cols;
+    let l1c = lap1.as_slice()[y * w + x];
+
+    // lap0 is double-sized (previous finer octave).
+    let (x_mul2, y_mul2) = bilinear_upsample_point(x as f32, y as f32, 1);
+    let val = bilinear_interpolate_f32(lap0, x_mul2, y_mul2);
+
+    let l2 = lap2.as_slice();
+
+    let lap0_px_pos = bilinear_interpolate_f32(lap0, x_mul2 - 2.0, y_mul2);
+    let lap0_px_neg = bilinear_interpolate_f32(lap0, x_mul2 + 2.0, y_mul2);
+    let lap0_py_pos = bilinear_interpolate_f32(lap0, x_mul2, y_mul2 - 2.0);
+    let lap0_py_neg = bilinear_interpolate_f32(lap0, x_mul2, y_mul2 + 2.0);
+
+    let ds = 0.5 * (l2[y * w + x] - val);
+    let dss = val + (-2.0 * l1c) + l2[y * w + x];
+    let dxs = 0.25 * ((lap0_px_pos + l2[y * w + x + 1]) - (lap0_px_neg + l2[y * w + x - 1]));
+    let dys = 0.25 * ((lap0_py_pos + l2[(y + 1) * w + x]) - (lap0_py_neg + l2[(y - 1) * w + x]));
+    let h = [dxx, dxy, dxs, dxy, dyy, dys, dxs, dys, dss];
+    let b = [-dx, -dy, -ds];
+    (h, b)
+}
+
+/// Edge-curvature score. Returns `None` if the 2×2 determinant is zero.
+fn compute_edge_score(h: &[f32; 9]) -> Option<f32> {
+    let dxx = h[0];
+    let dxy = h[1];
+    let dyy = h[4];
+    let det = dxx * dyy - dxy * dxy;
+    if det == 0.0 {
+        return None;
+    }
+    Some((dxx + dyy).powi(2) / det)
+}
+
+/// Solve a 3×3 linear system via Gaussian elimination with partial
+/// pivoting. Returns `None` on near-singular matrices.
+fn solve_3x3(a: &[f32; 9], b: &[f32; 3]) -> Option<[f32; 3]> {
+    let mut m = [
+        [a[0], a[1], a[2], b[0]],
+        [a[3], a[4], a[5], b[1]],
+        [a[6], a[7], a[8], b[2]],
+    ];
+    // Forward elimination with pivoting.
+    for k in 0..3 {
+        // Find pivot.
+        let mut max_row = k;
+        let mut max_val = m[k][k].abs();
+        for i in (k + 1)..3 {
+            let v = m[i][k].abs();
+            if v > max_val {
+                max_val = v;
+                max_row = i;
+            }
+        }
+        if max_val < 1e-12 {
+            return None;
+        }
+        if max_row != k {
+            m.swap(k, max_row);
+        }
+        for i in (k + 1)..3 {
+            let factor = m[i][k] / m[k][k];
+            for j in k..4 {
+                m[i][j] -= factor * m[k][j];
+            }
+        }
+    }
+    // Back substitution.
+    let mut x = [0.0f32; 3];
+    for i in (0..3).rev() {
+        let mut sum = m[i][3];
+        for j in (i + 1)..3 {
+            sum -= m[i][j] * x[j];
+        }
+        x[i] = sum / m[i][i];
+    }
+    Some(x)
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Bucket pruning
+// ──────────────────────────────────────────────────────────────────────
+
+/// Distribute keypoints across an `nx × ny` spatial grid (on the
+/// fine-image coordinates) and keep the top-K per bucket where
+/// `K = max_total / (nx * ny)`.
+///
+/// C equivalent: `vision::PruneDoGFeatures` (uses `std::nth_element`
+/// per bucket).
+fn prune_features_bucketed(
+    points: Vec<DoGFeaturePoint>,
+    fine_w: usize,
+    fine_h: usize,
+    nx: usize,
+    ny: usize,
+    max_total: usize,
+) -> Vec<DoGFeaturePoint> {
+    if points.len() <= max_total {
+        return points;
+    }
+    let num_buckets = nx * ny;
+    if num_buckets == 0 {
+        return points;
+    }
+    let num_per_bucket = max_total / num_buckets;
+    if num_per_bucket == 0 {
+        return points;
+    }
+    let dx = (fine_w as f32 / nx as f32).ceil().max(1.0) as usize;
+    let dy = (fine_h as f32 / ny as f32).ceil().max(1.0) as usize;
+
+    let mut buckets: Vec<Vec<(f32, usize)>> = vec![Vec::new(); num_buckets];
+    for (i, p) in points.iter().enumerate() {
+        let bx = ((p.x as usize) / dx).min(nx - 1);
+        let by = ((p.y as usize) / dy).min(ny - 1);
+        buckets[bx * ny + by].push((p.score.abs(), i));
+    }
+
+    let mut out = Vec::with_capacity(max_total);
+    for mut bucket in buckets {
+        let bucket_len = bucket.len();
+        let n = bucket_len.min(num_per_bucket);
+        if n == 0 {
+            continue;
+        }
+        // Partial sort descending by |score|. select_nth_unstable_by
+        // partitions so that bucket[0..pivot] are all >= bucket[pivot..],
+        // where pivot = n - 1. After the call, the top-n entries occupy
+        // positions 0..n (in unspecified internal order).
+        let pivot = (n - 1).min(bucket_len - 1);
+        bucket.select_nth_unstable_by(pivot, |a, b| {
+            b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
+        });
+        for k in 0..n {
+            out.push(points[bucket[k].1]);
+        }
+    }
+    out
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Orientation assignment
+// ──────────────────────────────────────────────────────────────────────
+
+fn assign_orientations(
+    refined: Vec<DoGFeaturePoint>,
+    pyramid: &GaussianScaleSpacePyramid,
+    oa: &OrientationAssignment,
+) -> Vec<DoGFeaturePoint> {
+    let num_scales = GaussianScaleSpacePyramid::NUM_SCALES_PER_OCTAVE;
+    // Precompute gradient images for every (octave, scale).
+    let mut gradients: Vec<Matrix<f32>> = Vec::with_capacity(pyramid.num_octaves * num_scales);
+    for oct in 0..pyramid.num_octaves {
+        for scale in 0..num_scales {
+            gradients.push(compute_polar_gradient_image(pyramid.level(oct, scale)));
+        }
+    }
+
+    let mut out = Vec::with_capacity(refined.len());
+    for kp in &refined {
+        // Downsample fine-image (x, y, sigma) to octave-local for OA.
+        let inv = 1.0 / (1u32 << (kp.octave as usize)) as f32;
+        let off = 0.5 * inv - 0.5;
+        let mut x_oct = kp.x * inv + off;
+        let mut y_oct = kp.y * inv + off;
+        let sigma_oct = kp.sigma * inv;
+
+        // Clip to octave bounds.
+        let g_idx = (kp.octave as usize) * num_scales + (kp.scale as usize);
+        if g_idx >= gradients.len() {
+            continue;
+        }
+        let g = &gradients[g_idx];
+        x_oct = x_oct.clamp(0.0, g.cols as f32 - 1.0);
+        y_oct = y_oct.clamp(0.0, g.rows as f32 - 1.0);
+
+        let angles = oa.compute(g, x_oct, y_oct, sigma_oct);
+        for angle in angles {
+            let mut copy = *kp;
+            copy.angle = angle;
+            out.push(copy);
+        }
+    }
+    out
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Tests
+// ══════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load_grayscale(path: &str) -> Matrix<u8> {
+        let img = image::open(path).expect("load test image").to_luma8();
+        let (w, h) = img.dimensions();
+        Matrix::<u8>::from_vec(h as usize, w as usize, 1, img.into_raw())
+    }
+
+    fn build_test_pyramid(img: &Matrix<u8>, num_octaves: usize) -> GaussianScaleSpacePyramid {
+        let mut p = GaussianScaleSpacePyramid::new(num_octaves);
+        p.build(img).expect("build gaussian pyramid");
+        p
+    }
+
+    #[test]
+    fn test_dog_feature_point_from_conversion() {
+        let d = DoGFeaturePoint {
+            x: 12.5,
+            y: 34.5,
+            angle: 1.57,
+            octave: 1,
+            scale: 0,
+            sp_scale: 0.25,
+            score: -0.04,
+            sigma: 2.1,
+            edge_score: 5.0,
+        };
+        let fp: FeaturePoint = (&d).into();
+        assert!((fp.x - 12.5).abs() < 1e-6);
+        assert!((fp.y - 34.5).abs() < 1e-6);
+        assert!((fp.angle - 1.57).abs() < 1e-6);
+        assert!((fp.scale - 2.1).abs() < 1e-6);
+        // score < 0 => minima.
+        assert!(!fp.maxima);
+
+        let d2 = DoGFeaturePoint { score: 0.5, ..d };
+        let fp2: FeaturePoint = (&d2).into();
+        assert!(fp2.maxima);
+    }
+
+    #[test]
+    fn test_dog_detector_zero_octave_pyramid_is_handled() {
+        // Smallest valid pyramid: 1 octave, smallest valid input.
+        // GaussianScaleSpacePyramid requires >= 5x5 input.
+        let img = Matrix::<u8>::from_vec(8, 8, 1, vec![100u8; 64]);
+        let mut p = GaussianScaleSpacePyramid::new(1);
+        p.build(&img).expect("build");
+        let det = DoGScaleInvariantDetector::new(0.0, 10.0, 5000, false);
+        let pts = det.detect(&p);
+        // With only 1 octave we have 2 DoG levels (indices 0,1). The
+        // interior loop `1..size-1` is empty for size=2, so no extrema.
+        assert!(pts.is_empty(), "expected zero keypoints, got {}", pts.len());
+    }
+
+    #[test]
+    fn test_dog_detector_finds_keypoints_on_real_image() {
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let pyr = build_test_pyramid(&img, 3);
+        let det = DoGScaleInvariantDetector::new(0.0, 10.0, 5000, false);
+        let pts = det.detect(&pyr);
+        assert!(pts.len() > 50, "expected > 50 keypoints, got {}", pts.len());
+    }
+
+    #[test]
+    fn test_dog_detector_keypoints_within_image_bounds() {
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let pyr = build_test_pyramid(&img, 3);
+        let det = DoGScaleInvariantDetector::new(0.0, 10.0, 5000, false);
+        let pts = det.detect(&pyr);
+        let w = img.cols as f32;
+        let h = img.rows as f32;
+        for p in &pts {
+            let fp: FeaturePoint = p.into();
+            assert!(
+                fp.x >= 0.0 && fp.x < w && fp.y >= 0.0 && fp.y < h,
+                "keypoint ({}, {}) outside [0, {})x[0, {})",
+                fp.x,
+                fp.y,
+                w,
+                h
+            );
+        }
+    }
+
+    // ── Dual-mode: keypoint count agreement with C++ ──────────────────
+
+    #[cfg(feature = "dual-mode")]
+    extern "C" {
+        fn webarkit_cpp_dog_detect_count(
+            src: *const u8,
+            src_w: i32,
+            src_h: i32,
+            num_octaves: i32,
+            laplacian_threshold: f32,
+            edge_threshold: f32,
+            max_num_feature_points: i32,
+            find_orientation: i32,
+            count_out: *mut i32,
+        ) -> i32;
+    }
+
+    #[cfg(feature = "dual-mode")]
+    fn cpp_detect_count(
+        img: &Matrix<u8>,
+        num_octaves: usize,
+        laplacian_threshold: f32,
+        edge_threshold: f32,
+        max_num_feature_points: usize,
+        find_orientation: bool,
+    ) -> i32 {
+        let mut count: i32 = 0;
+        // SAFETY: the shim validates pointers and dimensions; img owns
+        // the source buffer; count_out points to a stack-local i32.
+        let rc = unsafe {
+            webarkit_cpp_dog_detect_count(
+                img.as_slice().as_ptr(),
+                img.cols as i32,
+                img.rows as i32,
+                num_octaves as i32,
+                laplacian_threshold,
+                edge_threshold,
+                max_num_feature_points as i32,
+                if find_orientation { 1 } else { 0 },
+                &mut count,
+            )
+        };
+        assert_eq!(rc, 0, "C++ shim returned error {rc}");
+        count
+    }
+
+    #[test]
+    #[cfg(feature = "dual-mode")]
+    fn test_dog_keypoints_match_cpp_count() {
+        // Tolerance covers sort tie-breaking and bucket ordering variance
+        // only. Any algorithm-level error would dwarf this.
+        const MAX_TIE_DIVERGENCE: i32 = 5;
+
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let num_octaves = 3;
+        let laplacian_threshold = 0.0;
+        let edge_threshold = 10.0;
+        let max_pts = 5000;
+        let find_orientation = false;
+
+        let pyr = build_test_pyramid(&img, num_octaves);
+        let det = DoGScaleInvariantDetector::new(
+            laplacian_threshold,
+            edge_threshold,
+            max_pts,
+            find_orientation,
+        );
+        let rust_count = det.detect(&pyr).len() as i32;
+
+        let cpp_count = cpp_detect_count(
+            &img,
+            num_octaves,
+            laplacian_threshold,
+            edge_threshold,
+            max_pts,
+            find_orientation,
+        );
+
+        let diff = (rust_count - cpp_count).abs();
+        assert!(
+            diff <= MAX_TIE_DIVERGENCE,
+            "keypoint count divergence: rust={rust_count}, cpp={cpp_count}, |diff|={diff} > {MAX_TIE_DIVERGENCE}"
+        );
+    }
+}

--- a/crates/core/src/kpm/freak/gaussian_pyramid.rs
+++ b/crates/core/src/kpm/freak/gaussian_pyramid.rs
@@ -640,35 +640,13 @@ mod tests {
         dst
     }
 
-    /// Distance in ULPs between two non-negative f32 values. Returns
-    /// `i64::MAX` for sign mismatches or NaN.
-    #[cfg(feature = "dual-mode")]
-    fn ulp_distance(a: f32, b: f32) -> i64 {
-        if a.is_nan() || b.is_nan() {
-            return i64::MAX;
-        }
-        if a.is_sign_negative() != b.is_sign_negative() {
-            return i64::MAX;
-        }
-        // For same-sign floats, to_bits() is monotonic, so the integer
-        // difference of the bit patterns equals the ULP distance.
-        (a.to_bits() as i64 - b.to_bits() as i64).abs()
-    }
-
     #[test]
     #[cfg(feature = "dual-mode")]
     fn test_gaussian_pyramid_pixels_match_cpp() {
-        // We assert <= 1 ULP rather than strict bit equality because Apple
-        // clang on ARM64 emits FMA (fused multiply-add) instructions for
-        // the binomial filter expression by default, while MSVC and GCC
-        // (Linux) do not. FMA is *more* precise (no intermediate rounding),
-        // so the C++ output differs by 1 ULP across platforms — and the
-        // Rust output (no FMA) lands at one of those rounded values. The
-        // 1-ULP tolerance keeps the test meaningful (it would still fail
-        // on any real algorithm error) while accommodating cross-platform
-        // C++ FP contraction. See docs/design/m8-2-gaussian-pyramid.md §7.
-        const MAX_ULP_DIFF: i64 = 1;
-
+        // Strict byte-for-byte f32 parity. The C++ side is compiled with
+        // `-ffp-contract=off` (see build.rs) to prevent Apple clang on ARM64
+        // from emitting FMA instructions that would drift from the non-FMA
+        // Rust output by multiple ULPs.
         let src_w = 32;
         let src_h = 32;
         let src = gradient_u8(src_h, src_w);
@@ -683,10 +661,10 @@ mod tests {
                 let rust = rust_pyr.level(oct, scale).as_slice();
                 assert_eq!(rust.len(), cpp.len(), "size mismatch at ({oct}, {scale})");
                 for (i, (&r, &c)) in rust.iter().zip(cpp.iter()).enumerate() {
-                    let ulp = ulp_distance(r, c);
-                    assert!(
-                        ulp <= MAX_ULP_DIFF,
-                        "f32 mismatch at ({oct}, {scale}) idx {i}: rust={r}, cpp={c}, ulp_diff={ulp}"
+                    assert_eq!(
+                        r.to_bits(),
+                        c.to_bits(),
+                        "f32 bit mismatch at ({oct}, {scale}) idx {i}: rust={r}, cpp={c}"
                     );
                 }
             }

--- a/crates/core/src/kpm/freak/gaussian_pyramid.rs
+++ b/crates/core/src/kpm/freak/gaussian_pyramid.rs
@@ -640,9 +640,35 @@ mod tests {
         dst
     }
 
+    /// Distance in ULPs between two non-negative f32 values. Returns
+    /// `i64::MAX` for sign mismatches or NaN.
+    #[cfg(feature = "dual-mode")]
+    fn ulp_distance(a: f32, b: f32) -> i64 {
+        if a.is_nan() || b.is_nan() {
+            return i64::MAX;
+        }
+        if a.is_sign_negative() != b.is_sign_negative() {
+            return i64::MAX;
+        }
+        // For same-sign floats, to_bits() is monotonic, so the integer
+        // difference of the bit patterns equals the ULP distance.
+        (a.to_bits() as i64 - b.to_bits() as i64).abs()
+    }
+
     #[test]
     #[cfg(feature = "dual-mode")]
     fn test_gaussian_pyramid_pixels_match_cpp() {
+        // We assert <= 1 ULP rather than strict bit equality because Apple
+        // clang on ARM64 emits FMA (fused multiply-add) instructions for
+        // the binomial filter expression by default, while MSVC and GCC
+        // (Linux) do not. FMA is *more* precise (no intermediate rounding),
+        // so the C++ output differs by 1 ULP across platforms — and the
+        // Rust output (no FMA) lands at one of those rounded values. The
+        // 1-ULP tolerance keeps the test meaningful (it would still fail
+        // on any real algorithm error) while accommodating cross-platform
+        // C++ FP contraction. See docs/design/m8-2-gaussian-pyramid.md §7.
+        const MAX_ULP_DIFF: i64 = 1;
+
         let src_w = 32;
         let src_h = 32;
         let src = gradient_u8(src_h, src_w);
@@ -657,10 +683,10 @@ mod tests {
                 let rust = rust_pyr.level(oct, scale).as_slice();
                 assert_eq!(rust.len(), cpp.len(), "size mismatch at ({oct}, {scale})");
                 for (i, (&r, &c)) in rust.iter().zip(cpp.iter()).enumerate() {
-                    assert_eq!(
-                        r.to_bits(),
-                        c.to_bits(),
-                        "f32 bit mismatch at ({oct}, {scale}) idx {i}: rust={r}, cpp={c}"
+                    let ulp = ulp_distance(r, c);
+                    assert!(
+                        ulp <= MAX_ULP_DIFF,
+                        "f32 mismatch at ({oct}, {scale}) idx {i}: rust={r}, cpp={c}, ulp_diff={ulp}"
                     );
                 }
             }

--- a/crates/core/src/kpm/freak/gaussian_pyramid.rs
+++ b/crates/core/src/kpm/freak/gaussian_pyramid.rs
@@ -1,0 +1,669 @@
+/*
+ *  gaussian_pyramid.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Binomial Gaussian scale-space pyramid (f32 levels, 3 scales per octave).
+//!
+//! Ported from
+//! `WebARKitLib/lib/SRC/KPM/FreakMatcher/detectors/gaussian_scale_space_pyramid.{h,cpp}`
+//! (the `BinomialPyramid32f` concrete impl plus its `GaussianScaleSpacePyramid`
+//! base). The C++ inheritance hierarchy is flattened into one Rust type since
+//! `BinomialPyramid32f` is the only concrete implementation in use.
+//!
+//! Input is `Matrix<u8>` (grayscale); output is `Matrix<f32>` per level
+//! (matches C++ `IMAGE_F32` storage). The binomial filter is a fixed 5-tap
+//! `[1, 4, 6, 4, 1]` kernel applied separably (H then V), with `1 / 256`
+//! normalization on the V pass. Border handling replicates edge pixels for
+//! the 2-pixel border on each side, matching the C++ exactly.
+
+use crate::{arlog_e, arlog_w};
+use purecv::core::Matrix;
+
+/// Errors that can occur while building a [`GaussianScaleSpacePyramid`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum GaussianPyramidError {
+    /// Input image had zero rows or zero columns.
+    EmptyImage,
+    /// Input image is smaller than 5x5; the binomial filter needs 2 border
+    /// pixels on each side.
+    ImageTooSmall { rows: usize, cols: usize },
+    /// `num_octaves` was 0 — a pyramid must have at least one octave.
+    ZeroOctaves,
+    /// Halving for `octave` would produce a level smaller than 5x5.
+    OctaveTooSmall {
+        octave: usize,
+        rows: usize,
+        cols: usize,
+    },
+}
+
+impl std::fmt::Display for GaussianPyramidError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyImage => write!(f, "input image is empty (0 rows or 0 cols)"),
+            Self::ImageTooSmall { rows, cols } => write!(
+                f,
+                "input image is {rows}x{cols}; binomial filter requires >= 5x5"
+            ),
+            Self::ZeroOctaves => write!(f, "num_octaves must be >= 1"),
+            Self::OctaveTooSmall { octave, rows, cols } => write!(
+                f,
+                "octave {octave} would be {rows}x{cols}; binomial filter requires >= 5x5"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for GaussianPyramidError {}
+
+/// Binomial Gaussian scale-space pyramid.
+///
+/// Each octave contains exactly [`Self::NUM_SCALES_PER_OCTAVE`] = 3 levels.
+/// Level dimensions: octave `o` has size `(rows >> o, cols >> o)`. Level
+/// storage is `Matrix<f32>` (row-major).
+#[derive(Debug, Clone)]
+pub struct GaussianScaleSpacePyramid {
+    /// `octaves[oct][scale]` — `Matrix<f32>` for the level.
+    pub octaves: Vec<Vec<Matrix<f32>>>,
+    /// Number of octaves requested at construction.
+    pub num_octaves: usize,
+    /// Scale step factor: `k = 2^(1 / (NUM_SCALES_PER_OCTAVE - 1)) = sqrt(2)`.
+    pub kfactor: f32,
+    /// `1 / ln(k)` — precomputed for [`Self::locate`].
+    pub one_over_log_k: f32,
+}
+
+impl GaussianScaleSpacePyramid {
+    /// C++ `BinomialPyramid32f::alloc` hardcodes 3 scales per octave; the
+    /// build sequence (`filter`, `filter`, `filter_twice`) is 3-specific.
+    pub const NUM_SCALES_PER_OCTAVE: usize = 3;
+
+    /// Create an empty pyramid configured for `num_octaves` octaves.
+    /// Levels are populated by [`Self::build`].
+    #[must_use]
+    pub fn new(num_octaves: usize) -> Self {
+        let k = 2f32.powf(1.0 / (Self::NUM_SCALES_PER_OCTAVE as f32 - 1.0));
+        Self {
+            octaves: Vec::with_capacity(num_octaves),
+            num_octaves,
+            kfactor: k,
+            one_over_log_k: 1.0 / k.ln(),
+        }
+    }
+
+    /// Number of scales per octave (always [`Self::NUM_SCALES_PER_OCTAVE`]).
+    #[must_use]
+    pub fn num_scales_per_octave(&self) -> usize {
+        Self::NUM_SCALES_PER_OCTAVE
+    }
+
+    /// Borrow level at `(octave, scale)`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `octave >= num_octaves` or `scale >= NUM_SCALES_PER_OCTAVE`.
+    #[must_use]
+    pub fn level(&self, octave: usize, scale: usize) -> &Matrix<f32> {
+        &self.octaves[octave][scale]
+    }
+
+    /// Effective sigma at `(octave, scale)`: `k^scale * 2^octave`.
+    #[must_use]
+    pub fn effective_sigma(&self, octave: usize, scale: usize) -> f32 {
+        self.kfactor.powi(scale as i32) * (1u32 << octave) as f32
+    }
+
+    /// Snap `sigma` to the nearest `(octave, scale)` pair. Clamped to the
+    /// pyramid bounds.
+    ///
+    /// C equivalent: `vision::GaussianScaleSpacePyramid::locate(int&, int&, float)`.
+    #[must_use]
+    pub fn locate(&self, sigma: f32) -> (usize, usize) {
+        let mut octave = sigma.log2().floor() as i32;
+        let octave_pow = if octave >= 0 {
+            (1i32 << octave) as f32
+        } else {
+            1.0 / (1i32 << -octave) as f32
+        };
+        let fscale = (sigma / octave_pow).ln() * self.one_over_log_k;
+        let mut scale = fscale.round() as i32;
+
+        // C++: if scale is the last in octave, bump to next octave's scale 0
+        // (coarser octaves are preferred for efficiency).
+        if scale == (Self::NUM_SCALES_PER_OCTAVE as i32) - 1 {
+            octave += 1;
+            scale = 0;
+        }
+
+        // Clamp to pyramid bounds.
+        if octave < 0 {
+            return (0, 0);
+        }
+        if (octave as usize) >= self.num_octaves {
+            return (self.num_octaves - 1, Self::NUM_SCALES_PER_OCTAVE - 1);
+        }
+        let scale = scale.clamp(0, Self::NUM_SCALES_PER_OCTAVE as i32 - 1) as usize;
+        (octave as usize, scale)
+    }
+
+    /// Populate `self.octaves` from `image`. Idempotent (clears prior state).
+    ///
+    /// Build sequence per C++ `BinomialPyramid32f::build`:
+    /// - Octave 0:
+    ///   - `octaves[0][0] = filter(input)` (u8 → f32)
+    ///   - `octaves[0][1] = filter(octaves[0][0])` (f32 → f32)
+    ///   - `octaves[0][2] = filter(filter(octaves[0][1]))` (2 applications)
+    /// - Octave i (i > 0):
+    ///   - `octaves[i][0] = downsample(octaves[i-1][2])`
+    ///   - `octaves[i][1] = filter(octaves[i][0])`
+    ///   - `octaves[i][2] = filter(filter(octaves[i][1]))`
+    pub fn build(&mut self, image: &Matrix<u8>) -> Result<(), GaussianPyramidError> {
+        if self.num_octaves == 0 {
+            arlog_e!("GaussianScaleSpacePyramid::build: num_octaves is 0");
+            return Err(GaussianPyramidError::ZeroOctaves);
+        }
+        if image.rows == 0 || image.cols == 0 {
+            arlog_e!("GaussianScaleSpacePyramid::build: input image is empty");
+            return Err(GaussianPyramidError::EmptyImage);
+        }
+        if image.rows < 5 || image.cols < 5 {
+            arlog_e!(
+                "GaussianScaleSpacePyramid::build: image too small ({}x{}); need >= 5x5",
+                image.rows,
+                image.cols
+            );
+            return Err(GaussianPyramidError::ImageTooSmall {
+                rows: image.rows,
+                cols: image.cols,
+            });
+        }
+        if image.channels != 1 {
+            arlog_w!(
+                "GaussianScaleSpacePyramid::build: input has {} channels; only the first is used",
+                image.channels
+            );
+        }
+
+        self.octaves.clear();
+
+        // Octave 0.
+        let l0 = binomial_4th_order_u8_to_f32(image);
+        let l1 = binomial_4th_order_f32_to_f32(&l0);
+        let l2_tmp = binomial_4th_order_f32_to_f32(&l1);
+        let l2 = binomial_4th_order_f32_to_f32(&l2_tmp);
+        self.octaves.push(vec![l0, l1, l2]);
+
+        // Octaves 1..num_octaves.
+        for oct in 1..self.num_octaves {
+            let prev_last = &self.octaves[oct - 1][Self::NUM_SCALES_PER_OCTAVE - 1];
+            let new_h = prev_last.rows >> 1;
+            let new_w = prev_last.cols >> 1;
+            if new_h < 5 || new_w < 5 {
+                arlog_e!(
+                    "GaussianScaleSpacePyramid::build: octave {oct} would be {new_h}x{new_w}; need >= 5x5"
+                );
+                return Err(GaussianPyramidError::OctaveTooSmall {
+                    octave: oct,
+                    rows: new_h,
+                    cols: new_w,
+                });
+            }
+            let l0 = downsample_bilinear_f32(prev_last);
+            let l1 = binomial_4th_order_f32_to_f32(&l0);
+            let l2_tmp = binomial_4th_order_f32_to_f32(&l1);
+            let l2 = binomial_4th_order_f32_to_f32(&l2_tmp);
+            self.octaves.push(vec![l0, l1, l2]);
+        }
+
+        Ok(())
+    }
+}
+
+/// Compute the number of octaves usable for a given image size, given the
+/// minimum coarsest-octave dimension.
+///
+/// C equivalent: `vision::numOctaves`.
+#[must_use]
+pub fn num_octaves_for(width: usize, height: usize, min_size: usize) -> usize {
+    let mut w = width;
+    let mut h = height;
+    let mut n = 0;
+    while w >= min_size && h >= min_size {
+        w >>= 1;
+        h >>= 1;
+        n += 1;
+    }
+    n
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Private filter helpers — byte-for-byte port of C++ `binomial_4th_order`
+// and `downsample_bilinear` from `gaussian_scale_space_pyramid.cpp`.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, u8 source → f32 dest.
+///
+/// H pass uses `u16` accumulator (max value `16 * 255 = 4080`, fits `u16`).
+/// V pass multiplies by `1 / 256` to yield `f32` output. Border replication:
+/// edge pixels extend the 2-pixel border on each side.
+///
+/// C equivalent: `vision::binomial_4th_order(float*, unsigned short*, const unsigned char*, ...)`.
+fn binomial_4th_order_u8_to_f32(src: &Matrix<u8>) -> Matrix<f32> {
+    let width = src.cols;
+    let height = src.rows;
+    debug_assert!(width >= 5 && height >= 5);
+
+    let src_data = src.as_slice();
+    let mut tmp = vec![0u16; width * height];
+
+    // Horizontal pass.
+    for row in 0..height {
+        let row_off = row * width;
+        let s = &src_data[row_off..row_off + width];
+        // col 0: xm2 = xm1 = c = s[0], xp1 = s[1], xp2 = s[2].
+        tmp[row_off] =
+            6 * s[0] as u16 + 4 * (s[0] as u16 + s[1] as u16) + (s[0] as u16 + s[2] as u16);
+        // col 1: xm2 = s[0], xm1 = s[0], c = s[1], xp1 = s[2], xp2 = s[3].
+        tmp[row_off + 1] =
+            6 * s[1] as u16 + 4 * (s[0] as u16 + s[2] as u16) + (s[0] as u16 + s[3] as u16);
+        // Non-border cols.
+        for col in 2..width - 2 {
+            tmp[row_off + col] = 6 * s[col] as u16
+                + 4 * (s[col - 1] as u16 + s[col + 1] as u16)
+                + (s[col - 2] as u16 + s[col + 2] as u16);
+        }
+        // col width-2: xp2 clamped to s[width-1].
+        let c = width - 2;
+        tmp[row_off + c] = 6 * s[c] as u16
+            + 4 * (s[c - 1] as u16 + s[c + 1] as u16)
+            + (s[c - 2] as u16 + s[c + 1] as u16);
+        // col width-1: xp1 = xp2 = s[width-1].
+        let c = width - 1;
+        tmp[row_off + c] =
+            6 * s[c] as u16 + 4 * (s[c - 1] as u16 + s[c] as u16) + (s[c - 2] as u16 + s[c] as u16);
+    }
+
+    // Vertical pass.
+    let mut dst_data = vec![0f32; width * height];
+    const INV_256: f32 = 1.0 / 256.0;
+
+    // Top border: rows 0 and 1.
+    for col in 0..width {
+        // row 0: pm2 = pm1 = p = tmp[col]; pp1 = tmp[width+col]; pp2 = tmp[2w+col].
+        let p = tmp[col] as u32;
+        let pp1 = tmp[width + col] as u32;
+        let pp2 = tmp[2 * width + col] as u32;
+        dst_data[col] = ((6 * p + 4 * (p + pp1) + p + pp2) as f32) * INV_256;
+        // row 1: pm2 = pm1 = tmp[col]; p = tmp[w+col]; pp1 = tmp[2w+col]; pp2 = tmp[3w+col].
+        let pm = tmp[col] as u32;
+        let p = tmp[width + col] as u32;
+        let pp1 = tmp[2 * width + col] as u32;
+        let pp2 = tmp[3 * width + col] as u32;
+        dst_data[width + col] = ((6 * p + 4 * (pm + pp1) + pm + pp2) as f32) * INV_256;
+    }
+
+    // Non-border rows.
+    for row in 2..height - 2 {
+        let row_off = row * width;
+        for col in 0..width {
+            let pm2 = tmp[(row - 2) * width + col] as u32;
+            let pm1 = tmp[(row - 1) * width + col] as u32;
+            let p = tmp[row_off + col] as u32;
+            let pp1 = tmp[(row + 1) * width + col] as u32;
+            let pp2 = tmp[(row + 2) * width + col] as u32;
+            dst_data[row_off + col] = ((6 * p + 4 * (pm1 + pp1) + pm2 + pp2) as f32) * INV_256;
+        }
+    }
+
+    // Bottom border: rows h-2 and h-1.
+    let h = height;
+    for col in 0..width {
+        // row h-2: pp1 = pp2 = tmp[(h-1)*w + col].
+        let pm2 = tmp[(h - 4) * width + col] as u32;
+        let pm1 = tmp[(h - 3) * width + col] as u32;
+        let p = tmp[(h - 2) * width + col] as u32;
+        let pp = tmp[(h - 1) * width + col] as u32;
+        dst_data[(h - 2) * width + col] = ((6 * p + 4 * (pm1 + pp) + pm2 + pp) as f32) * INV_256;
+        // row h-1: p = pp1 = pp2 = tmp[(h-1)*w + col].
+        let pm2 = tmp[(h - 3) * width + col] as u32;
+        let pm1 = tmp[(h - 2) * width + col] as u32;
+        let p = tmp[(h - 1) * width + col] as u32;
+        dst_data[(h - 1) * width + col] = ((6 * p + 4 * (pm1 + p) + pm2 + p) as f32) * INV_256;
+    }
+
+    Matrix::<f32>::from_vec(height, width, 1, dst_data)
+}
+
+/// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, f32 → f32. Used for
+/// the second and third levels within an octave and for all levels in
+/// non-zero octaves.
+///
+/// C equivalent: `vision::binomial_4th_order(float*, float*, const float*, ...)`.
+fn binomial_4th_order_f32_to_f32(src: &Matrix<f32>) -> Matrix<f32> {
+    let width = src.cols;
+    let height = src.rows;
+    debug_assert!(width >= 5 && height >= 5);
+
+    let src_data = src.as_slice();
+    let mut tmp = vec![0f32; width * height];
+
+    // Horizontal pass. Addition order matches C++ left-to-right exactly to
+    // preserve f32 bit-for-bit parity (no parenthesizing of the (ll + rr) term).
+    for row in 0..height {
+        let row_off = row * width;
+        let s = &src_data[row_off..row_off + width];
+        tmp[row_off] = 6.0 * s[0] + 4.0 * (s[0] + s[1]) + s[0] + s[2];
+        tmp[row_off + 1] = 6.0 * s[1] + 4.0 * (s[0] + s[2]) + s[0] + s[3];
+        for col in 2..width - 2 {
+            tmp[row_off + col] =
+                6.0 * s[col] + 4.0 * (s[col - 1] + s[col + 1]) + s[col - 2] + s[col + 2];
+        }
+        let c = width - 2;
+        tmp[row_off + c] = 6.0 * s[c] + 4.0 * (s[c - 1] + s[c + 1]) + s[c - 2] + s[c + 1];
+        let c = width - 1;
+        tmp[row_off + c] = 6.0 * s[c] + 4.0 * (s[c - 1] + s[c]) + s[c - 2] + s[c];
+    }
+
+    // Vertical pass.
+    let mut dst_data = vec![0f32; width * height];
+    const INV_256: f32 = 1.0 / 256.0;
+
+    for col in 0..width {
+        // row 0
+        let p = tmp[col];
+        let pp1 = tmp[width + col];
+        let pp2 = tmp[2 * width + col];
+        dst_data[col] = (6.0 * p + 4.0 * (p + pp1) + p + pp2) * INV_256;
+        // row 1
+        let pm = tmp[col];
+        let p = tmp[width + col];
+        let pp1 = tmp[2 * width + col];
+        let pp2 = tmp[3 * width + col];
+        dst_data[width + col] = (6.0 * p + 4.0 * (pm + pp1) + pm + pp2) * INV_256;
+    }
+
+    for row in 2..height - 2 {
+        let row_off = row * width;
+        for col in 0..width {
+            let pm2 = tmp[(row - 2) * width + col];
+            let pm1 = tmp[(row - 1) * width + col];
+            let p = tmp[row_off + col];
+            let pp1 = tmp[(row + 1) * width + col];
+            let pp2 = tmp[(row + 2) * width + col];
+            dst_data[row_off + col] = (6.0 * p + 4.0 * (pm1 + pp1) + pm2 + pp2) * INV_256;
+        }
+    }
+
+    let h = height;
+    for col in 0..width {
+        let pm2 = tmp[(h - 4) * width + col];
+        let pm1 = tmp[(h - 3) * width + col];
+        let p = tmp[(h - 2) * width + col];
+        let pp = tmp[(h - 1) * width + col];
+        dst_data[(h - 2) * width + col] = (6.0 * p + 4.0 * (pm1 + pp) + pm2 + pp) * INV_256;
+        let pm2 = tmp[(h - 3) * width + col];
+        let pm1 = tmp[(h - 2) * width + col];
+        let p = tmp[(h - 1) * width + col];
+        dst_data[(h - 1) * width + col] = (6.0 * p + 4.0 * (pm1 + p) + pm2 + p) * INV_256;
+    }
+
+    Matrix::<f32>::from_vec(height, width, 1, dst_data)
+}
+
+/// 2x2 bilinear downsample. Output dims: `(src.rows >> 1, src.cols >> 1)`.
+/// Per output pixel: `(p00 + p01 + p10 + p11) * 0.25`. No `ceil` adjustment
+/// (unlike the M8-1 box-filter pyramid).
+///
+/// C equivalent: `vision::downsample_bilinear`.
+fn downsample_bilinear_f32(src: &Matrix<f32>) -> Matrix<f32> {
+    let dst_w = src.cols >> 1;
+    let dst_h = src.rows >> 1;
+    let src_data = src.as_slice();
+    let src_w = src.cols;
+
+    let mut dst_data = Vec::<f32>::with_capacity(dst_w * dst_h);
+    for row in 0..dst_h {
+        let r0 = (row * 2) * src_w;
+        let r1 = r0 + src_w;
+        for col in 0..dst_w {
+            let c = col * 2;
+            let sum =
+                src_data[r0 + c] + src_data[r0 + c + 1] + src_data[r1 + c] + src_data[r1 + c + 1];
+            dst_data.push(sum * 0.25);
+        }
+    }
+    Matrix::<f32>::from_vec(dst_h, dst_w, 1, dst_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gradient_u8(rows: usize, cols: usize) -> Matrix<u8> {
+        let data: Vec<u8> = (0..rows * cols).map(|i| (i & 0xFF) as u8).collect();
+        Matrix::<u8>::from_vec(rows, cols, 1, data)
+    }
+
+    // ── Configuration sanity ─────────────────────────────────────────────
+
+    #[test]
+    fn test_kfactor_for_3_scales() {
+        let p = GaussianScaleSpacePyramid::new(1);
+        assert!(
+            (p.kfactor - 2f32.sqrt()).abs() < 1e-6,
+            "expected sqrt(2), got {}",
+            p.kfactor
+        );
+    }
+
+    #[test]
+    fn test_gaussian_pyramid_octave_count() {
+        let img = gradient_u8(64, 64);
+        let mut p = GaussianScaleSpacePyramid::new(3);
+        p.build(&img).unwrap();
+        assert_eq!(p.octaves.len(), 3);
+        for oct in &p.octaves {
+            assert_eq!(oct.len(), GaussianScaleSpacePyramid::NUM_SCALES_PER_OCTAVE);
+        }
+    }
+
+    #[test]
+    fn test_gaussian_pyramid_octave_downsamples() {
+        let img = gradient_u8(64, 64);
+        let mut p = GaussianScaleSpacePyramid::new(3);
+        p.build(&img).unwrap();
+        assert_eq!(p.level(0, 0).cols, 64);
+        assert_eq!(p.level(1, 0).cols, 32);
+        assert_eq!(p.level(2, 0).cols, 16);
+        assert_eq!(p.level(0, 0).rows, 64);
+        assert_eq!(p.level(1, 0).rows, 32);
+        assert_eq!(p.level(2, 0).rows, 16);
+    }
+
+    #[test]
+    fn test_gaussian_pyramid_sigma_increases() {
+        let p = GaussianScaleSpacePyramid::new(3);
+        // Within an octave: sigma grows by k each scale.
+        for oct in 0..3 {
+            for s in 0..2 {
+                assert!(
+                    p.effective_sigma(oct, s + 1) > p.effective_sigma(oct, s),
+                    "sigma did not increase within octave {oct} from scale {s} to {}",
+                    s + 1
+                );
+            }
+        }
+        // Across octaves: sigma doubles each octave at the same scale.
+        for s in 0..3 {
+            assert!(
+                p.effective_sigma(1, s) > p.effective_sigma(0, s),
+                "sigma did not increase from octave 0 to 1 at scale {s}"
+            );
+        }
+        // effective_sigma(0, 0) is the implicit base sigma == 1.0.
+        assert!((p.effective_sigma(0, 0) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_locate_clamps_to_pyramid_bounds() {
+        let p = GaussianScaleSpacePyramid::new(2);
+        // Very small sigma → (0, 0).
+        assert_eq!(p.locate(0.1), (0, 0));
+        // Very large sigma → last octave, last scale.
+        let (o, s) = p.locate(1000.0);
+        assert_eq!(o, 1);
+        assert_eq!(s, GaussianScaleSpacePyramid::NUM_SCALES_PER_OCTAVE - 1);
+    }
+
+    #[test]
+    fn test_gaussian_pyramid_build_is_idempotent() {
+        let img1 = gradient_u8(32, 32);
+        let img2 = gradient_u8(16, 16);
+        let mut p = GaussianScaleSpacePyramid::new(2);
+        p.build(&img1).unwrap();
+        p.build(&img2).unwrap();
+        assert_eq!(p.octaves.len(), 2);
+        // Reflects img2, not img1.
+        assert_eq!(p.level(0, 0).rows, 16);
+        assert_eq!(p.level(0, 0).cols, 16);
+    }
+
+    // ── Error variants ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_gaussian_pyramid_empty_image_returns_error() {
+        let img = Matrix::<u8>::zeros(0, 0, 1);
+        let mut p = GaussianScaleSpacePyramid::new(2);
+        assert_eq!(p.build(&img), Err(GaussianPyramidError::EmptyImage));
+    }
+
+    #[test]
+    fn test_gaussian_pyramid_image_too_small_returns_error() {
+        let img = gradient_u8(4, 4); // < 5
+        let mut p = GaussianScaleSpacePyramid::new(1);
+        assert!(matches!(
+            p.build(&img),
+            Err(GaussianPyramidError::ImageTooSmall { .. })
+        ));
+    }
+
+    #[test]
+    fn test_gaussian_pyramid_zero_octaves_returns_error() {
+        let img = gradient_u8(16, 16);
+        let mut p = GaussianScaleSpacePyramid::new(0);
+        assert_eq!(p.build(&img), Err(GaussianPyramidError::ZeroOctaves));
+    }
+
+    #[test]
+    fn test_num_octaves_for() {
+        // 64x64, min_size 8: 64→32→16→8→4 (stop because 4 < 8) → 4 octaves.
+        assert_eq!(num_octaves_for(64, 64, 8), 4);
+        // 100x50, min_size 16: limited by height. 50→25→12 (stop) → 2 octaves.
+        assert_eq!(num_octaves_for(100, 50, 16), 2);
+    }
+
+    // ── Dual-mode: byte-for-byte parity vs C++ ───────────────────────────
+
+    #[cfg(feature = "dual-mode")]
+    extern "C" {
+        fn webarkit_cpp_binomial_pyramid_build_level(
+            src: *const u8,
+            src_w: i32,
+            src_h: i32,
+            num_octaves: i32,
+            target_octave: i32,
+            target_scale: i32,
+            dst_out: *mut f32,
+            dst_capacity_floats: i32,
+        ) -> i32;
+    }
+
+    #[cfg(feature = "dual-mode")]
+    fn cpp_build_level(
+        src: &[u8],
+        src_w: usize,
+        src_h: usize,
+        num_octaves: usize,
+        target_octave: usize,
+        target_scale: usize,
+    ) -> Vec<f32> {
+        let lvl_w = src_w >> target_octave;
+        let lvl_h = src_h >> target_octave;
+        let mut dst = vec![0f32; lvl_w * lvl_h];
+        // SAFETY: src and dst are valid for the declared lengths; the C++
+        // shim checks capacity and copies row-by-row.
+        let rc = unsafe {
+            webarkit_cpp_binomial_pyramid_build_level(
+                src.as_ptr(),
+                src_w as i32,
+                src_h as i32,
+                num_octaves as i32,
+                target_octave as i32,
+                target_scale as i32,
+                dst.as_mut_ptr(),
+                dst.len() as i32,
+            )
+        };
+        assert_eq!(rc, 0, "C++ shim returned error {rc}");
+        dst
+    }
+
+    #[test]
+    #[cfg(feature = "dual-mode")]
+    fn test_gaussian_pyramid_pixels_match_cpp() {
+        let src_w = 32;
+        let src_h = 32;
+        let src = gradient_u8(src_h, src_w);
+        let num_octaves = 3;
+
+        let mut rust_pyr = GaussianScaleSpacePyramid::new(num_octaves);
+        rust_pyr.build(&src).unwrap();
+
+        for oct in 0..num_octaves {
+            for scale in 0..GaussianScaleSpacePyramid::NUM_SCALES_PER_OCTAVE {
+                let cpp = cpp_build_level(src.as_slice(), src_w, src_h, num_octaves, oct, scale);
+                let rust = rust_pyr.level(oct, scale).as_slice();
+                assert_eq!(rust.len(), cpp.len(), "size mismatch at ({oct}, {scale})");
+                for (i, (&r, &c)) in rust.iter().zip(cpp.iter()).enumerate() {
+                    assert_eq!(
+                        r.to_bits(),
+                        c.to_bits(),
+                        "f32 bit mismatch at ({oct}, {scale}) idx {i}: rust={r}, cpp={c}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/core/src/kpm/freak/hough.rs
+++ b/crates/core/src/kpm/freak/hough.rs
@@ -386,12 +386,6 @@ impl HoughSimilarityVoting {
     }
 }
 
-/// Placeholder for Keyframe from M8.
-#[derive(Clone, Debug)]
-pub struct Keyframe {
-    pub features: Vec<FeaturePoint>,
-}
-
 /// A feature point with position, orientation, scale, and extremum type.
 /// C equivalent: vision::FeaturePoint
 #[derive(Clone, Debug, Copy)]
@@ -434,13 +428,39 @@ pub struct HoughMatch {
     pub distance: f32,
 }
 
-/// Stub for FindFeatures (M8 will implement).
+/// Detect keypoints in the Gaussian pyramid and extract FREAK descriptors
+/// into `keyframe.store`.
+///
+/// Caller responsibilities:
+/// - `pyramid` is already built (via `pyramid.build(image)?`).
+/// - `detector` is configured with `find_orientation = true`. Otherwise
+///   keypoints have `angle = 0.0` and the resulting FREAK descriptors are
+///   rotation-variant, defeating the FREAK design.
+///
+/// C equivalent: `vision::FindFeatures` (`visual_database.h` lines 207–239).
 pub fn find_features(
-    _keyframe: &mut Keyframe,
-    _detector: &super::detector::DoGScaleInvariantDetector,
-    _pyramid: &super::gaussian_pyramid::GaussianScaleSpacePyramid,
+    keyframe: &mut super::keyframe::Keyframe,
+    pyramid: &super::gaussian_pyramid::GaussianScaleSpacePyramid,
+    detector: &super::detector::DoGScaleInvariantDetector,
 ) -> Result<(), KpmError> {
-    arlog_i!("find_features: stub implementation (M8 pending)");
+    // 1. Detect keypoints (M8-3).
+    let dog_points = detector.detect(pyramid);
+
+    // 2. Project rich DoG keypoints to persistent FeaturePoint (M8-3 From impl).
+    let points: Vec<FeaturePoint> = dog_points.iter().map(FeaturePoint::from).collect();
+
+    // 3. Extract FREAK descriptors as a flat Vec<u8>.
+    let mut buf =
+        Vec::<u8>::with_capacity(points.len() * super::descriptor::FREAK_DESCRIPTOR_BYTES);
+    super::descriptor::extract_freak_descriptors(pyramid, &points, &mut buf);
+
+    // 4. Populate the keyframe's FeatureStore.
+    for (i, point) in points.iter().enumerate() {
+        let start = i * super::descriptor::FREAK_DESCRIPTOR_BYTES;
+        let desc = &buf[start..start + super::descriptor::FREAK_DESCRIPTOR_BYTES];
+        keyframe.store.add(*point, desc)?;
+    }
+
     Ok(())
 }
 

--- a/crates/core/src/kpm/freak/hough.rs
+++ b/crates/core/src/kpm/freak/hough.rs
@@ -386,12 +386,6 @@ impl HoughSimilarityVoting {
     }
 }
 
-/// Stub types for M8 (to be implemented in Milestone 8).
-/// These are placeholders to allow M7 to compile independently.
-/// Placeholder for DoGScaleInvariantDetector from M8.
-#[derive(Clone, Debug)]
-pub struct DoGScaleInvariantDetector;
-
 /// Placeholder for Keyframe from M8.
 #[derive(Clone, Debug)]
 pub struct Keyframe {
@@ -443,7 +437,7 @@ pub struct HoughMatch {
 /// Stub for FindFeatures (M8 will implement).
 pub fn find_features(
     _keyframe: &mut Keyframe,
-    _detector: &DoGScaleInvariantDetector,
+    _detector: &super::detector::DoGScaleInvariantDetector,
     _pyramid: &super::gaussian_pyramid::GaussianScaleSpacePyramid,
 ) -> Result<(), KpmError> {
     arlog_i!("find_features: stub implementation (M8 pending)");

--- a/crates/core/src/kpm/freak/hough.rs
+++ b/crates/core/src/kpm/freak/hough.rs
@@ -392,10 +392,6 @@ impl HoughSimilarityVoting {
 #[derive(Clone, Debug)]
 pub struct DoGScaleInvariantDetector;
 
-/// Placeholder for GaussianScaleSpacePyramid from M8.
-#[derive(Clone, Debug)]
-pub struct GaussianScaleSpacePyramid;
-
 /// Placeholder for Keyframe from M8.
 #[derive(Clone, Debug)]
 pub struct Keyframe {
@@ -448,7 +444,7 @@ pub struct HoughMatch {
 pub fn find_features(
     _keyframe: &mut Keyframe,
     _detector: &DoGScaleInvariantDetector,
-    _pyramid: &GaussianScaleSpacePyramid,
+    _pyramid: &super::gaussian_pyramid::GaussianScaleSpacePyramid,
 ) -> Result<(), KpmError> {
     arlog_i!("find_features: stub implementation (M8 pending)");
     Ok(())

--- a/crates/core/src/kpm/freak/interpolate.rs
+++ b/crates/core/src/kpm/freak/interpolate.rs
@@ -1,0 +1,181 @@
+/*
+ *  interpolate.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Bilinear interpolation utilities and pyramid coordinate mappings.
+//!
+//! Ported from `WebARKitLib/lib/SRC/KPM/FreakMatcher/detectors/interpolate.h`
+//! and the point-mapping helpers in
+//! `WebARKitLib/lib/SRC/KPM/FreakMatcher/detectors/gaussian_scale_space_pyramid.h`.
+//!
+//! The OOB returns `0.0` behavior is a Rust safety improvement over the C++
+//! `ASSERT`s; callers that need strict in-bounds checks can pre-validate.
+
+use purecv::core::Matrix;
+
+/// Bilinear interpolation at `(x, y)` on a `Matrix<u8>` level.
+///
+/// Returns `0.0` if `(x, y)` requires a neighbor pixel outside the image
+/// (i.e. `x < 0`, `y < 0`, `x + 1 >= cols`, or `y + 1 >= rows`).
+///
+/// C equivalent: `vision::bilinear_interpolation<unsigned char, float>`.
+#[inline(always)]
+pub fn bilinear_interpolate_u8(image: &Matrix<u8>, x: f32, y: f32) -> f32 {
+    bilinear_interpolate(image.as_slice(), image.cols, image.rows, x, y)
+}
+
+/// Bilinear interpolation at `(x, y)` on a `Matrix<f32>` level.
+///
+/// Returns `0.0` if `(x, y)` is out of bounds.
+///
+/// C equivalent: `vision::bilinear_interpolation<float, float>`.
+#[inline(always)]
+pub fn bilinear_interpolate_f32(image: &Matrix<f32>, x: f32, y: f32) -> f32 {
+    let cols = image.cols;
+    let rows = image.rows;
+    let x0 = x.floor() as i32;
+    let y0 = y.floor() as i32;
+    if x0 < 0 || y0 < 0 {
+        return 0.0;
+    }
+    let x0u = x0 as usize;
+    let y0u = y0 as usize;
+    if x0u + 1 >= cols || y0u + 1 >= rows {
+        return 0.0;
+    }
+    let dx = x - x0 as f32;
+    let dy = y - y0 as f32;
+    let data = image.as_slice();
+    let p00 = data[y0u * cols + x0u];
+    let p01 = data[y0u * cols + x0u + 1];
+    let p10 = data[(y0u + 1) * cols + x0u];
+    let p11 = data[(y0u + 1) * cols + x0u + 1];
+    (1.0 - dy) * ((1.0 - dx) * p00 + dx * p01) + dy * ((1.0 - dx) * p10 + dx * p11)
+}
+
+/// Bilinear interpolation on a raw row-major `&[u8]` buffer.
+///
+/// Used by FREAK descriptor sampling where the buffer may be a slice of a
+/// `Matrix<u8>` level. Returns `0.0` if `(x, y)` is out of bounds.
+#[inline(always)]
+pub fn bilinear_interpolate(data: &[u8], width: usize, height: usize, x: f32, y: f32) -> f32 {
+    let x0 = x.floor() as i32;
+    let y0 = y.floor() as i32;
+    if x0 < 0 || y0 < 0 {
+        return 0.0;
+    }
+    let x0u = x0 as usize;
+    let y0u = y0 as usize;
+    if x0u + 1 >= width || y0u + 1 >= height {
+        return 0.0;
+    }
+    let dx = x - x0 as f32;
+    let dy = y - y0 as f32;
+    let p00 = data[y0u * width + x0u] as f32;
+    let p01 = data[y0u * width + x0u + 1] as f32;
+    let p10 = data[(y0u + 1) * width + x0u] as f32;
+    let p11 = data[(y0u + 1) * width + x0u + 1] as f32;
+    (1.0 - dy) * ((1.0 - dx) * p00 + dx * p01) + dy * ((1.0 - dx) * p10 + dx * p11)
+}
+
+/// Map an octave-local point back to fine-image coordinates.
+///
+/// `xp = x * 2^octave + 2^(octave-1) - 0.5`, same for `yp`.
+///
+/// C equivalent: `vision::bilinear_upsample_point` (3-arg variant).
+#[inline(always)]
+#[must_use]
+pub fn bilinear_upsample_point(x: f32, y: f32, octave: i32) -> (f32, f32) {
+    let a = 2f32.powi(octave - 1) - 0.5;
+    let b = (1i32 << octave) as f32;
+    (x * b + a, y * b + a)
+}
+
+/// Map a fine-image point down to octave-local coordinates.
+///
+/// `xp = x / 2^octave + 1 / (2 * 2^octave) - 0.5`, same for `yp`.
+///
+/// C equivalent: `vision::bilinear_downsample_point` (3-arg variant).
+#[inline(always)]
+#[must_use]
+pub fn bilinear_downsample_point(x: f32, y: f32, octave: i32) -> (f32, f32) {
+    let a = 1.0 / (1i32 << octave) as f32;
+    let b = 0.5 * a - 0.5;
+    (x * a + b, y * a + b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gradient_u8(rows: usize, cols: usize) -> Matrix<u8> {
+        let data: Vec<u8> = (0..rows * cols).map(|i| (i & 0xFF) as u8).collect();
+        Matrix::<u8>::from_vec(rows, cols, 1, data)
+    }
+
+    #[test]
+    fn test_bilinear_interpolate_at_integer_coords() {
+        let img = gradient_u8(8, 8);
+        // pixel(y=2, x=3) = 2*8 + 3 = 19.
+        let v = bilinear_interpolate_u8(&img, 3.0, 2.0);
+        assert!((v - 19.0).abs() < 1e-4, "expected 19.0, got {v}");
+    }
+
+    #[test]
+    fn test_bilinear_interpolate_out_of_bounds_returns_zero() {
+        let img = gradient_u8(4, 4);
+        assert_eq!(bilinear_interpolate_u8(&img, -0.1, 1.0), 0.0);
+        assert_eq!(bilinear_interpolate_u8(&img, 1.0, -0.1), 0.0);
+        // x = 3.0 needs neighbor at col 4 (OOB; cols = 4).
+        assert_eq!(bilinear_interpolate_u8(&img, 3.0, 1.0), 0.0);
+        assert_eq!(bilinear_interpolate_u8(&img, 1.0, 3.0), 0.0);
+    }
+
+    #[test]
+    fn test_bilinear_interpolate_midpoint() {
+        // 2x2 image: [10, 20; 30, 40]. At (0.5, 0.5) = average = 25.
+        let img = Matrix::<u8>::from_vec(2, 2, 1, vec![10, 20, 30, 40]);
+        let v = bilinear_interpolate_u8(&img, 0.5, 0.5);
+        assert!((v - 25.0).abs() < 1e-4, "expected 25.0, got {v}");
+    }
+
+    #[test]
+    fn test_bilinear_upsample_downsample_roundtrip() {
+        let (xp, yp) = bilinear_upsample_point(10.0, 20.0, 2);
+        let (x_back, y_back) = bilinear_downsample_point(xp, yp, 2);
+        assert!((x_back - 10.0).abs() < 1e-4);
+        assert!((y_back - 20.0).abs() < 1e-4);
+    }
+}

--- a/crates/core/src/kpm/freak/keyframe.rs
+++ b/crates/core/src/kpm/freak/keyframe.rs
@@ -1,0 +1,121 @@
+/*
+ *  keyframe.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Per-frame container holding FREAK descriptors and feature points.
+//!
+//! Mirrors C++ `vision::Keyframe<96>` from `keyframe.h`. The C++ template
+//! parameter `NUM_BYTES_PER_FEATURE = 96` matches our
+//! [`super::descriptor::FREAK_DESCRIPTOR_BYTES`].
+//!
+//! Keyframe is a **passive container**: it stores the per-frame results
+//! but does not run the detection / extraction pipeline itself. The
+//! orchestration that populates this container lives in
+//! [`super::hough::find_features`] (mirroring C++ `vision::FindFeatures`
+//! in `visual_database.h`).
+//!
+//! The C++ Keyframe also holds a `BinaryHierarchicalClustering` index for
+//! fast nearest-neighbour matching. That index is **not** built here —
+//! downstream KPM matching (already in main from M7) constructs its own
+//! index when needed.
+
+use crate::kpm::backend::KpmError;
+
+use super::descriptor::FREAK_DESCRIPTOR_BYTES;
+use super::matcher::FeatureStore;
+
+/// Per-frame container holding FREAK descriptors and feature points.
+///
+/// C equivalent: `vision::Keyframe<96>`.
+pub struct Keyframe {
+    /// FREAK descriptors and their associated feature points.
+    /// `bytes_per_feature` is fixed at [`FREAK_DESCRIPTOR_BYTES`] = 96.
+    pub store: FeatureStore,
+    /// Width of the source image.
+    pub width: i32,
+    /// Height of the source image.
+    pub height: i32,
+}
+
+impl Keyframe {
+    /// Create an empty Keyframe sized for `(width, height)` source images.
+    /// The internal [`FeatureStore`] is configured for 96-byte descriptors.
+    pub fn new(width: i32, height: i32) -> Result<Self, KpmError> {
+        Ok(Self {
+            store: FeatureStore::new(FREAK_DESCRIPTOR_BYTES)?,
+            width,
+            height,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kpm::freak::detector::DoGScaleInvariantDetector;
+    use crate::kpm::freak::gaussian_pyramid::GaussianScaleSpacePyramid;
+    use crate::kpm::freak::hough::find_features;
+    use purecv::core::Matrix;
+
+    fn load_grayscale(path: &str) -> Matrix<u8> {
+        let img = image::open(path).expect("load test image").to_luma8();
+        let (w, h) = img.dimensions();
+        Matrix::<u8>::from_vec(h as usize, w as usize, 1, img.into_raw())
+    }
+
+    #[test]
+    fn test_keyframe_new_stores_dimensions() {
+        let kf = Keyframe::new(640, 480).unwrap();
+        assert_eq!(kf.width, 640);
+        assert_eq!(kf.height, 480);
+        assert_eq!(kf.store.num_features(), 0);
+    }
+
+    #[test]
+    fn test_find_features_populates_keyframe() {
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let mut pyr = GaussianScaleSpacePyramid::new(3);
+        pyr.build(&img).unwrap();
+        let det = DoGScaleInvariantDetector::new(0.0, 10.0, 5000, true);
+
+        let mut kf = Keyframe::new(img.cols as i32, img.rows as i32).unwrap();
+        find_features(&mut kf, &pyr, &det).expect("find_features");
+        assert!(
+            kf.store.num_features() > 50,
+            "expected > 50 features on found.jpg, got {}",
+            kf.store.num_features()
+        );
+    }
+}

--- a/crates/core/src/kpm/freak/mod.rs
+++ b/crates/core/src/kpm/freak/mod.rs
@@ -41,11 +41,13 @@
 //! implementation and optimized for performance.
 
 pub mod clustering;
+pub mod descriptor;
 pub mod detector;
 pub mod gaussian_pyramid;
 pub mod homography;
 pub mod hough;
 pub mod interpolate;
+pub mod keyframe;
 pub mod matcher;
 pub mod math;
 pub mod orientation;
@@ -53,16 +55,18 @@ pub mod pyramid;
 
 // Public re-exports for convenience
 pub use clustering::{hamming_distance_96, BhcNode, BinaryHierarchicalClustering, KMedoids};
+pub use descriptor::{extract_freak_descriptors, FREAK_DESCRIPTOR_BYTES};
 pub use detector::{DoGFeaturePoint, DoGScaleInvariantDetector};
 pub use gaussian_pyramid::{num_octaves_for, GaussianPyramidError, GaussianScaleSpacePyramid};
 pub use hough::{
     find_features, find_hough_matches, find_hough_similarity, BinParams, FeaturePoint, HoughMatch,
-    HoughSimilarityVoting, Keyframe, Match,
+    HoughSimilarityVoting, Match,
 };
 pub use interpolate::{
     bilinear_downsample_point, bilinear_interpolate, bilinear_interpolate_f32,
     bilinear_interpolate_u8, bilinear_upsample_point,
 };
+pub use keyframe::Keyframe;
 pub use matcher::{FeatureMatcher, FeatureStore};
 pub use orientation::{compute_polar_gradient_image, OrientationAssignment};
 pub use pyramid::{Pyramid, PyramidError};

--- a/crates/core/src/kpm/freak/mod.rs
+++ b/crates/core/src/kpm/freak/mod.rs
@@ -45,6 +45,7 @@ pub mod homography;
 pub mod hough;
 pub mod matcher;
 pub mod math;
+pub mod pyramid;
 
 // Public re-exports for convenience
 pub use clustering::{hamming_distance_96, BhcNode, BinaryHierarchicalClustering, KMedoids};
@@ -53,3 +54,4 @@ pub use hough::{
     FeaturePoint, GaussianScaleSpacePyramid, HoughMatch, HoughSimilarityVoting, Keyframe, Match,
 };
 pub use matcher::{FeatureMatcher, FeatureStore};
+pub use pyramid::{Pyramid, PyramidError};

--- a/crates/core/src/kpm/freak/mod.rs
+++ b/crates/core/src/kpm/freak/mod.rs
@@ -41,17 +41,24 @@
 //! implementation and optimized for performance.
 
 pub mod clustering;
+pub mod gaussian_pyramid;
 pub mod homography;
 pub mod hough;
+pub mod interpolate;
 pub mod matcher;
 pub mod math;
 pub mod pyramid;
 
 // Public re-exports for convenience
 pub use clustering::{hamming_distance_96, BhcNode, BinaryHierarchicalClustering, KMedoids};
+pub use gaussian_pyramid::{num_octaves_for, GaussianPyramidError, GaussianScaleSpacePyramid};
 pub use hough::{
     find_features, find_hough_matches, find_hough_similarity, BinParams, DoGScaleInvariantDetector,
-    FeaturePoint, GaussianScaleSpacePyramid, HoughMatch, HoughSimilarityVoting, Keyframe, Match,
+    FeaturePoint, HoughMatch, HoughSimilarityVoting, Keyframe, Match,
+};
+pub use interpolate::{
+    bilinear_downsample_point, bilinear_interpolate, bilinear_interpolate_f32,
+    bilinear_interpolate_u8, bilinear_upsample_point,
 };
 pub use matcher::{FeatureMatcher, FeatureStore};
 pub use pyramid::{Pyramid, PyramidError};

--- a/crates/core/src/kpm/freak/mod.rs
+++ b/crates/core/src/kpm/freak/mod.rs
@@ -41,24 +41,28 @@
 //! implementation and optimized for performance.
 
 pub mod clustering;
+pub mod detector;
 pub mod gaussian_pyramid;
 pub mod homography;
 pub mod hough;
 pub mod interpolate;
 pub mod matcher;
 pub mod math;
+pub mod orientation;
 pub mod pyramid;
 
 // Public re-exports for convenience
 pub use clustering::{hamming_distance_96, BhcNode, BinaryHierarchicalClustering, KMedoids};
+pub use detector::{DoGFeaturePoint, DoGScaleInvariantDetector};
 pub use gaussian_pyramid::{num_octaves_for, GaussianPyramidError, GaussianScaleSpacePyramid};
 pub use hough::{
-    find_features, find_hough_matches, find_hough_similarity, BinParams, DoGScaleInvariantDetector,
-    FeaturePoint, HoughMatch, HoughSimilarityVoting, Keyframe, Match,
+    find_features, find_hough_matches, find_hough_similarity, BinParams, FeaturePoint, HoughMatch,
+    HoughSimilarityVoting, Keyframe, Match,
 };
 pub use interpolate::{
     bilinear_downsample_point, bilinear_interpolate, bilinear_interpolate_f32,
     bilinear_interpolate_u8, bilinear_upsample_point,
 };
 pub use matcher::{FeatureMatcher, FeatureStore};
+pub use orientation::{compute_polar_gradient_image, OrientationAssignment};
 pub use pyramid::{Pyramid, PyramidError};

--- a/crates/core/src/kpm/freak/orientation.rs
+++ b/crates/core/src/kpm/freak/orientation.rs
@@ -55,11 +55,14 @@ const ONE_OVER_2PI: f32 = 1.0 / TWO_PI;
 
 /// Smoothing kernel (Gaussian sigma=1).
 /// Matches the C++ inline kernel in
-/// `orientation_assignment.cpp::compute` (smoothing loop).
+/// `orientation_assignment.cpp::compute` (smoothing loop) byte-for-byte.
+/// The 15-digit literals are taken verbatim from the C++ source with the
+/// explicit `_f32` suffix so Rust rounds them directly to the same f32
+/// bit pattern as the C++ `float` literals.
 const SMOOTH_KERNEL: [f32; 3] = [
-    0.274_068_62, // 0.274068619061197
-    0.451_862_77, // 0.451862761877606
-    0.274_068_62, // 0.274068619061197
+    0.274_068_619_061_197_f32,
+    0.451_862_761_877_606_f32,
+    0.274_068_619_061_197_f32,
 ];
 
 /// Compute orientations at sub-pixel keypoint locations using a gradient
@@ -336,52 +339,62 @@ mod tests {
         Matrix::<f32>::from_vec(rows, cols, 1, data)
     }
 
+    /// Build a synthetic image with a *slightly diagonal* gradient:
+    /// `pixel = col + 0.5 * row`. This produces gradient `(dx=2, dy=1)`
+    /// in the interior — a single dominant direction that does **not**
+    /// straddle two adjacent histogram bins symmetrically.
+    ///
+    /// A purely horizontal gradient (`pixel = col`) makes `fbin = 18.0`
+    /// exactly, splitting votes 50/50 across bins 17 and 18. After
+    /// smoothing with a kernel that sums to exactly 1.0, those two bins
+    /// remain bit-for-bit equal, and the strict-greater-than peak check
+    /// (`h0 > hm1 && h0 > hp1`) fails at both. The diagonal offset
+    /// breaks that perfect symmetry and produces a clear single peak.
+    fn diagonal_gradient_level(rows: usize, cols: usize) -> Matrix<f32> {
+        let data: Vec<f32> = (0..rows * cols)
+            .map(|i| {
+                let row = i / cols;
+                let col = i % cols;
+                col as f32 + 0.5 * row as f32
+            })
+            .collect();
+        Matrix::<f32>::from_vec(rows, cols, 1, data)
+    }
+
     fn flat_level(rows: usize, cols: usize, value: f32) -> Matrix<f32> {
         Matrix::<f32>::from_vec(rows, cols, 1, vec![value; rows * cols])
     }
 
     #[test]
     fn test_orientation_assignment_horizontal_gradient() {
-        // Constant horizontal gradient: pixel = col. dy = 0 everywhere
-        // (top/bottom border rows have dy = 1 from one-sided diff against
-        // the next row, but in the constant-horizontal case the next row
-        // is identical so dy = 0 there too).
-        // dx = +1 in interior (col-1 to col+1 via central diff: 2), at
-        // the left/right border dx = 1 (one-sided diff). atan2(0, dx) = 0,
-        // angle channel = 0 + π = π.
+        // Slightly diagonal gradient: dx = 2, dy = 1 in the interior.
+        // atan2(dy=1, dx=2) ≈ 0.4636 rad. After the `+π` shift applied
+        // by ComputePolarGradients, the angle channel value is
+        // ≈ π + 0.4636 ≈ 3.6052 rad.
         //
-        // Histogram bin for angle = π: fbin = num_bins * π / (2π) = 18
-        // (out of 36 bins). After smoothing, peak is at bin 18.
+        // Histogram bin for that angle:
+        //   fbin = num_bins · angle / (2π) = 36 · 3.6052 / (2π) ≈ 20.66
+        // → bilinear update votes mostly into bin 20 (with some into 21).
+        // After smoothing, the peak sits near bin 20-21.
         //
-        // Final angle formula: angle = 2π · (fbin + 0.5 + num_bins) / num_bins mod 2π
-        //                            = 2π · (18 + 0.5 + 36) / 36 mod 2π
-        //                            = 2π · 54.5 / 36 mod 2π
-        //                            = (3π + π/18) mod 2π
-        //                            = π + π/18 ≈ 3.32 rad
-        // The "+0.5 + num_bins" bin-center offset in the C++ formula is
-        // calibrated to land at the dominant gradient direction.
+        // Final-angle formula maps the sub-bin peak back to an angle
+        // close to the gradient direction (≈ 3.6052 rad), accounting for
+        // the half-bin offset in the C++ formula.
         //
-        // For dx=+1, dy=0 (right-pointing gradient), the dominant
-        // perpendicular orientation for a vertical edge is π/2 — but the
-        // gradient direction itself is 0 (east). The histogram votes for
-        // the gradient direction, not the edge direction.
-
-        let level = horizontal_gradient_level(64, 64);
+        // We use a diagonal rather than a purely horizontal gradient
+        // because the latter produces fbin = 18.0 exactly (votes split
+        // 50/50 across bins 17 and 18); after smoothing with the kernel
+        // that sums to exactly 1.0, those two bins stay bit-for-bit
+        // equal and the strict-greater-than peak check fails at both.
+        let level = diagonal_gradient_level(64, 64);
         let gradient = compute_polar_gradient_image(&level);
         let oa = OrientationAssignment::new();
         let angles = oa.compute(&gradient, 32.0, 32.0, 1.0);
 
         assert!(!angles.is_empty(), "expected at least one orientation");
 
-        // The angle channel is dy.atan2(dx) + π. For a right-pointing
-        // gradient (dx>0, dy=0), that's 0 + π = π. The histogram peaks
-        // near bin num_bins/2 = 18. The final-angle formula maps bin 18
-        // back to an angle near π (with a half-bin offset).
-        //
-        // After the (fbin + 0.5 + num_bins) / num_bins · 2π modular
-        // formula, the dominant angle should be close to π + half-bin =
-        // π + (2π / num_bins) / 2 = π + π/36.
-        let expected = PI + PI / 36.0;
+        // Expected angle: roughly the gradient direction, π + atan2(1, 2).
+        let expected = PI + 0.5f32.atan2(1.0);
         let best = angles
             .iter()
             .copied()
@@ -393,7 +406,7 @@ mod tests {
             })
             .unwrap();
         assert!(
-            (best - expected).abs() < 0.2,
+            (best - expected).abs() < 0.3,
             "expected dominant orientation near {expected}, got {best} (all = {angles:?})"
         );
     }

--- a/crates/core/src/kpm/freak/orientation.rs
+++ b/crates/core/src/kpm/freak/orientation.rs
@@ -1,0 +1,454 @@
+/*
+ *  orientation.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Orientation assignment via gradient histograms.
+//!
+//! Ported from `WebARKitLib/.../detectors/orientation_assignment.{h,cpp}`
+//! and `detectors/gradients.{h,cpp}`. The public two-phase C++ API
+//! (`computeGradients` + `compute`) is simplified for M8-3 to a single
+//! [`OrientationAssignment::compute`] method taking a precomputed
+//! gradient image. The detector batches gradient computation across all
+//! pyramid levels via [`compute_polar_gradient_image`].
+//!
+//! M8-4 (FREAK descriptor) will share the gradient cache with this
+//! module and may promote the API to expose the cache directly.
+
+use purecv::core::Matrix;
+
+use std::f32::consts::PI;
+
+const TWO_PI: f32 = 2.0 * PI;
+const ONE_OVER_2PI: f32 = 1.0 / TWO_PI;
+
+/// Smoothing kernel (Gaussian sigma=1).
+/// Matches the C++ inline kernel in
+/// `orientation_assignment.cpp::compute` (smoothing loop).
+const SMOOTH_KERNEL: [f32; 3] = [
+    0.274_068_62, // 0.274068619061197
+    0.451_862_77, // 0.451862761877606
+    0.274_068_62, // 0.274068619061197
+];
+
+/// Compute orientations at sub-pixel keypoint locations using a gradient
+/// histogram over a Gaussian-weighted circular window around the keypoint.
+///
+/// C equivalent: `vision::OrientationAssignment`.
+///
+/// **Defaults**: matches the C++ `DoGScaleInvariantDetector::alloc(...)`
+/// call site (lines 126-134 of `DoG_scale_invariant_detector.cpp`):
+/// `num_bins = 36`, `gaussian_expansion_factor = 3.0`,
+/// `support_region_expansion_factor = 1.5`, `num_smoothing_iterations = 5`,
+/// `peak_threshold = 0.8`.
+pub struct OrientationAssignment {
+    num_bins: usize,
+    gaussian_expansion_factor: f32,
+    support_region_expansion_factor: f32,
+    num_smoothing_iterations: usize,
+    peak_threshold: f32,
+}
+
+impl Default for OrientationAssignment {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OrientationAssignment {
+    /// Construct with hardcoded FREAK pipeline defaults.
+    ///
+    /// M8-4 will promote these to constructor parameters.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            num_bins: 36,
+            gaussian_expansion_factor: 3.0,
+            support_region_expansion_factor: 1.5,
+            num_smoothing_iterations: 5,
+            peak_threshold: 0.8,
+        }
+    }
+
+    /// Number of histogram bins.
+    #[must_use]
+    pub fn num_bins(&self) -> usize {
+        self.num_bins
+    }
+
+    /// Compute dominant orientations (radians, in `[0, 2π)`) for the
+    /// keypoint at `(x, y)` with characteristic `sigma`, using the
+    /// precomputed `gradient` image (`channels = 2`, interleaved as
+    /// `(angle, magnitude)` — matches C++ `ComputePolarGradients`).
+    ///
+    /// Returns one orientation per histogram peak that is **both** a
+    /// strict local maximum **and** above `peak_threshold × max_peak`.
+    /// Each peak is sub-pixel-refined via a parabolic fit to its three
+    /// neighboring bins (matches C++ `Quadratic3Points`).
+    ///
+    /// Returns an empty `Vec` if `(x, y)` is outside the image or the
+    /// histogram has no positive peak.
+    #[must_use]
+    pub fn compute(&self, gradient: &Matrix<f32>, x: f32, y: f32, sigma: f32) -> Vec<f32> {
+        debug_assert_eq!(
+            gradient.channels, 2,
+            "gradient image must have 2 channels (angle, magnitude)"
+        );
+
+        let width = gradient.cols;
+        let height = gradient.rows;
+        let data = gradient.as_slice();
+
+        // Reject negative coordinates at the float level. The C++ casts
+        // `(int)(x + 0.5f)` rounds -1.0 to 0 (truncation toward zero), so
+        // checking only the integer bounds would let small negative values
+        // slip through. Real callers (DoG detector) always pass
+        // non-negative coordinates; this is a Rust safety guard.
+        if x < 0.0 || y < 0.0 {
+            return Vec::new();
+        }
+        let xi = (x + 0.5) as i32;
+        let yi = (y + 0.5) as i32;
+        if (xi as usize) >= width || (yi as usize) >= height {
+            return Vec::new();
+        }
+
+        // Gaussian window: σ_window = max(1, gaussian_expansion_factor · sigma).
+        let gw_sigma = (self.gaussian_expansion_factor * sigma).max(1.0);
+        let gw_scale = -1.0 / (2.0 * gw_sigma * gw_sigma);
+
+        // Circular support radius.
+        let radius = self.support_region_expansion_factor * gw_sigma;
+        let radius2 = (radius * radius).ceil();
+        let radius_int = (radius + 0.5) as i32;
+
+        // Clip the box to image bounds.
+        let x0 = (xi - radius_int).max(0) as usize;
+        let x1 = (xi + radius_int).min(width as i32 - 1) as usize;
+        let y0 = (yi - radius_int).max(0) as usize;
+        let y1 = (yi + radius_int).min(height as i32 - 1) as usize;
+
+        // Build the orientation histogram.
+        let mut hist = vec![0.0f32; self.num_bins];
+        for yp in y0..=y1 {
+            let dy = yp as f32 - y;
+            let dy2 = dy * dy;
+            let row_base = yp * width * 2;
+            for xp in x0..=x1 {
+                let dx = xp as f32 - x;
+                let r2 = dx * dx + dy2;
+                if r2 > radius2 {
+                    continue;
+                }
+                let idx = row_base + xp * 2;
+                let angle = data[idx];
+                let mag = data[idx + 1];
+
+                // Gaussian weight.
+                let w = (r2 * gw_scale).exp();
+
+                // Sub-bin location.
+                let fbin = self.num_bins as f32 * angle * ONE_OVER_2PI;
+                bilinear_histogram_update(&mut hist, fbin, w * mag, self.num_bins);
+            }
+        }
+
+        // Smooth circularly with the C++ kernel.
+        let mut buf = vec![0.0f32; self.num_bins];
+        for _ in 0..self.num_smoothing_iterations {
+            smooth_orientation_histogram_circular(&mut buf, &hist, &SMOOTH_KERNEL);
+            hist.copy_from_slice(&buf);
+        }
+
+        // Find peak height.
+        let max_height = hist.iter().copied().fold(0.0f32, f32::max);
+        if max_height <= 0.0 {
+            return Vec::new();
+        }
+
+        // Find peaks: strict local max above threshold; sub-pixel-refine
+        // via parabolic fit.
+        let mut angles: Vec<f32> = Vec::new();
+        let threshold = self.peak_threshold * max_height;
+        for i in 0..self.num_bins {
+            let h0 = hist[i];
+            if h0 <= threshold {
+                continue;
+            }
+            let hm1 = hist[(i + self.num_bins - 1) % self.num_bins];
+            let hp1 = hist[(i + 1) % self.num_bins];
+            if !(h0 > hm1 && h0 > hp1) {
+                continue;
+            }
+
+            // Parabolic fit through (i-1, hm1), (i, h0), (i+1, hp1).
+            // Critical point: x* = i + 0.5 · (hm1 - hp1) / (hm1 - 2·h0 + hp1).
+            let denom = hm1 - 2.0 * h0 + hp1;
+            let fbin = if denom.abs() > f32::EPSILON {
+                i as f32 + 0.5 * (hm1 - hp1) / denom
+            } else {
+                i as f32
+            };
+
+            let nb = self.num_bins as f32;
+            let angle = (TWO_PI * (fbin + 0.5 + nb) / nb) % TWO_PI;
+            angles.push(angle);
+        }
+
+        angles
+    }
+}
+
+/// Vote `magnitude` into a circular `num_bins` histogram at fractional
+/// position `fbin`, splitting between two adjacent bins by linear weight.
+///
+/// C equivalent: `vision::bilinear_histogram_update` (inline in
+/// `orientation_assignment.h`).
+#[inline]
+fn bilinear_histogram_update(hist: &mut [f32], fbin: f32, magnitude: f32, num_bins: usize) {
+    let bin = (fbin - 0.5).floor() as i32;
+    let w2 = fbin - bin as f32 - 0.5;
+    let w1 = 1.0 - w2;
+    let nb = num_bins as i32;
+    let b1 = ((bin % nb + nb) % nb) as usize;
+    let b2 = (((bin + 1) % nb + nb) % nb) as usize;
+    hist[b1] += w1 * magnitude;
+    hist[b2] += w2 * magnitude;
+}
+
+/// One pass of a 3-tap circular smoothing convolution.
+///
+/// C equivalent: `vision::SmoothOrientationHistogram`.
+#[inline]
+fn smooth_orientation_histogram_circular(dst: &mut [f32], src: &[f32], kernel: &[f32; 3]) {
+    let n = src.len();
+    debug_assert_eq!(dst.len(), n);
+    if n < 2 {
+        dst.copy_from_slice(src);
+        return;
+    }
+    let first = src[0];
+    let mut prev = src[n - 1];
+    for i in 0..(n - 1) {
+        let cur = src[i];
+        dst[i] = kernel[0] * prev + kernel[1] * cur + kernel[2] * src[i + 1];
+        prev = cur;
+    }
+    dst[n - 1] = kernel[0] * prev + kernel[1] * src[n - 1] + kernel[2] * first;
+}
+
+/// Build a 2-channel `(angle, magnitude)` polar gradient image from a
+/// pyramid level. Channel layout matches C++ `ComputePolarGradients`:
+///
+/// - Channel 0 = `atan2(dy, dx) + π` (shifted to `[0, 2π]`)
+/// - Channel 1 = `sqrt(dx² + dy²)`
+///
+/// Borders use one-sided differences; interior uses central differences.
+///
+/// C equivalent: `vision::ComputePolarGradients`.
+#[must_use]
+pub fn compute_polar_gradient_image(level: &Matrix<f32>) -> Matrix<f32> {
+    debug_assert_eq!(level.channels, 1, "input level must be single-channel");
+    let w = level.cols;
+    let h = level.rows;
+    let src = level.as_slice();
+
+    let mut dst = vec![0.0f32; w * h * 2];
+
+    // Helper closures for one-sided / central differences.
+    let dx_at = |row: usize, col: usize| -> f32 {
+        if col == 0 {
+            src[row * w + 1] - src[row * w]
+        } else if col == w - 1 {
+            src[row * w + col] - src[row * w + col - 1]
+        } else {
+            src[row * w + col + 1] - src[row * w + col - 1]
+        }
+    };
+    let dy_at = |row: usize, col: usize| -> f32 {
+        if row == 0 {
+            src[w + col] - src[col]
+        } else if row == h - 1 {
+            src[(h - 1) * w + col] - src[(h - 2) * w + col]
+        } else {
+            src[(row + 1) * w + col] - src[(row - 1) * w + col]
+        }
+    };
+
+    for row in 0..h {
+        for col in 0..w {
+            let dx = dx_at(row, col);
+            let dy = dy_at(row, col);
+            let angle = dy.atan2(dx) + PI;
+            let mag = (dx * dx + dy * dy).sqrt();
+            let idx = (row * w + col) * 2;
+            dst[idx] = angle;
+            dst[idx + 1] = mag;
+        }
+    }
+
+    Matrix::<f32>::from_vec(h, w, 2, dst)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic constant horizontal-gradient image: `pixel = col`.
+    /// dx is constant; dy is 0. atan2(0, dx>0) = 0 → angle channel ≈ π
+    /// (after the +π shift). That maps to bin `num_bins / 2`; the
+    /// dominant orientation in our normalized convention is π/2 +
+    /// half-bin offset due to the `(fbin + 0.5)` shift in the final
+    /// angle formula.
+    fn horizontal_gradient_level(rows: usize, cols: usize) -> Matrix<f32> {
+        let data: Vec<f32> = (0..rows * cols).map(|i| (i % cols) as f32).collect();
+        Matrix::<f32>::from_vec(rows, cols, 1, data)
+    }
+
+    fn flat_level(rows: usize, cols: usize, value: f32) -> Matrix<f32> {
+        Matrix::<f32>::from_vec(rows, cols, 1, vec![value; rows * cols])
+    }
+
+    #[test]
+    fn test_orientation_assignment_horizontal_gradient() {
+        // Constant horizontal gradient: pixel = col. dy = 0 everywhere
+        // (top/bottom border rows have dy = 1 from one-sided diff against
+        // the next row, but in the constant-horizontal case the next row
+        // is identical so dy = 0 there too).
+        // dx = +1 in interior (col-1 to col+1 via central diff: 2), at
+        // the left/right border dx = 1 (one-sided diff). atan2(0, dx) = 0,
+        // angle channel = 0 + π = π.
+        //
+        // Histogram bin for angle = π: fbin = num_bins * π / (2π) = 18
+        // (out of 36 bins). After smoothing, peak is at bin 18.
+        //
+        // Final angle formula: angle = 2π · (fbin + 0.5 + num_bins) / num_bins mod 2π
+        //                            = 2π · (18 + 0.5 + 36) / 36 mod 2π
+        //                            = 2π · 54.5 / 36 mod 2π
+        //                            = (3π + π/18) mod 2π
+        //                            = π + π/18 ≈ 3.32 rad
+        // The "+0.5 + num_bins" bin-center offset in the C++ formula is
+        // calibrated to land at the dominant gradient direction.
+        //
+        // For dx=+1, dy=0 (right-pointing gradient), the dominant
+        // perpendicular orientation for a vertical edge is π/2 — but the
+        // gradient direction itself is 0 (east). The histogram votes for
+        // the gradient direction, not the edge direction.
+
+        let level = horizontal_gradient_level(64, 64);
+        let gradient = compute_polar_gradient_image(&level);
+        let oa = OrientationAssignment::new();
+        let angles = oa.compute(&gradient, 32.0, 32.0, 1.0);
+
+        assert!(!angles.is_empty(), "expected at least one orientation");
+
+        // The angle channel is dy.atan2(dx) + π. For a right-pointing
+        // gradient (dx>0, dy=0), that's 0 + π = π. The histogram peaks
+        // near bin num_bins/2 = 18. The final-angle formula maps bin 18
+        // back to an angle near π (with a half-bin offset).
+        //
+        // After the (fbin + 0.5 + num_bins) / num_bins · 2π modular
+        // formula, the dominant angle should be close to π + half-bin =
+        // π + (2π / num_bins) / 2 = π + π/36.
+        let expected = PI + PI / 36.0;
+        let best = angles
+            .iter()
+            .copied()
+            .min_by(|a, b| {
+                (a - expected)
+                    .abs()
+                    .partial_cmp(&(b - expected).abs())
+                    .unwrap()
+            })
+            .unwrap();
+        assert!(
+            (best - expected).abs() < 0.2,
+            "expected dominant orientation near {expected}, got {best} (all = {angles:?})"
+        );
+    }
+
+    #[test]
+    fn test_orientation_assignment_empty_when_no_gradients() {
+        // Flat image → zero gradients everywhere → empty result.
+        let level = flat_level(32, 32, 128.0);
+        let gradient = compute_polar_gradient_image(&level);
+        let oa = OrientationAssignment::new();
+        let angles = oa.compute(&gradient, 16.0, 16.0, 1.0);
+        assert!(
+            angles.is_empty(),
+            "flat image should produce zero orientations, got {angles:?}"
+        );
+    }
+
+    #[test]
+    fn test_orientation_assignment_out_of_bounds_returns_empty() {
+        let level = horizontal_gradient_level(16, 16);
+        let gradient = compute_polar_gradient_image(&level);
+        let oa = OrientationAssignment::new();
+        assert!(oa.compute(&gradient, -1.0, 8.0, 1.0).is_empty());
+        assert!(oa.compute(&gradient, 8.0, -1.0, 1.0).is_empty());
+        assert!(oa.compute(&gradient, 16.0, 8.0, 1.0).is_empty());
+        assert!(oa.compute(&gradient, 8.0, 16.0, 1.0).is_empty());
+    }
+
+    #[test]
+    fn test_polar_gradient_horizontal_image() {
+        // pixel = col, so dx is constant. atan2(0, +dx) + π = π
+        // for interior cols; magnitude is the difference.
+        let level = horizontal_gradient_level(8, 8);
+        let g = compute_polar_gradient_image(&level);
+        // Pick an interior pixel.
+        let row = 4usize;
+        let col = 4usize;
+        let idx = (row * 8 + col) * 2;
+        let data = g.as_slice();
+        let angle = data[idx];
+        let mag = data[idx + 1];
+        // Interior central diff: dx = col+1 - (col-1) = 2, dy = 0.
+        // atan2(0, 2) = 0; angle channel = 0 + π = π.
+        assert!((angle - PI).abs() < 1e-4, "expected π, got {angle}");
+        // magnitude = sqrt(4) = 2.
+        assert!((mag - 2.0).abs() < 1e-4, "expected 2.0, got {mag}");
+    }
+
+    #[test]
+    fn test_polar_gradient_output_shape() {
+        let level = horizontal_gradient_level(16, 24);
+        let g = compute_polar_gradient_image(&level);
+        assert_eq!(g.rows, 16);
+        assert_eq!(g.cols, 24);
+        assert_eq!(g.channels, 2);
+        assert_eq!(g.as_slice().len(), 16 * 24 * 2);
+    }
+}

--- a/crates/core/src/kpm/freak/orientation.rs
+++ b/crates/core/src/kpm/freak/orientation.rs
@@ -59,6 +59,15 @@ const ONE_OVER_2PI: f32 = 1.0 / TWO_PI;
 /// The 15-digit literals are taken verbatim from the C++ source with the
 /// explicit `_f32` suffix so Rust rounds them directly to the same f32
 /// bit pattern as the C++ `float` literals.
+///
+/// `clippy::excessive_precision` would suggest truncating to ~8 digits
+/// (the limit of f32 precision). We deliberately keep the full 15-digit
+/// form for source-level fidelity with the C++ port — a reviewer
+/// cross-referencing the C++ can compare digit-for-digit without doing
+/// the rounding mentally. Rust's f32 literal parser handles the trailing
+/// digits identically to clipping them, so there is no behavioral
+/// difference; this is purely about source readability.
+#[allow(clippy::excessive_precision)]
 const SMOOTH_KERNEL: [f32; 3] = [
     0.274_068_619_061_197_f32,
     0.451_862_761_877_606_f32,

--- a/crates/core/src/kpm/freak/pyramid.rs
+++ b/crates/core/src/kpm/freak/pyramid.rs
@@ -1,0 +1,347 @@
+/*
+ *  pyramid.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Image pyramid built by repeated box-filter downsampling.
+//!
+//! Ported from `WebARKitLib/lib/SRC/KPM/FreakMatcher/detectors/pyramid.{h,cpp}`
+//! (`BoxFilterPyramid8u` / `BoxFilterDecimate`).
+//!
+//! The pyramid produces successively half-sized levels via a 2x2 box-filter
+//! average with rounding: `(p0 + p1 + p2 + p3 + 2) >> 2`. Output is
+//! byte-identical to the C++ baseline.
+//!
+//! C equivalent: `vision::BoxFilterPyramid8u`
+
+use crate::{arlog_e, arlog_w};
+use purecv::core::Matrix;
+
+/// Errors that can occur while building a [`Pyramid`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum PyramidError {
+    /// Input image had zero rows or zero columns.
+    EmptyImage,
+    /// `scale_factor` is not supported. Currently only `2.0` is accepted
+    /// (matches the C++ `BoxFilterPyramid8u` behavior).
+    InvalidScaleFactor(f32),
+    /// `num_levels` was 0 — a pyramid must have at least one level.
+    ZeroLevels,
+    /// Downsampling at this level would produce a 0-sized image.
+    /// Returned when the input image is too small for the requested
+    /// number of levels.
+    LevelTooSmall { level: usize },
+}
+
+impl std::fmt::Display for PyramidError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyImage => write!(f, "input image is empty (0 rows or 0 cols)"),
+            Self::InvalidScaleFactor(s) => {
+                write!(
+                    f,
+                    "scale_factor {s} is not supported (only 2.0 is accepted)"
+                )
+            }
+            Self::ZeroLevels => write!(f, "num_levels must be >= 1"),
+            Self::LevelTooSmall { level } => {
+                write!(f, "downsampled image at level {level} would be 0-sized")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PyramidError {}
+
+/// Image pyramid built from a single grayscale input via repeated 2x2
+/// box-filter downsampling.
+///
+/// Level 0 is a copy of the input. Each subsequent level has dimensions
+/// `ceil((prev.rows - 1) / 2) x ceil((prev.cols - 1) / 2)` to match the
+/// C++ `BoxFilterPyramid8u::init()` formula.
+#[derive(Debug, Clone)]
+pub struct Pyramid {
+    /// Levels from finest (index 0 = input copy) to coarsest.
+    pub levels: Vec<Matrix<u8>>,
+    /// Downsample factor between successive levels. Currently must be `2.0`.
+    pub scale_factor: f32,
+    /// Number of levels requested at construction.
+    num_levels: usize,
+}
+
+impl Pyramid {
+    /// Create an empty pyramid configured for `num_levels` levels, each
+    /// `scale_factor` smaller than the previous. Levels are populated by
+    /// [`Pyramid::build`].
+    ///
+    /// Only `scale_factor == 2.0` is currently supported; any other value
+    /// causes [`Pyramid::build`] to return
+    /// [`PyramidError::InvalidScaleFactor`].
+    #[must_use]
+    pub fn new(num_levels: usize, scale_factor: f32) -> Self {
+        Self {
+            levels: Vec::with_capacity(num_levels),
+            scale_factor,
+            num_levels,
+        }
+    }
+
+    /// Number of populated levels (i.e. levels successfully built so far).
+    #[must_use]
+    pub fn num_levels(&self) -> usize {
+        self.levels.len()
+    }
+
+    /// Borrow level `i`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i >= self.num_levels()`.
+    #[must_use]
+    pub fn level(&self, i: usize) -> &Matrix<u8> {
+        &self.levels[i]
+    }
+
+    /// Populate `self.levels` from `image`.
+    ///
+    /// - Level 0 is a deep copy of the input.
+    /// - Level k > 0 is `downsample(level k-1)`.
+    ///
+    /// Calling `build` again on the same pyramid clears prior state first
+    /// (idempotent).
+    pub fn build(&mut self, image: &Matrix<u8>) -> Result<(), PyramidError> {
+        if self.num_levels == 0 {
+            arlog_e!("Pyramid::build: num_levels is 0");
+            return Err(PyramidError::ZeroLevels);
+        }
+        if (self.scale_factor - 2.0).abs() > f32::EPSILON {
+            arlog_e!(
+                "Pyramid::build: scale_factor {} not supported (only 2.0)",
+                self.scale_factor
+            );
+            return Err(PyramidError::InvalidScaleFactor(self.scale_factor));
+        }
+        if image.rows == 0 || image.cols == 0 {
+            arlog_e!("Pyramid::build: input image is empty");
+            return Err(PyramidError::EmptyImage);
+        }
+        if image.channels != 1 {
+            arlog_w!(
+                "Pyramid::build: input has {} channels; only the first channel is read",
+                image.channels
+            );
+        }
+
+        // Idempotent: clear any previous build state.
+        self.levels.clear();
+
+        // Level 0 = deep copy of the input.
+        self.levels.push(image.clone());
+
+        // Levels 1..num_levels.
+        for k in 1..self.num_levels {
+            let prev = &self.levels[k - 1];
+            let new_h = (prev.rows.saturating_sub(1) as f32 / 2.0).ceil() as usize;
+            let new_w = (prev.cols.saturating_sub(1) as f32 / 2.0).ceil() as usize;
+            if new_h == 0 || new_w == 0 {
+                arlog_e!("Pyramid::build: level {k} would be 0-sized");
+                return Err(PyramidError::LevelTooSmall { level: k });
+            }
+            self.levels.push(downsample(prev));
+        }
+
+        Ok(())
+    }
+}
+
+/// 2x2 box-filter downsample, byte-identical to C++ `BoxFilterDecimate`.
+///
+/// Output dimensions: `new_h = ceil((src.rows - 1) / 2)`,
+/// `new_w = ceil((src.cols - 1) / 2)`.
+///
+/// Per output pixel, sum the four corresponding source pixels (as `u16`
+/// to avoid overflow), add 2 for rounding, then shift right by 2. This
+/// is the combined effect of `HorizontalBoxFilterDecimate` plus
+/// `VerticalBoxFilter` from `pyramid-inline.h`.
+fn downsample(src: &Matrix<u8>) -> Matrix<u8> {
+    let new_h = (src.rows.saturating_sub(1) as f32 / 2.0).ceil() as usize;
+    let new_w = (src.cols.saturating_sub(1) as f32 / 2.0).ceil() as usize;
+
+    let src_data = src.as_slice();
+    let src_cols = src.cols;
+
+    let mut dst_data = Vec::<u8>::with_capacity(new_h * new_w);
+
+    for out_row in 0..new_h {
+        let r0 = (out_row * 2) * src_cols;
+        let r1 = r0 + src_cols;
+        let row0 = &src_data[r0..r0 + src_cols];
+        let row1 = &src_data[r1..r1 + src_cols];
+
+        for out_col in 0..new_w {
+            let c = out_col * 2;
+            // u16 promotion prevents u8 wrap; max sum = 4*255 + 2 = 1022.
+            let sum: u16 =
+                row0[c] as u16 + row0[c + 1] as u16 + row1[c] as u16 + row1[c + 1] as u16 + 2;
+            dst_data.push((sum >> 2) as u8);
+        }
+    }
+
+    Matrix::<u8>::from_vec(new_h, new_w, 1, dst_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic gradient image: pixel(r, c) = (r * cols + c) as u8.
+    fn gradient(rows: usize, cols: usize) -> Matrix<u8> {
+        let data: Vec<u8> = (0..rows * cols).map(|i| (i & 0xFF) as u8).collect();
+        Matrix::<u8>::from_vec(rows, cols, 1, data)
+    }
+
+    // ── User-specified tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_pyramid_level_count() {
+        let img = gradient(64, 64);
+        let mut p = Pyramid::new(4, 2.0);
+        p.build(&img).expect("build should succeed");
+        assert_eq!(p.num_levels(), 4);
+    }
+
+    #[test]
+    fn test_pyramid_level_dimensions_shrink() {
+        let img = gradient(64, 64);
+        let mut p = Pyramid::new(3, 2.0);
+        p.build(&img).unwrap();
+
+        // Level 0: same size as input.
+        assert_eq!(p.level(0).rows, 64);
+        assert_eq!(p.level(0).cols, 64);
+        // Level 1: ceil((64 - 1) / 2) = 32.
+        assert_eq!(p.level(1).rows, 32);
+        assert_eq!(p.level(1).cols, 32);
+        // Level 2: ceil((32 - 1) / 2) = 16.
+        assert_eq!(p.level(2).rows, 16);
+        assert_eq!(p.level(2).cols, 16);
+    }
+
+    #[test]
+    fn test_pyramid_pixel_values_in_range() {
+        let img = gradient(32, 32);
+        let mut p = Pyramid::new(3, 2.0);
+        p.build(&img).unwrap();
+        // u8 is inherently in [0, 255]; verify every level is fully
+        // populated with the right number of pixels.
+        for k in 0..p.num_levels() {
+            let lvl = p.level(k);
+            assert!(lvl.rows > 0 && lvl.cols > 0);
+            assert_eq!(lvl.as_slice().len(), lvl.rows * lvl.cols);
+        }
+    }
+
+    // ── Hardening tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_pyramid_box_filter_known_values() {
+        // 4x4 input where the exact output can be hand-computed.
+        // Input:
+        //   [ 10,  20,  30,  40]
+        //   [ 50,  60,  70,  80]
+        //   [ 90, 100, 110, 120]
+        //   [130, 140, 150, 160]
+        //
+        // Output (ceil(3/2) = 2 x 2):
+        //   dst[0,0] = (10  + 20  + 50  + 60  + 2) >> 2 = 142 >> 2 = 35
+        //   dst[0,1] = (30  + 40  + 70  + 80  + 2) >> 2 = 222 >> 2 = 55
+        //   dst[1,0] = (90  + 100 + 130 + 140 + 2) >> 2 = 462 >> 2 = 115
+        //   dst[1,1] = (110 + 120 + 150 + 160 + 2) >> 2 = 542 >> 2 = 135
+        let data = vec![
+            10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160,
+        ];
+        let src = Matrix::<u8>::from_vec(4, 4, 1, data);
+        let mut p = Pyramid::new(2, 2.0);
+        p.build(&src).unwrap();
+        assert_eq!(p.level(1).as_slice(), &[35, 55, 115, 135]);
+    }
+
+    #[test]
+    fn test_pyramid_build_is_idempotent() {
+        let img1 = gradient(32, 32);
+        let img2 = gradient(16, 16);
+        let mut p = Pyramid::new(2, 2.0);
+        p.build(&img1).unwrap();
+        p.build(&img2).unwrap();
+        // Levels reflect img2, not img1.
+        assert_eq!(p.num_levels(), 2);
+        assert_eq!(p.level(0).rows, 16);
+        assert_eq!(p.level(0).cols, 16);
+    }
+
+    #[test]
+    fn test_pyramid_empty_image_returns_error() {
+        let img = Matrix::<u8>::zeros(0, 0, 1);
+        let mut p = Pyramid::new(2, 2.0);
+        assert_eq!(p.build(&img), Err(PyramidError::EmptyImage));
+    }
+
+    #[test]
+    fn test_pyramid_invalid_scale_returns_error() {
+        let img = gradient(16, 16);
+        let mut p = Pyramid::new(2, 1.5);
+        assert!(matches!(
+            p.build(&img),
+            Err(PyramidError::InvalidScaleFactor(_))
+        ));
+    }
+
+    #[test]
+    fn test_pyramid_zero_levels_returns_error() {
+        let img = gradient(16, 16);
+        let mut p = Pyramid::new(0, 2.0);
+        assert_eq!(p.build(&img), Err(PyramidError::ZeroLevels));
+    }
+
+    #[test]
+    fn test_pyramid_level_too_small_returns_error() {
+        // 4x4 image: ceil(3/2)=2, ceil(1/2)=1, ceil(0/2)=0 -> fails at level 3.
+        let img = gradient(4, 4);
+        let mut p = Pyramid::new(5, 2.0);
+        assert!(matches!(
+            p.build(&img),
+            Err(PyramidError::LevelTooSmall { .. })
+        ));
+    }
+}

--- a/crates/core/src/kpm/kpm_c_api.cpp
+++ b/crates/core/src/kpm/kpm_c_api.cpp
@@ -59,6 +59,7 @@
 #include <detectors/DoG_scale_invariant_detector.h>
 #include <detectors/gaussian_scale_space_pyramid.h>
 #include <framework/image.h>
+#include <matchers/freak.h>
 #include <Eigen/Core>
 #include <unsupported/Eigen/MatrixFunctions>
 
@@ -506,6 +507,72 @@ int webarkit_cpp_fast_random(int* seed) {
 
 void webarkit_cpp_array_shuffle(int* v, int pop_size, int sample_size, int* seed) {
     vision::ArrayShuffle<int>(v, pop_size, sample_size, *seed);
+}
+
+/* ---- Dual-mode validation: FREAKExtractor bridge (Milestone 8, #129) ---- */
+
+int webarkit_cpp_extract_freak_descriptors(
+    const unsigned char* src,
+    int src_w,
+    int src_h,
+    int num_octaves,
+    const float* keypoints,
+    int num_keypoints,
+    unsigned char* dst_out,
+    int dst_capacity_bytes) {
+
+    if (!src || (!keypoints && num_keypoints > 0) || !dst_out
+        || src_w < 5 || src_h < 5 || num_octaves < 1 || num_keypoints < 0) {
+        return 1;
+    }
+    // Verify all octaves fit the binomial filter (M8-2 invariant: each octave >= 5x5).
+    {
+        int w = src_w;
+        int h = src_h;
+        for (int o = 0; o < num_octaves; ++o) {
+            if (w < 5 || h < 5) {
+                return 2;
+            }
+            w >>= 1;
+            h >>= 1;
+        }
+    }
+    if (dst_capacity_bytes < num_keypoints * 96) {
+        return 3;
+    }
+
+    try {
+        vision::Image image(
+            const_cast<unsigned char*>(src), vision::IMAGE_UINT8,
+            src_w, src_h, src_w /* step */, 1);
+
+        vision::BinomialPyramid32f pyr;
+        pyr.alloc(src_w, src_h, num_octaves);
+        pyr.build(image);
+
+        std::vector<vision::FeaturePoint> points;
+        points.reserve(static_cast<size_t>(num_keypoints));
+        for (int i = 0; i < num_keypoints; ++i) {
+            const float* k = &keypoints[i * 4];
+            // maxima is unused by FREAK extraction; pass true.
+            points.emplace_back(k[0], k[1], k[2], k[3], /*maxima=*/true);
+        }
+
+        vision::BinaryFeatureStore store;
+        // store.setNumBytesPerFeature(96) is called inside extract().
+        vision::FREAKExtractor extractor;
+        extractor.extract(store, &pyr, points);
+
+        if (num_keypoints > 0) {
+            std::memcpy(
+                dst_out,
+                store.feature(0),
+                static_cast<size_t>(num_keypoints) * 96);
+        }
+        return 0;
+    } catch (...) {
+        return 4;
+    }
 }
 
 /* ---- Dual-mode validation: DoGScaleInvariantDetector bridge (Milestone 8, #128) ---- */

--- a/crates/core/src/kpm/kpm_c_api.cpp
+++ b/crates/core/src/kpm/kpm_c_api.cpp
@@ -56,6 +56,7 @@
 #include <math/linear_solvers.h>
 #include <math/rand.h>
 #include <homography_estimation/robust_homography.h>
+#include <detectors/DoG_scale_invariant_detector.h>
 #include <detectors/gaussian_scale_space_pyramid.h>
 #include <framework/image.h>
 #include <Eigen/Core>
@@ -505,6 +506,62 @@ int webarkit_cpp_fast_random(int* seed) {
 
 void webarkit_cpp_array_shuffle(int* v, int pop_size, int sample_size, int* seed) {
     vision::ArrayShuffle<int>(v, pop_size, sample_size, *seed);
+}
+
+/* ---- Dual-mode validation: DoGScaleInvariantDetector bridge (Milestone 8, #128) ---- */
+
+int webarkit_cpp_dog_detect_count(
+    const unsigned char* src,
+    int src_w,
+    int src_h,
+    int num_octaves,
+    float laplacian_threshold,
+    float edge_threshold,
+    int max_num_feature_points,
+    int find_orientation,
+    int* count_out) {
+
+    if (!src || !count_out || src_w < 5 || src_h < 5 || num_octaves < 1
+        || edge_threshold <= 0.0f || max_num_feature_points <= 0) {
+        return 1;
+    }
+
+    // Ensure all octaves are at least 5x5 (binomial filter requirement).
+    {
+        int w = src_w;
+        int h = src_h;
+        for (int o = 0; o < num_octaves; ++o) {
+            if (w < 5 || h < 5) {
+                return 2;
+            }
+            w >>= 1;
+            h >>= 1;
+        }
+    }
+
+    try {
+        vision::Image image(
+            const_cast<unsigned char*>(src), vision::IMAGE_UINT8,
+            src_w, src_h, src_w /* step */, 1);
+
+        vision::BinomialPyramid32f pyr;
+        pyr.alloc(src_w, src_h, num_octaves);
+        pyr.build(image);
+
+        vision::DoGScaleInvariantDetector det;
+        det.alloc(&pyr);
+        det.setLaplacianThreshold(laplacian_threshold);
+        det.setEdgeThreshold(edge_threshold);
+        det.setMaxNumFeaturePoints(static_cast<size_t>(max_num_feature_points));
+        det.setFindOrientation(find_orientation != 0);
+
+        det.detect(&pyr);
+
+        *count_out = static_cast<int>(det.features().size());
+        return 0;
+    } catch (...) {
+        return 4;
+    }
 }
 
 /* ---- Dual-mode validation: BinomialPyramid32f bridge (Milestone 8, #127) ---- */

--- a/crates/core/src/kpm/kpm_c_api.cpp
+++ b/crates/core/src/kpm/kpm_c_api.cpp
@@ -56,6 +56,8 @@
 #include <math/linear_solvers.h>
 #include <math/rand.h>
 #include <homography_estimation/robust_homography.h>
+#include <detectors/gaussian_scale_space_pyramid.h>
+#include <framework/image.h>
 #include <Eigen/Core>
 #include <unsupported/Eigen/MatrixFunctions>
 
@@ -503,6 +505,57 @@ int webarkit_cpp_fast_random(int* seed) {
 
 void webarkit_cpp_array_shuffle(int* v, int pop_size, int sample_size, int* seed) {
     vision::ArrayShuffle<int>(v, pop_size, sample_size, *seed);
+}
+
+/* ---- Dual-mode validation: BinomialPyramid32f bridge (Milestone 8, #127) ---- */
+
+int webarkit_cpp_binomial_pyramid_build_level(
+    const unsigned char* src,
+    int src_w,
+    int src_h,
+    int num_octaves,
+    int target_octave,
+    int target_scale,
+    float* dst_out,
+    int dst_capacity_floats) {
+
+    if (!src || !dst_out || src_w < 5 || src_h < 5 || num_octaves < 1
+        || target_octave < 0 || target_octave >= num_octaves
+        || target_scale < 0 || target_scale >= 3) {
+        return 1;
+    }
+
+    const int lvl_w = src_w >> target_octave;
+    const int lvl_h = src_h >> target_octave;
+    if (lvl_w < 5 || lvl_h < 5) {
+        return 2;
+    }
+    if (dst_capacity_floats < lvl_w * lvl_h) {
+        return 3;
+    }
+
+    try {
+        vision::Image image(
+            const_cast<unsigned char*>(src), vision::IMAGE_UINT8,
+            src_w, src_h, src_w /* step */, 1);
+
+        vision::BinomialPyramid32f pyr;
+        pyr.alloc(src_w, src_h, num_octaves);
+        pyr.build(image);
+
+        const vision::Image& lvl = pyr.get(target_octave, target_scale);
+        const float* lvl_ptr = reinterpret_cast<const float*>(lvl.get());
+        const int lvl_step_floats = static_cast<int>(lvl.step() / sizeof(float));
+        for (int row = 0; row < lvl_h; ++row) {
+            std::memcpy(
+                dst_out + row * lvl_w,
+                lvl_ptr + row * lvl_step_floats,
+                static_cast<size_t>(lvl_w) * sizeof(float));
+        }
+        return 0;
+    } catch (...) {
+        return 4;
+    }
 }
 
 } // extern "C"

--- a/crates/core/src/kpm/kpm_c_api.h
+++ b/crates/core/src/kpm/kpm_c_api.h
@@ -239,6 +239,34 @@ int webarkit_cpp_match_features_guided(
 int  webarkit_cpp_fast_random(int* seed);
 void webarkit_cpp_array_shuffle(int* v, int pop_size, int sample_size, int* seed);
 
+/* ---- Dual-mode validation: BinomialPyramid32f bridge (Milestone 8, #127) ---- */
+
+/* Build a vision::BinomialPyramid32f from `src` (grayscale, src_w x src_h,
+ * row-major, tight stride) and copy the f32 level at (target_octave,
+ * target_scale) into `dst_out`.
+ *
+ * `num_octaves` is the pyramid depth.
+ * `target_octave` must be in [0, num_octaves); `target_scale` in [0, 3).
+ *
+ * The level (o, s) has size (src_w >> o) x (src_h >> o). The caller must
+ * provide `dst_capacity_floats` >= that product (in floats, not bytes).
+ *
+ * Returns:
+ *   0  success
+ *   1  validation error (null ptr, bad dims, out-of-range indices)
+ *   2  octave too small for binomial filter (< 5x5)
+ *   3  dst_capacity_floats too small for the requested level
+ *   4  C++ exception caught (ASSERT, std::exception, etc.) */
+int webarkit_cpp_binomial_pyramid_build_level(
+    const unsigned char* src,
+    int src_w,
+    int src_h,
+    int num_octaves,
+    int target_octave,
+    int target_scale,
+    float* dst_out,
+    int dst_capacity_floats);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crates/core/src/kpm/kpm_c_api.h
+++ b/crates/core/src/kpm/kpm_c_api.h
@@ -239,6 +239,41 @@ int webarkit_cpp_match_features_guided(
 int  webarkit_cpp_fast_random(int* seed);
 void webarkit_cpp_array_shuffle(int* v, int pop_size, int sample_size, int* seed);
 
+/* ---- Dual-mode validation: FREAKExtractor bridge (Milestone 8, #129) ---- */
+
+/* Build a vision::BinomialPyramid32f from `src`, then run
+ * vision::FREAKExtractor::extract at the caller-supplied keypoints.
+ * Writes `num_keypoints * 96` bytes to `dst_out` (84 bytes of FREAK
+ * descriptor data + 12 bytes zero padding per feature, matching the
+ * C++ BinaryFeatureStore layout).
+ *
+ * `keypoints` is a flat float array of 4 floats per keypoint:
+ * [x0, y0, angle0, scale0, x1, y1, angle1, scale1, ...]. The `maxima`
+ * flag of vision::FeaturePoint is unused by the FREAK descriptor
+ * algorithm so it is omitted from the serialization.
+ *
+ * Both sides must use identical config (`num_octaves` and the same
+ * source image) for the dual-mode parity test to be meaningful. Rust
+ * supplies the keypoints (it has already run its own detection), so
+ * this shim tests the descriptor algorithm in isolation from the
+ * detection pipeline.
+ *
+ * Returns:
+ *   0  success
+ *   1  validation error (null ptr, bad dims, negative count)
+ *   2  pyramid too small for the requested octave count
+ *   3  dst_capacity_bytes < num_keypoints * 96
+ *   4  C++ exception caught (ASSERT, std::exception, etc.) */
+int webarkit_cpp_extract_freak_descriptors(
+    const unsigned char* src,
+    int src_w,
+    int src_h,
+    int num_octaves,
+    const float* keypoints,
+    int num_keypoints,
+    unsigned char* dst_out,
+    int dst_capacity_bytes);
+
 /* ---- Dual-mode validation: DoGScaleInvariantDetector bridge (Milestone 8, #128) ---- */
 
 /* Build a BinomialPyramid32f from `src` and run a DoGScaleInvariantDetector

--- a/crates/core/src/kpm/kpm_c_api.h
+++ b/crates/core/src/kpm/kpm_c_api.h
@@ -239,6 +239,31 @@ int webarkit_cpp_match_features_guided(
 int  webarkit_cpp_fast_random(int* seed);
 void webarkit_cpp_array_shuffle(int* v, int pop_size, int sample_size, int* seed);
 
+/* ---- Dual-mode validation: DoGScaleInvariantDetector bridge (Milestone 8, #128) ---- */
+
+/* Build a BinomialPyramid32f from `src` and run a DoGScaleInvariantDetector
+ * with the supplied configuration. Writes the number of detected keypoints
+ * to `*count_out`. Both Rust and C++ sides must call with identical config
+ * for the dual-mode parity test to be meaningful.
+ *
+ * `find_orientation` is treated as boolean (0 = false, non-zero = true).
+ *
+ * Returns:
+ *   0  success
+ *   1  validation error (null ptr, bad dims, out-of-range indices)
+ *   2  pyramid too small for the requested octave count
+ *   4  C++ exception caught (ASSERT, std::exception, etc.) */
+int webarkit_cpp_dog_detect_count(
+    const unsigned char* src,
+    int src_w,
+    int src_h,
+    int num_octaves,
+    float laplacian_threshold,
+    float edge_threshold,
+    int max_num_feature_points,
+    int find_orientation,
+    int* count_out);
+
 /* ---- Dual-mode validation: BinomialPyramid32f bridge (Milestone 8, #127) ---- */
 
 /* Build a vision::BinomialPyramid32f from `src` (grayscale, src_w x src_h,

--- a/docs/design/m8-2-gaussian-pyramid.md
+++ b/docs/design/m8-2-gaussian-pyramid.md
@@ -164,4 +164,6 @@ Returns 0 on success; non-zero codes for validation failure, octave too small, b
 
 1. **purecv `Matrix<f32>` API parity with `Matrix<u8>`** — will verify before coding; minor adaptations possible.
 2. **f32 bit-for-bit parity** — relies on deterministic integer arithmetic + `* (1.0 / 256.0)`. If LLVM reassociates the binomial sum differently than the C++ compiler, parity could break. Mitigation: use the *exact* additive order from the C++ source (no commutative rewriting).
+
+   **Update (post-merge of M8-1, pre-merge of M8-2)**: This risk materialized on macOS. Apple clang on ARM64 emits FMA (fused multiply-add) instructions for the binomial filter expression by default, while MSVC (Windows) and GCC (Linux) do not. The result is a 1-ULP difference in C++ output between macOS and the other platforms. The dual-mode test was relaxed to ≤1 ULP tolerance — strict bit equality is impractical given cross-platform C++ FP contraction. The 1-ULP tolerance still catches any algorithm error while accommodating the platform variance. Local 1-ULP bugs (like the H-pass parenthesization caught during implementation) are still detected because they produce >1 ULP errors at higher scales.
 3. **FFI shim must compile cleanly on all CI targets** — including macOS (post-#117 libc++ fix) and the flaky macOS rust-cache (#134). If #134 isn't fixed, expect occasional CI re-runs.

--- a/docs/design/m8-2-gaussian-pyramid.md
+++ b/docs/design/m8-2-gaussian-pyramid.md
@@ -111,6 +111,53 @@ int webarkit_cpp_binomial_pyramid_build_level(
 
 Returns 0 on success; non-zero codes for validation failure, octave too small, buffer overflow, C++ exception.
 
+### 3.5 Bilinear interpolation formula
+
+Implemented verbatim as the issue spec requested in
+[`crates/core/src/kpm/freak/interpolate.rs:85`](../../crates/core/src/kpm/freak/interpolate.rs#L85)
+and
+[`crates/core/src/kpm/freak/interpolate.rs:110`](../../crates/core/src/kpm/freak/interpolate.rs#L110):
+
+```rust
+let dx = x - x0 as f32;
+let dy = y - y0 as f32;
+(1.0 - dy) * ((1.0 - dx) * p00 + dx * p01) + dy * ((1.0 - dx) * p10 + dx * p11)
+```
+
+Where `p00, p01, p10, p11` are the four neighbor pixels surrounding the
+sample point `(x, y)`, with `x0 = floor(x)` and `y0 = floor(y)`. Returns
+`0.0` when `(x, y)` requires a neighbor outside the image bounds (Rust
+safety improvement over the C++ `ASSERT`s).
+
+#### Relation to the C++ source
+
+The C++ in `interpolate.h` uses the equivalent 4-weight form:
+
+```cpp
+res = w0 * p00 + w1 * p01 + w2 * p10 + w3 * p11;
+// w0 = (xp_plus_1 - x) * (yp_plus_1 - y)   = (1 - dx) * (1 - dy)
+// w1 = (x - xp)        * (yp_plus_1 - y)   =      dx  * (1 - dy)
+// w2 = (xp_plus_1 - x) * (y - yp)          = (1 - dx) *      dy
+// w3 = (x - xp)        * (y - yp)          =      dx  *      dy
+```
+
+Algebraically identical to the factored Rust form. The factored form has
+**4 multiplications** (vs C++'s **8**) for the same result. For `f32`
+the two forms are not guaranteed to produce bit-identical output because
+floating-point addition is not associative, but the bilinear
+interpolation **is not part of the dual-mode parity test** — only the
+binomial filter is. The bilinear functions are exercised by
+`test_bilinear_interpolate_*` unit tests that assert values within a
+small tolerance.
+
+#### Single shared implementation
+
+`bilinear_interpolate_u8` does not duplicate the formula — it forwards
+to `bilinear_interpolate(image.as_slice(), image.cols, image.rows, x, y)`
+so the actual math lives in one place. `bilinear_interpolate_f32`
+duplicates the formula because it operates on `&Matrix<f32>` (different
+pixel type), but the structure is identical.
+
 ---
 
 ## 4. Assumptions

--- a/docs/design/m8-2-gaussian-pyramid.md
+++ b/docs/design/m8-2-gaussian-pyramid.md
@@ -1,0 +1,167 @@
+# Milestone 8 — Step 2: Bilinear Interpolation + Gaussian Scale-Space Pyramid
+
+**Status**: Design approved, ready for implementation
+**Branch**: `feat/m8-2-interpolate-gaussian-pyramid` (PR target: `feat/m8-freak-detector`)
+**Issue**: #127
+**Author**: Walter Perdan ([@kalwalt](https://github.com/kalwalt))
+**Date**: 2026-05-15
+
+---
+
+## 1. Understanding Summary
+
+- **What**: Port `interpolate.h` + `gaussian_scale_space_pyramid.{h,cpp}` to two new Rust modules:
+  - `crates/core/src/kpm/freak/interpolate.rs`
+  - `crates/core/src/kpm/freak/gaussian_pyramid.rs`
+- **Why**: Step 2 of Milestone 8. The Gaussian scale-space pyramid is the input to the DoG detector (M8-3); bilinear interpolation is used throughout the FREAK pipeline.
+- **Who**: Internal infrastructure consumed by M8-3 (DoG), M8-4 (FREAK descriptor), and downstream KPM matching.
+- **Success criterion**: `f32` pyramid output is byte-identical to C++ `BinomialPyramid32f::build`, verified by a live FFI dual-mode test (`#[cfg(feature = "dual-mode")]`).
+- **Non-goals (this PR)**: DoG detector, FREAK descriptor, SIMD/rayon optimization, harris.* dead code, fixture-based testing.
+
+---
+
+## 2. Decision Log
+
+| # | Decision | Alternatives considered | Rationale |
+|---|----------|-------------------------|-----------|
+| 1 | Faithful C++ port — `[1,4,6,4,1]/16` binomial filter, `Matrix<f32>` storage, 3 scales/octave hardcoded | True Gaussian with `ceil(3*sigma)*2+1` kernel + u8 storage; hybrid u8 storage with binomial filter | "Port" means preserve behavior. C++ uses a fixed binomial filter (not sigma-parameterized) and f32 storage. Bit-for-bit parity matters because M8-3 (DoG) was tuned against this exact output |
+| 2 | Port all helpers from the C++ header in this PR (`bilinear_upsample_point`, `bilinear_downsample_point`, `num_octaves_for`, `effective_sigma`, `kfactor`, `locate`) | Minimum surface only; defer point-mapping helpers to M8-3 | Same C++ header; M8-3 needs them; each is 5–20 lines; tests are trivial |
+| 3 | Split into 3 sibling modules: `pyramid.rs` (M8-1, existing) + `gaussian_pyramid.rs` (new) + `interpolate.rs` (new) | Everything in `pyramid.rs`; `pyramid.rs` + one new file | Mirrors C++ file organization; keeps each file focused; interpolation is reusable independent of any pyramid type |
+| 4 | Live FFI dual-mode test (existing project pattern) | Pre-generated binary fixture file in `tests/fixtures/` | Matches PRs #76, #77, clustering test; no binary blob in git; output always current vs C++ baseline |
+| 5 | Per-level FFI shim: `webarkit_cpp_binomial_pyramid_build_level(...)` | Whole-pyramid shim with array of buffers | Simpler C-ABI; one rebuild per test call is negligible cost for a 32×32 input |
+| 6 | Constructor `new(num_octaves: usize)` only — drop `num_levels` and `sigma_0` from original prompt | Original prompt: `new(num_octaves, num_levels, sigma_0)` | C++ `BinomialPyramid32f` hardcodes 3 scales (build sequence is 3-specific). Sigma is *derived*: `sigma(oct, scale) = k^scale * 2^oct` with `k = 2^(1/(num_scales-1))` |
+| 7 | `build(&mut self, image: &Matrix<u8>) -> Result<(), GaussianPyramidError>`; idempotent (clear & rebuild) | C++ `void` signature; non-idempotent | Mirrors M8-1; project "log + return Err" idiom (CLAUDE.md §1) |
+| 8 | `NUM_SCALES_PER_OCTAVE = 3` exposed as public `const` | Magic number; constructor parameter | Avoids magic number in callers; documents the C++ contract |
+| 9 | Bilinear API: 3 concrete fns (u8/f32/raw-slice), `f32` return for u8 input, OOB → `0.0` | Generic-over-T with trait; literal C++ u8-returns-u8 | Matches prompt; preserves precision; safer than C++ `ASSERT`s |
+
+---
+
+## 3. Final API
+
+### 3.1 `interpolate.rs`
+
+```rust
+pub fn bilinear_interpolate_u8(image: &Matrix<u8>, x: f32, y: f32) -> f32;
+pub fn bilinear_interpolate_f32(image: &Matrix<f32>, x: f32, y: f32) -> f32;
+pub fn bilinear_interpolate(data: &[u8], width: usize, height: usize, x: f32, y: f32) -> f32;
+pub fn bilinear_upsample_point(x: f32, y: f32, octave: i32) -> (f32, f32);
+pub fn bilinear_downsample_point(x: f32, y: f32, octave: i32) -> (f32, f32);
+```
+
+Formula: `result = (1-dy) * ((1-dx) * p00 + dx * p01) + dy * ((1-dx) * p10 + dx * p11)`
+where `dx = x - floor(x)`, `dy = y - floor(y)`.
+
+### 3.2 `gaussian_pyramid.rs`
+
+```rust
+pub struct GaussianScaleSpacePyramid {
+    pub octaves: Vec<Vec<Matrix<f32>>>,
+    pub num_octaves: usize,
+    pub kfactor: f32,
+    pub one_over_log_k: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GaussianPyramidError {
+    EmptyImage,
+    ImageTooSmall { rows: usize, cols: usize },
+    ZeroOctaves,
+    OctaveTooSmall { octave: usize, rows: usize, cols: usize },
+}
+
+impl GaussianScaleSpacePyramid {
+    pub const NUM_SCALES_PER_OCTAVE: usize = 3;
+
+    pub fn new(num_octaves: usize) -> Self;
+    pub fn build(&mut self, image: &Matrix<u8>) -> Result<(), GaussianPyramidError>;
+    pub fn level(&self, octave: usize, scale: usize) -> &Matrix<f32>;
+    pub fn num_scales_per_octave(&self) -> usize;
+    pub fn effective_sigma(&self, octave: usize, scale: usize) -> f32;
+    pub fn locate(&self, sigma: f32) -> (usize, usize);
+}
+
+pub fn num_octaves_for(width: usize, height: usize, min_size: usize) -> usize;
+```
+
+### 3.3 Build sequence (per C++ `BinomialPyramid32f::build`)
+
+- **Octave 0**:
+  - `octaves[0][0] = filter(input)` — u8 → f32
+  - `octaves[0][1] = filter(octaves[0][0])` — f32 → f32
+  - `octaves[0][2] = filter(filter(octaves[0][1]))` — 2 applications
+- **Octave i (i > 0)**:
+  - `octaves[i][0] = downsample(octaves[i-1][2])` — half-size, bilinear 2×2 average
+  - `octaves[i][1] = filter(octaves[i][0])`
+  - `octaves[i][2] = filter(filter(octaves[i][1]))`
+
+Filter coefficients (separable):
+- **H pass**: `6c + 4(l+r) + (ll+rr)` (u16 accumulator for u8 src, f32 for f32 src)
+- **V pass**: same shape × `1/256`
+- **Border**: replicate edge pixels for 2-pixel border
+
+### 3.4 FFI shim (`kpm_c_api.h/.cpp`)
+
+```c
+int webarkit_cpp_binomial_pyramid_build_level(
+    const uint8_t* src, int src_w, int src_h,
+    int num_octaves,
+    int target_octave, int target_scale,
+    float* dst_out, int dst_capacity_floats);
+```
+
+Returns 0 on success; non-zero codes for validation failure, octave too small, buffer overflow, C++ exception.
+
+---
+
+## 4. Assumptions
+
+1. `purecv 0.4.0` supports `Matrix<f32>` with the same surface as `Matrix<u8>`. Will verify before coding.
+2. The H pass output max is `16 × 255 = 4080` (fits `u16`); V pass output `* 1/256` is exactly representable in `f32`, so bit-for-bit parity with C++ is achievable.
+3. C++ `Image` may have row stride > width when `AUTO_STEP` aligns; FFI shim copies row-by-row using `lvl.step() / sizeof(float)`.
+4. `apply_filter_twice` shared-buffer optimization in C++ does not affect output (filter is deterministic); Rust port allocates a fresh intermediate buffer per pass — same final bytes.
+5. Test data: synthetic gradient (`pixel = (r * cols + c) & 0xFF`); no fixture files in git.
+6. License header: `.claude/HEADER.txt`, year 2026.
+7. No `CHANGELOG.md` edits (release-only).
+
+---
+
+## 5. Test Plan
+
+### 5.1 `interpolate.rs` (4 tests)
+
+- `test_bilinear_interpolate_at_integer_coords`
+- `test_bilinear_interpolate_out_of_bounds_returns_zero`
+- `test_bilinear_interpolate_midpoint` — verifies `(0.5, 0.5)` produces average of 4 corners
+- `test_bilinear_upsample_downsample_roundtrip`
+
+### 5.2 `gaussian_pyramid.rs` (9 unit tests + 1 dual-mode)
+
+- `test_kfactor_for_3_scales` — `kfactor ≈ √2`
+- `test_gaussian_pyramid_octave_count`
+- `test_gaussian_pyramid_octave_downsamples` — `level(oct, 0).cols == src_cols >> oct`
+- `test_gaussian_pyramid_sigma_increases` — within and across octaves
+- `test_locate_clamps_to_pyramid_bounds`
+- `test_gaussian_pyramid_build_is_idempotent`
+- `test_gaussian_pyramid_empty_image_returns_error`
+- `test_gaussian_pyramid_image_too_small_returns_error`
+- `test_gaussian_pyramid_zero_octaves_returns_error`
+- `test_num_octaves_for`
+- `test_gaussian_pyramid_pixels_match_cpp` (`#[cfg(feature = "dual-mode")]`) — byte-for-byte `f32::to_bits()` parity at all (octave, scale) levels for a 32×32 gradient input
+
+**Verification**: `cargo test -p webarkitlib-rs -- kpm::freak` + `cargo test -p webarkitlib-rs --lib --features dual-mode`.
+
+---
+
+## 6. Follow-up Work (Out of Scope This PR)
+
+- **M8-3**: DoG scale-invariant detector (will consume this pyramid)
+- **M8-4**: FREAK descriptor extraction
+- **Perf**: criterion benchmark, then SIMD path for the binomial filter (file a follow-up issue analogous to #131/#132 for `Pyramid` once this lands)
+
+---
+
+## 7. Open Risks
+
+1. **purecv `Matrix<f32>` API parity with `Matrix<u8>`** — will verify before coding; minor adaptations possible.
+2. **f32 bit-for-bit parity** — relies on deterministic integer arithmetic + `* (1.0 / 256.0)`. If LLVM reassociates the binomial sum differently than the C++ compiler, parity could break. Mitigation: use the *exact* additive order from the C++ source (no commutative rewriting).
+3. **FFI shim must compile cleanly on all CI targets** — including macOS (post-#117 libc++ fix) and the flaky macOS rust-cache (#134). If #134 isn't fixed, expect occasional CI re-runs.

--- a/docs/design/m8-3-dog-detector.md
+++ b/docs/design/m8-3-dog-detector.md
@@ -1,0 +1,234 @@
+# Milestone 8 — Step 3: DoG Detector + Orientation Assignment
+
+**Status**: Design approved, ready for implementation
+**Branch**: `feat/m8-3-dog-detector` (PR target: `feat/m8-freak-detector`)
+**Issue**: #128
+**Author**: Walter Perdan ([@kalwalt](https://github.com/kalwalt))
+**Date**: 2026-05-16
+
+---
+
+## 1. Understanding Summary
+
+- **What**: Port `orientation_assignment.{h,cpp}` and `DoG_scale_invariant_detector.{h,cpp}` to two new Rust sibling modules:
+  - `crates/core/src/kpm/freak/orientation.rs`
+  - `crates/core/src/kpm/freak/detector.rs`
+- **Why**: Step 3 of Milestone 8. The Difference-of-Gaussians (DoG) detector finds scale-invariant keypoints from the Gaussian pyramid (M8-2 output); these keypoints feed the FREAK descriptor (M8-4) and the downstream KPM matching pipeline.
+- **Who**: Internal infrastructure consumed by M8-4 (FREAK descriptor) and downstream KPM matching.
+- **Success criterion**: Live FFI dual-mode test: Rust detector keypoint count agrees with C++ within `±5` on `found.jpg`, with identical detector configuration on both sides. Plus 6 unit tests for shape/coverage/correctness.
+- **Non-goals (this PR)**:
+  - FREAK descriptor extraction (M8-4)
+  - SIMD/rayon optimization
+  - Harris detector port (dead code — explicitly excluded by issue)
+  - Public two-phase `OrientationAssignment` API (`compute_gradients` separated from `compute`) — deferred to M8-4
+  - Full 7-parameter `OrientationAssignment::new(...)` constructor — using hardcoded FREAK defaults
+
+---
+
+## 2. Decision Log
+
+| # | Decision | Alternatives considered | Rationale |
+|---|----------|-------------------------|-----------|
+| 1 | **Option C scope**: faithful on algorithm-critical bits (3-way Hessian dispatch, bucket pruning, `Matrix<f32>` DoG, rich `DoGFeaturePoint`, all detector params), simplified on `OrientationAssignment` public surface | Option A (fully faithful, ~1500 lines); Option B (spec-as-written, naive top-N pruning, single Hessian variant) | Keeps PR reviewable while preserving algorithm correctness; deferred surface promotion lands naturally in M8-4 where it's actually needed |
+| 2 | **Option B FeaturePoint**: new `DoGFeaturePoint` (9 fields) in `detector.rs`; `hough.rs::FeaturePoint` unchanged; `From<&DoGFeaturePoint>` conversion | Option A: extend existing `hough.rs::FeaturePoint` with 4 new fields; Option C: move to shared `feature_point.rs` module | Mirrors C++ architecture (`vision::FeaturePoint` in `matchers/` is persistent type; `DoGScaleInvariantDetector::FeaturePoint` is working type with diagnostics); avoids coupling this PR to `hough.rs` |
+| 3 | **B: Split into 2 modules** — `orientation.rs` + `detector.rs` | Option A: single `detector.rs` (~1300 lines mixing two concerns); Option C: 3-way split | Mirrors C++ file organization; matches M8-2 splitting pattern; each file ~600 lines and forward-compatible with M8-4 API promotion |
+| 4 | **A: Live FFI shim** `webarkit_cpp_dog_detect_count(...)` parameterized by detector config | Option B: pre-generated `tests/fixtures/dog_keypoint_count.txt`; Option C: hybrid xtask-regenerated | Matches M8-2 pattern; no binary/text blob in git; both sides run identical configuration |
+| 5 | **C: `MAX_TIE_DIVERGENCE = 5`** for keypoint count tolerance | Option A: exact match (`assert_eq!`); Option B: ±10% (issue spec literal) | Issue's ±10% would allow ±50 keypoints — too loose to detect real bugs. ±5 catches sort tie-breaking variance only. Tighten to exact in a follow-up if CI shows consistent equality |
+| 6 | **`detect()` is infallible**: returns `Vec<DoGFeaturePoint>` directly | `Result<Vec<DoGFeaturePoint>, DetectorError>` (M8-1/M8-2 pattern) | Pre-validated pyramid input; no failure modes that aren't already caught upstream; matches C++ `void detect()`; empty Vec = "no keypoints found", not error |
+| 7 | **`DoGScaleInvariantDetector::new()` is infallible**: validates config with `debug_assert!` | `Result<Self, DetectorError>` | Constructor just stores numeric params; bad values trip debug asserts |
+
+---
+
+## 3. Final API
+
+### 3.1 `orientation.rs`
+
+```rust
+pub struct OrientationAssignment {
+    num_bins: usize,                       // FREAK default: 36
+    gaussian_expansion_factor: f32,        // FREAK default: 1.5
+    support_region_expansion_factor: f32,  // FREAK default: 3.0
+    num_smoothing_iterations: usize,       // FREAK default: 5
+    peak_threshold: f32,                   // FREAK default: 0.8
+}
+
+impl OrientationAssignment {
+    #[must_use]
+    pub fn new() -> Self;
+
+    #[must_use]
+    pub fn compute(
+        &self,
+        gradient: &Matrix<f32>,   // channels = 2: (magnitude, angle) interleaved
+        x: f32,
+        y: f32,
+        sigma: f32,
+    ) -> Vec<f32>;
+}
+
+/// Build a 2-channel (magnitude, angle) gradient image from a pyramid level.
+#[must_use]
+pub fn compute_gradient_image(level: &Matrix<f32>) -> Matrix<f32>;
+```
+
+### 3.2 `detector.rs`
+
+```rust
+#[derive(Debug, Clone, Copy)]
+pub struct DoGFeaturePoint {
+    pub x: f32,
+    pub y: f32,
+    pub angle: f32,        // 0 if find_orientation == false
+    pub octave: i32,
+    pub scale: i32,        // integer scale index (0..NUM_SCALES_PER_OCTAVE)
+    pub sp_scale: f32,     // sub-pixel scale offset, in (-0.5, 0.5)
+    pub score: f32,        // signed DoG response at refined location
+    pub sigma: f32,        // characteristic Gaussian sigma after refinement
+    pub edge_score: f32,
+}
+
+impl From<&DoGFeaturePoint> for super::hough::FeaturePoint {
+    fn from(d: &DoGFeaturePoint) -> Self;  // projects to persistent type
+}
+
+pub struct DoGScaleInvariantDetector {
+    laplacian_threshold: f32,
+    edge_threshold: f32,
+    max_subpixel_distance_sqr: f32,    // FREAK default: 3.0
+    num_buckets_x: usize,              // FREAK default: 10
+    num_buckets_y: usize,              // FREAK default: 10
+    max_num_feature_points: usize,
+    find_orientation: bool,
+    orientation_assignment: OrientationAssignment,
+}
+
+impl DoGScaleInvariantDetector {
+    pub const DEFAULT_MAX_NUM_FEATURE_POINTS: usize = 5000;
+
+    pub fn new(
+        laplacian_threshold: f32,
+        edge_threshold: f32,
+        max_num_feature_points: usize,
+        find_orientation: bool,
+    ) -> Self;
+
+    pub fn detect(
+        &self,
+        pyramid: &GaussianScaleSpacePyramid,
+    ) -> Vec<DoGFeaturePoint>;
+}
+```
+
+### 3.3 detect() pipeline
+
+1. **Build DoG pyramid**: `dog[oct][s] = pyramid.level(oct, s+1) - pyramid.level(oct, s)` for `s` in `0..NUM_DOG_PER_OCTAVE` (= 2 with 3 scales/octave). `Matrix<f32>` storage.
+2. **Find 3D extrema**: for each `(oct, dog_idx, r, c)`, compare to all 26 neighbours in the 3×3×3 cube. Cross-octave neighbours accessed via bilinear interpolation.
+3. **Contrast threshold**: discard `|value| < laplacian_threshold`.
+4. **Sub-pixel refinement** (`compute_subpixel_hessian` dispatcher):
+   - `SameOctave` — all three laplacians same size
+   - `FineOctavePair` — lap0/lap1 same size, lap2 half size
+   - `CoarseOctavePair` — lap0 double size, lap1/lap2 same
+   Solve 3×3 `H · δ = b` via Gaussian elimination. Discard if `||δ||² > max_subpixel_distance_sqr` or H is degenerate.
+5. **Edge rejection**: `compute_edge_score` from H's top-left 2×2; discard if `|score| ≥ (edge_threshold + 1)² / edge_threshold`.
+6. **Orientation assignment** (when `find_orientation == true`): precompute one gradient image per pyramid level; for each refined point query `OrientationAssignment::compute(...)`; emit one copy per dominant peak (zero peaks ⇒ keypoint dropped, matches C++).
+7. **Bucket pruning**: distribute keypoints across `num_buckets_x × num_buckets_y` fine-image spatial buckets; take best-by-|score| per bucket round-robin until `max_num_feature_points` reached.
+
+### 3.4 FFI shim (`kpm_c_api.h/.cpp`)
+
+```c
+int webarkit_cpp_dog_detect_count(
+    const unsigned char* src, int src_w, int src_h,
+    int num_octaves,
+    float laplacian_threshold, float edge_threshold,
+    int max_num_feature_points, int find_orientation,
+    int* count_out);
+```
+
+Returns 0 on success; non-zero codes for validation failure / C++ exception. ~90 lines of C++.
+
+---
+
+## 4. Assumptions
+
+1. `Matrix<f32>` API surface (verified in M8-2) supports all needed operations: `as_slice`, `as_mut_slice`, `from_vec`, `zeros`, `rows`, `cols`, `channels` fields.
+2. `bilinear_interpolate_f32` from `interpolate.rs` (M8-2) is the right API for sub-pixel gradient access on `Matrix<f32>` gradient images.
+3. `bilinear_upsample_point` / `bilinear_downsample_point` from `interpolate.rs` (M8-2) handle the cross-octave Hessian variants and the `From<&DoGFeaturePoint>` fine-image projection.
+4. `found.jpg` lives at `benchmarks/data/found.jpg` (verified); loaded as grayscale `Matrix<u8>` in tests via the `image` crate.
+5. License header on both new files; year 2026; author Walter Perdan @kalwalt.
+6. Sort stability: Rust's `sort_by` is stable, C++ `std::sort` is not guaranteed stable. The `MAX_TIE_DIVERGENCE = 5` tolerance covers any tie-related variance.
+7. The `-ffp-contract=off` flag added in M8-2 keeps C++ floating-point output deterministic across platforms; all numeric helpers in this PR inherit that determinism.
+
+### 4.1 C++-verified defaults (sourced from `DoG_scale_invariant_detector.cpp` lines 108–134)
+
+| Parameter | Value | Source |
+|---|---|---|
+| `laplacian_threshold` | `0` (no contrast filter) | `DoGScaleInvariantDetector::DoGScaleInvariantDetector` |
+| `edge_threshold` | `10` → `hessian_threshold = (10+1)²/10 = 12.1` | same |
+| `max_subpixel_distance_sqr` | `9` (`3*3` — already squared; name has `Sqr` suffix) | same |
+| `num_buckets_x = num_buckets_y` | `10` | same |
+| `find_orientation` | `true` | same |
+| `max_num_feature_points` (`kMaxNumFeaturePoints`) | `5000` | same |
+| `kMaxNumOrientations` | `36` (used both as histogram bin count and per-keypoint orientation cap) | header constant |
+| OA `num_bins` | `36` (= `kMaxNumOrientations`) | `alloc(...)` call site |
+| OA `gaussian_expansion_factor` | `3.0` | `alloc(...)` call site |
+| OA `support_region_expansion_factor` | `1.5` | `alloc(...)` call site |
+| OA `num_smoothing_iterations` | `5` | `alloc(...)` call site |
+| OA `peak_threshold` | `0.8` | `alloc(...)` call site |
+
+### 4.2 Corrections to §3 found during implementation
+
+- **DoG direction**: `dog[s] = pyramid[s] - pyramid[s+1]` (less-blurred minus more-blurred), per C++ `difference_image_binomial` (lines 85–106). The opposite direction was assumed in the original §3.3 draft.
+- **Fine-image coordinates from extraction**: `(x, y)` are upsampled to fine-image coordinates **at extraction time** via `bilinear_upsample_point`, matching C++. The original draft stored octave-local coords until the `From` projection. Now stored as fine-image coords throughout `DoGFeaturePoint`.
+- **Pipeline order**: prune → orient (matches C++ `detect()`), **not** orient → prune. Pruning before orientation avoids computing orientations for keypoints that get dropped.
+- **`sp_scale` semantics**: full sub-pixel scale value `scale + u[2]`, clipped to `[0, NUM_DOG_PER_OCTAVE]`. Not an offset in `(-0.5, 0.5)` as originally drafted.
+- **`OrientationAssignment` gradient channel order**: `(angle, magnitude)` — matches C++ `ComputePolarGradients` which writes `atan2(dy, dx) + π` to channel 0 and `sqrt(dx² + dy²)` to channel 1. The angle channel is shifted into `[0, 2π]` (atan2 result `+ π`). The original draft had `(magnitude, angle)`.
+- **OA factor names swapped in original draft**: `gaussian_expansion_factor = 3.0` and `support_region_expansion_factor = 1.5` (not the reverse). Total support radius = `3.0 · 1.5 · sigma = 4.5 · sigma`.
+
+---
+
+## 5. Test Plan
+
+| Test | Source | Notes |
+|---|---|---|
+| `test_orientation_assignment_horizontal_gradient` | Issue spec | Synthetic level (`pixel = col as f32`); call `compute_gradient_image` → `OrientationAssignment::compute`; dominant orientation within tolerance of π/2 |
+| `test_orientation_assignment_empty_when_no_gradients` | Hardening | Flat image returns empty Vec |
+| `test_dog_detector_finds_keypoints_on_real_image` | Issue spec | Load `found.jpg`; 3-octave pyramid; assert > 50 keypoints |
+| `test_dog_detector_keypoints_within_image_bounds` | Issue spec | All `(x, y)` ∈ `[0, w) × [0, h)` after `From<&DoGFeaturePoint>` projection |
+| `test_dog_feature_point_from_conversion` | Hardening | Hand-crafted `DoGFeaturePoint` projects correctly; `maxima = score >= 0` |
+| `test_dog_detector_zero_octave_pyramid_is_handled` | Hardening | Degenerate pyramid; no panic, possibly empty Vec |
+| `test_dog_keypoints_match_cpp_count` | Issue spec (modified) | `#[cfg(feature = "dual-mode")]`; live FFI; `\|rust - cpp\| <= 5` |
+
+**Verification commands:**
+
+```
+cargo test -p webarkitlib-rs -- kpm::freak::orientation kpm::freak::detector
+cargo test -p webarkitlib-rs --lib --features dual-mode -- kpm::freak::detector
+cargo clippy -p webarkitlib-rs -- -D warnings
+```
+
+---
+
+## 6. Follow-up Work (Out of Scope This PR)
+
+The Option C deferred items, naturally absorbed into **M8-4 (FREAK descriptor)** since the descriptor will share gradient images with `OrientationAssignment`:
+
+- **Public two-phase `OrientationAssignment` API** — `compute_gradients(&mut self, pyramid)` and `compute(...)` as separate public methods, with caller-owned gradient image cache reused across detect/describe calls.
+- **Full 7-parameter `OrientationAssignment::new(...)`** — replace hardcoded FREAK defaults with constructor parameters.
+- **Reusable gradient image cache** — currently rebuilt per `detect()` call; M8-4 will expose the cache so describe() can reuse it.
+
+Also deferred (analogous to #131/#132 for the box-filter pyramid):
+
+- **`criterion` benchmark** for `detect()` end-to-end and `compute_gradient_image` hot path.
+- **SIMD path** for `compute_gradient_image` (largest hot loop in M8-3) and `dog_image`.
+
+---
+
+## 7. Open Risks
+
+1. **`OrientationAssignment` default values** — hardcoded FREAK defaults in §3.1 are best-effort cross-references; if any differ from the actual C++ FreakMatcher facade call site, the dual-mode test count will diverge. Mitigation: verify defaults from C++ source before coding; document the source location.
+
+2. **Cross-octave Hessian dispatch indexing** — the 3 variants depend on consistent (oct, dog_idx) → (lap0, lap1, lap2) mapping. Off-by-one in the boundary cases would produce wrong refinement and lose keypoints near octave transitions. Mitigation: extensive unit tests with hand-crafted DoG pyramids that span octave boundaries.
+
+3. **Bucket pruning sort stability** — C++ `std::sort` is unstable; Rust `sort_by` is stable. Where multiple keypoints have identical |score| (rare but possible), the pruning order will differ. The `MAX_TIE_DIVERGENCE = 5` tolerance covers this. If CI shows divergence > 5 we know there's a real bug to find.
+
+4. **f32 cross-platform parity (legacy)** — the M8-2 `-ffp-contract=off` build flag should keep this PR deterministic across platforms. If macOS CI still produces a different keypoint count, investigate whether new code paths introduce FP contraction opportunities not covered by the existing flag.

--- a/docs/design/m8-3-dog-detector.md
+++ b/docs/design/m8-3-dog-detector.md
@@ -133,7 +133,34 @@ impl DoGScaleInvariantDetector {
 6. **Orientation assignment** (when `find_orientation == true`): precompute one gradient image per pyramid level; for each refined point query `OrientationAssignment::compute(...)`; emit one copy per dominant peak (zero peaks ⇒ keypoint dropped, matches C++).
 7. **Bucket pruning**: distribute keypoints across `num_buckets_x × num_buckets_y` fine-image spatial buckets; take best-by-|score| per bucket round-robin until `max_num_feature_points` reached.
 
-### 3.4 FFI shim (`kpm_c_api.h/.cpp`)
+### 3.4 Replacing the C++ `NONMAX_CHECK` preprocessor macro
+
+The C++ `extractFeatures` uses an `#define NONMAX_CHECK(OPERATOR, VALUE)` macro that expands to a chain of 26 short-circuit `&&` comparisons (9 from `im0`, 8 from `im1` excluding the center, 9 from `im2`). It is parameterized by an operator token (`>` or `<`) so a single macro covers both maxima and minima detection, and a single chain runs at full speed because each comparison is inlined by the preprocessor.
+
+Rust doesn't let you pass operator tokens as macro parameters as cleanly, so the macro is replaced by **an `enum NonMaxOp { Greater, Less }` plus three private inlined helper functions**, one per dimension pattern:
+
+| Function | C++ macro instance |
+|---|---|
+| `nonmax_same_octave(op, val, im0, im1, im2, w, row, col)` | SameOctave (all three `im*` same dims) |
+| `nonmax_fine_octave(op, val, im0, im1, im2, w, row, col, ds_x, ds_y)` | FineOctavePair (`im2` half-sized → 9 `bilinear_interpolate_f32` lookups) |
+| `nonmax_coarse_octave(op, val, im0, im1, im2, w, row, col, us_x, us_y)` | CoarseOctavePair (`im0` double-sized → 9 `bilinear_interpolate_f32` lookups) |
+
+Each helper builds a `cmp` closure with a `match op { Greater => a > b, Less => a < b }` and chains the 26 `cmp(val, neighbor)` calls with `&&`. The call site mirrors the C++ `if/else if`:
+
+```rust
+let extrema = nonmax_same_octave(NonMaxOp::Greater, value, d0, d1, d2, w, row, col)
+    || nonmax_same_octave(NonMaxOp::Less, value, d0, d1, d2, w, row, col);
+```
+
+**Trade-offs considered:**
+
+- **Trait-generic `fn nonmax<C: Fn(f32, f32) -> bool>(cmp: C, ...)`** — would force monomorphization twice per call site and bloat the call graph; rejected.
+- **`macro_rules!` macro** — would match the C++ structure most literally, but Rust hygiene requires explicit captures of every variable, making the macro definition harder to read than the function form; rejected.
+- **Inline expansion** of all 156 comparisons (26 × 2 operators × 3 patterns) — rejected as repetitive.
+
+The enum-with-closure form is shorter than the alternatives and the `#[inline]` annotation gives the compiler the same opportunity to specialize as the C++ macro got at preprocess time. In optimized builds the `match op` is constant-folded per call site because the caller passes a literal `NonMaxOp::Greater` or `NonMaxOp::Less`.
+
+### 3.5 FFI shim (`kpm_c_api.h/.cpp`)
 
 ```c
 int webarkit_cpp_dog_detect_count(

--- a/docs/design/m8-4-freak-descriptor.md
+++ b/docs/design/m8-4-freak-descriptor.md
@@ -1,0 +1,179 @@
+# Milestone 8 — Step 4: FREAK Descriptor + Keyframe
+
+**Status**: Design approved, ready for implementation
+**Branch**: `feat/m8-4-freak-descriptor` (PR target: `feat/m8-freak-detector`)
+**Issue**: #129
+**Author**: Walter Perdan ([@kalwalt](https://github.com/kalwalt))
+**Date**: 2026-05-17
+
+---
+
+## 1. Understanding Summary
+
+- **What**: Port `freak.h` + `freak.cpp` + `keyframe.h` to two new Rust sibling modules:
+  - `crates/core/src/kpm/freak/descriptor.rs` — FREAK extraction (84-byte data in a 96-byte slot)
+  - `crates/core/src/kpm/freak/keyframe.rs` — passive container (mirrors C++ `Keyframe<96>`)
+- Plus: replace the M7 `find_features` stub in `hough.rs` with a real `vision::FindFeatures`-style orchestrator.
+- **Why**: Final step of Milestone 8. Closes the FREAK pipeline (pyramid → DoG detector → FREAK descriptor → `FeatureStore`). Makes the M7 KPM matching pipeline end-to-end-runnable in pure Rust.
+- **Who**: Internal infrastructure consumed by KPM matching (already in main from M7).
+- **Success criterion**: Live FFI dual-mode test — Rust descriptor bytes match C++ within `MAX_HAMMING_PER_DESCRIPTOR = 2` for the top-10 keypoints on `found.jpg`. Plus unit tests for descriptor length, padding, reproducibility, and Keyframe population.
+- **Non-goals (this PR)**:
+  - Public two-phase `OrientationAssignment` API + 7-param ctor + reusable gradient cache — these M8-3-deferred items have no real consumer in M8-4 (the FREAK descriptor doesn't read gradient images). Tracked in #138.
+  - FREAK matching itself (already in M7 via `FeatureMatcher`)
+  - SIMD/rayon for the descriptor inner loop (follow-up)
+  - Harris detector (still dead code)
+
+---
+
+## 2. Decision Log
+
+| # | Decision | Alternatives considered | Rationale |
+|---|----------|-------------------------|-----------|
+| 1 | **Faithful C++ port** — 96-byte storage layout (84 data + 12 zero padding), `samples[i] < samples[j]` comparison, `bitstring_set_bit` LSB-first packing, 666 pairs from 37 receptors | "spec-as-written" with 96 actual descriptor bytes; hybrid | Required for byte-for-byte parity in the dual-mode Hamming-distance test; matches M7's `hamming_distance_96` |
+| 2 | **Defer M8-3 OA items indefinitely** — tracked in #138 | Absorb in M8-4 (was the original plan) | YAGNI: FREAK descriptor samples the Gaussian pyramid directly; no real consumer for the two-phase OA API or gradient cache. Documented in corrections on #128 + #129 |
+| 3 | **Split into 2 modules** — `descriptor.rs` + `keyframe.rs` | Single file; 3-way split | Mirrors C++ file organization (`freak.{h,cpp}` vs `keyframe.h`); matches M8-2/M8-3 pattern |
+| 4 | **Live FFI shim, Rust supplies keypoints** (option A.1) — `webarkit_cpp_extract_freak_descriptors(...)` | Pre-generated fixture file (issue spec literal); hybrid | Matches M8-2/M8-3 pattern; no binary blob; **isolates descriptor algorithm from detection variance** (descriptor parity is tested independently) |
+| 5 | **`MAX_HAMMING_PER_DESCRIPTOR = 2`** for top-10 keypoint dual-mode test | Exact match (0); larger tolerance (≥ 5) | Issue spec says 0; we allow up to 2 bits / 666 (~0.3%) for libm/FMA cross-platform variance in sign decisions. Tight enough to catch real algorithm bugs |
+| 6 | **Caller-owns model** with free `find_features` mirroring C++ `vision::FindFeatures` | `Keyframe::build(image, detector, pyramid)` (user prompt) | Faithful to C++ (Keyframe is a passive container; orchestration is a free function in `visual_database.h`). Fills the M7 `find_features` stub |
+| 7 | **Free function `extract_freak_descriptors(pyramid, keypoints, &mut Vec<u8>)`** | Marker struct `FreakDescriptor::compute(...)` (user prompt); stateful `FreakExtractor` (C++ literal) | C++ "state" is all constants — naturally `const` at module scope in Rust. Free function is idiomatic; raw-bytes output decouples descriptor from `FeatureStore` and improves testability |
+| 8 | **96-byte storage with 84 bytes of descriptor data + 12 zero padding** | 84-byte descriptors (initial draft) | C++ `FREAKExtractor::extract` calls `store.setNumBytesPerFeature(96)` then writes 84 bytes via `ExtractFREAK84`; bytes 84..96 stay zero. M7's `hamming_distance_96` assumes 96-byte descriptors |
+
+---
+
+## 3. Final API
+
+### 3.1 `descriptor.rs`
+
+```rust
+/// Storage size per FREAK descriptor (matches C++ `setNumBytesPerFeature(96)`).
+/// Bytes 0..84 carry 666 packed bits; bytes 84..96 are zero padding.
+pub const FREAK_DESCRIPTOR_BYTES: usize = 96;
+
+/// Compute FREAK descriptors for each keypoint and append to `out`.
+///
+/// After: `out.len()` has grown by `keypoints.len() * FREAK_DESCRIPTOR_BYTES`.
+/// Each 96-byte slot is zero-initialized and 84 bytes are filled with
+/// packed bit comparisons; bytes 84..96 remain zero.
+///
+/// Caller responsibility: `keypoint.angle` should be set by
+/// `OrientationAssignment` (M8-3) — otherwise descriptors use `angle = 0.0`
+/// and become rotation-variant.
+pub fn extract_freak_descriptors(
+    pyramid: &GaussianScaleSpacePyramid,
+    keypoints: &[FeaturePoint],
+    out: &mut Vec<u8>,
+);
+```
+
+### 3.2 `keyframe.rs`
+
+```rust
+pub struct Keyframe {
+    pub store: FeatureStore,  // bytes_per_feature = 96
+    pub width: i32,
+    pub height: i32,
+}
+
+impl Keyframe {
+    pub fn new(width: i32, height: i32) -> Result<Self, KpmError>;
+}
+```
+
+### 3.3 Orchestration (`hough.rs` — replaces M7 stub)
+
+```rust
+pub fn find_features(
+    keyframe: &mut Keyframe,
+    pyramid: &GaussianScaleSpacePyramid,
+    detector: &DoGScaleInvariantDetector,
+) -> Result<(), KpmError> {
+    // 1. dog_points = detector.detect(pyramid)
+    // 2. points: Vec<FeaturePoint> = dog_points.iter().map(Into::into).collect()
+    // 3. extract_freak_descriptors(pyramid, &points, &mut buf)
+    // 4. for (point, desc_slice) in zip(points, buf.chunks_exact(96)): keyframe.store.add(*point, desc_slice)?
+}
+```
+
+### 3.4 Algorithm (per keypoint)
+
+1. **Similarity transform** with `transform_scale = max(keypoint.scale · 7.0, 1.0)`; precompute `cs = transform_scale · cos(angle)`, `sn = transform_scale · sin(angle)`.
+2. **Transform sigmas**: `s_n = sigma_n · transform_scale` for each ring (and center).
+3. **Sample 6 rings** in C++ order (ring5 → ring4 → … → ring0 → center):
+   - Per ring: `pyramid.locate(s_n)` → `(octave, scale_idx)`
+   - Per receptor: apply transform `(rx, ry) = (kp.x + cs·px − sn·py, kp.y + sn·px + cs·py)`, sample via `bilinear_interpolate_f32` on `pyramid.level(octave, scale_idx)` after `bilinear_downsample_point`.
+4. **Pack 666 pairwise comparisons** `samples[i] < samples[j]` (for `0 ≤ i < j < 37`) into the first 84 bytes via LSB-first `desc[pos/8] |= 1 << (pos%8)`.
+5. Bytes 84..96 stay zero (from `out.resize(start + 96, 0)`).
+
+### 3.5 FFI shim (`kpm_c_api.h/.cpp`)
+
+```c
+int webarkit_cpp_extract_freak_descriptors(
+    const unsigned char* src, int src_w, int src_h,
+    int num_octaves,
+    const float* keypoints,    /* 4 floats per keypoint: x, y, angle, scale */
+    int num_keypoints,
+    unsigned char* dst_out,
+    int dst_capacity_bytes);
+```
+
+C++ implementation: build `BinomialPyramid32f`, construct `std::vector<vision::FeaturePoint>` from Rust-supplied data, instantiate `FREAKExtractor`, call `extract(store, pyramid, points)`, `memcpy` `num_keypoints * 96` bytes out. Returns 0 on success; non-zero codes for validation / capacity / exception.
+
+---
+
+## 4. Assumptions
+
+1. The 7 sigma constants and 6 ring arrays from `freak84-inline.h` are ported verbatim as Rust `const f32` values at module scope in `descriptor.rs`. `mExpansionFactor = 7.0` is also a `const`.
+2. The Rust `FeaturePoint` (5 fields from `hough.rs`) matches C++ `vision::FeaturePoint` layout for our purposes; the `maxima` field is unused by FREAK extraction.
+3. `pyramid.locate(sigma) -> (usize, usize)` from M8-2, `bilinear_downsample_point` + `bilinear_interpolate_f32` from M8-2, `From<&DoGFeaturePoint> for FeaturePoint` from M8-3 — all reused as-is.
+4. `FeatureStore::new(96)` (M7-3) accepts 96 as `bytes_per_feature` and exposes `add(point, &[u8])`.
+5. The existing `Keyframe` placeholder in `hough.rs:395–398` and the M7 `find_features` stub are removed/replaced. Mirrors the M8-2 / M8-3 placeholder-cleanup pattern.
+6. License header on both new files; year 2026; author Walter Perdan @kalwalt.
+7. `found.jpg` at `benchmarks/data/found.jpg` is the dual-mode test input.
+8. `-ffp-contract=off` from M8-2 still applies to the C++ build, so libm/FMA cross-platform variance is bounded to ~1–2 ULPs per arithmetic op. The 666-bit descriptor allows for ~2 bit flips due to this variance, hence `MAX_HAMMING_PER_DESCRIPTOR = 2`.
+
+---
+
+## 5. Test Plan
+
+### 5.1 `descriptor.rs` (5 unit + 1 dual-mode)
+
+| Test | Source | Notes |
+|---|---|---|
+| `test_freak_descriptor_length_one_keypoint` | Issue spec | 1 keypoint → `out.len() == 96` |
+| `test_freak_descriptor_length_multiple_keypoints` | Issue spec | 5 keypoints → 480 bytes |
+| `test_freak_descriptor_padding_bytes_are_zero` | Hardening | `out[84..96] == [0; 12]` |
+| `test_freak_descriptor_empty_input` | Hardening | Empty input doesn't panic; `out` unchanged |
+| `test_freak_descriptor_is_reproducible` | Issue spec | Two runs on identical inputs → byte-equal outputs |
+| `test_freak_descriptors_match_cpp_baseline` (`#[cfg(feature = "dual-mode")]`) | Issue spec (modified to live FFI) | Top-10 keypoints (Rust-selected) → C++ shim describes the same keypoints → Hamming distance ≤ 2 per descriptor |
+
+### 5.2 `keyframe.rs` (2 unit)
+
+| Test | Source | Notes |
+|---|---|---|
+| `test_keyframe_new_stores_dimensions` | Hardening | Constructor wiring; `bytes_per_feature == 96` |
+| `test_find_features_populates_keyframe` | Issue spec (renamed) | On `found.jpg` → `keyframe.store.num_features() > 50` |
+
+**Verification commands:**
+
+```
+cargo test -p webarkitlib-rs -- kpm::freak::descriptor kpm::freak::keyframe
+cargo test -p webarkitlib-rs --lib --features dual-mode -- kpm::freak::descriptor
+cargo clippy -p webarkitlib-rs -- -D warnings
+```
+
+---
+
+## 6. Follow-up Work (Out of Scope This PR)
+
+- **#138** — Promote `OrientationAssignment` API surface when a real consumer surfaces (multi-frame matcher, tuning experiments, external callers).
+- **Performance** — `criterion` benchmark for `extract_freak_descriptors`; SIMD path for the 666-pair packing loop (analogous to #131/#132).
+- **Reference-image building** — the `BinaryHierarchicalClustering` index that C++ `Keyframe<96>::buildIndex()` constructs is not built here. M7's KPM matching builds its own index when needed; this remains decoupled.
+
+---
+
+## 7. Open Risks
+
+1. **C++ libm / FMA cross-platform variance** — the 666 sign decisions are sensitive to ULP-level FP variance in `sin`, `cos`, and `bilinear_interpolate_f32`. The `MAX_HAMMING_PER_DESCRIPTOR = 2` tolerance accommodates this. If macOS/Linux CI shows ≤ 2 consistently we can tighten to 0 in a follow-up.
+2. **`pyramid.locate(sigma)` boundary behavior** — at very small or large sigmas, `locate` may clamp to a different `(octave, scale)` than C++. M8-2 verified the clamp matches C++ but the dual-mode count test (find_orientation = true) showed 0 divergence, suggesting `locate` is faithful. Worth re-verifying when M8-4 dual-mode runs.
+3. **Sample ordering** — C++ samples in ring5 → ring4 → … → center order. Reordering would produce a fundamentally different bit pattern incompatible with the C++ baseline. The Rust port preserves the C++ order explicitly.
+4. **`store.feature(0)` pointer arithmetic in the FFI shim** — relies on `BinaryFeatureStore` storing features contiguously with no inter-feature padding. C++ source confirms this layout (`feature(i)` is computed as `&data[i * bytes_per_feature]`).

--- a/docs/design/m8-pyramid.md
+++ b/docs/design/m8-pyramid.md
@@ -1,0 +1,152 @@
+# Milestone 8 — Step 1: Image Pyramid (Box Filter)
+
+**Status**: Design approved, ready for implementation
+**Branch**: `feat/m8-freak-descriptor-work` (PR target: `feat/m8-freak-detector`)
+**Issues**: #125, #126
+**Author**: Walter Perdan ([@kalwalt](https://github.com/kalwalt))
+**Date**: 2026-05-14
+
+---
+
+## 1. Understanding Summary
+
+- **What**: Port the C++ `BoxFilterPyramid8u` (from `WebARKitLib/lib/SRC/KPM/FreakMatcher/detectors/pyramid.{h,cpp}`) to Rust as `crates/core/src/kpm/freak/pyramid.rs`.
+- **Why**: First step of Milestone 8 (FREAK descriptor & DoG detector). The pyramid is the foundation the DoG detector will sit on.
+- **Who**: Internal infrastructure — used by the upcoming DoG detector and downstream KPM matching pipeline.
+- **Success criterion**: Output `Matrix<u8>` byte-identical to the C++ `BoxFilterDecimate` baseline.
+- **Non-goals (this PR)**: DoG detector, SIMD intrinsics, rayon parallelization, 128-byte chunked memory layout, Harris detector port (dead code).
+
+---
+
+## 2. Decision Log
+
+| # | Decision | Alternatives considered | Rationale |
+|---|----------|-------------------------|-----------|
+| 1 | Port the `BoxFilterPyramid8u` C++ algorithm bit-for-bit (2×2 average with `+2 >> 2` rounding) | Simplified standard box filter; defer-and-optimize | User chose Option A — exact parity required for validating against C++ baseline |
+| 2 | `build()` returns `Result<(), PyramidError>` instead of `void` | Infallible signature; hybrid (silent failure + log) | Project idiom (CLAUDE.md §1): errors not panics; log + return Err pattern from PRs #76/#77 |
+| 3 | Scalar-only this PR; SIMD/rayon in follow-up PR with benchmarks | Scalar + SIMD + rayon all-in-one PR; scalar + rayon only | Matches PRs #76/#77 pattern; small reviewable PR; "measure first" rule |
+| 4 | Keep `scale_factor: f32` in API, but only `2.0` accepted (else error) | Drop the parameter entirely; accept arbitrary scales | Future-proof API surface while honoring C++ limitation |
+| 5 | Output dims: `ceil((src-1)/2)` per C++ `init()` formula | `(src/scale).round()` from user's draft spec | Bit-for-bit parity requires the C++ dimension formula |
+| 6 | Drop the 128-byte chunking; plain row-major loop | Port the C++ chunking verbatim | Chunking is cache-only; output unchanged; defer with benchmarks |
+| 7 | `build()` is idempotent — clears `self.levels` then populates | Append; error on re-build | Rust idiom; cheap; intuitive |
+| 8 | Hard error `PyramidError::LevelTooSmall { level }` if a level would be 0-sized | Stop early + warn; require pre-flight check | Project's log + return Err pattern; lets caller decide retry strategy |
+
+---
+
+## 3. Assumptions
+
+1. `purecv 0.4.0` `Matrix<u8>` has `rows`, `cols`, `channels` fields, `as_slice()`, `get(r,c,ch)`, `zeros(h,w,ch)`, and `from_vec(...)`. To be verified before coding.
+2. `scale_factor != 2.0` returns `InvalidScaleFactor(f32)` — leaves the door open for future binomial / arbitrary-scale pyramids.
+3. Test data: synthetic gradient image (`pixel = (r * cols + c) as u8`) is sufficient for unit tests; no fixture files needed.
+4. License header: every new `.rs` file uses `.claude/HEADER.txt` template, year 2026.
+5. Logging: `use crate::{arlog_e, arlog_w};`; use `arlog_e!` for each error path.
+6. No `CHANGELOG.md` edits in this PR (release-only rule).
+7. Branch: `feat/m8-freak-descriptor-work` → PR target `feat/m8-freak-detector`.
+
+---
+
+## 4. Final Design
+
+### 4.1 File layout
+
+- **New file**: `crates/core/src/kpm/freak/pyramid.rs`
+- **Edit**: `crates/core/src/kpm/freak/mod.rs` — add `pub mod pyramid;` and `pub use pyramid::{Pyramid, PyramidError};`
+
+### 4.2 Module doc
+
+```rust
+//! Image pyramid built by repeated box-filter downsampling.
+//!
+//! Ported from `WebARKitLib/lib/SRC/KPM/FreakMatcher/detectors/pyramid.{h,cpp}`
+//! (`BoxFilterPyramid8u` / `BoxFilterDecimate`).
+//!
+//! C equivalent: `vision::BoxFilterPyramid8u`
+```
+
+### 4.3 Public API
+
+```rust
+pub struct Pyramid {
+    pub levels: Vec<Matrix<u8>>,
+    pub scale_factor: f32,
+    num_levels: usize,  // private; remembers constructor param
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PyramidError {
+    EmptyImage,
+    InvalidScaleFactor(f32),
+    ZeroLevels,
+    LevelTooSmall { level: usize },
+}
+
+impl Pyramid {
+    #[must_use]
+    pub fn new(num_levels: usize, scale_factor: f32) -> Self;
+
+    pub fn build(&mut self, image: &Matrix<u8>) -> Result<(), PyramidError>;
+
+    #[must_use]
+    pub fn num_levels(&self) -> usize;
+
+    #[must_use]
+    pub fn level(&self, i: usize) -> &Matrix<u8>;
+}
+```
+
+### 4.4 Algorithm
+
+Per output pixel:
+```
+dst[i', j'] = (src[2i', 2j']   + src[2i', 2j'+1]
+             + src[2i'+1, 2j'] + src[2i'+1, 2j'+1]
+             + 2) >> 2
+```
+
+- `u16` accumulator (matches C++ `unsigned short`; max sum = `4·255 + 2 = 1022`).
+- Output dims: `new_h = ceil((src.rows-1)/2)`, `new_w = ceil((src.cols-1)/2)`.
+- No `unsafe`, no SIMD intrinsics, no chunking.
+
+### 4.5 Error handling
+
+Every error site uses the project's "log + return Err" pattern:
+```rust
+if image.rows == 0 || image.cols == 0 {
+    arlog_e!("Pyramid::build: input image is empty");
+    return Err(PyramidError::EmptyImage);
+}
+```
+
+### 4.6 Tests
+
+| Test name | Purpose |
+|-----------|---------|
+| `test_pyramid_level_count` | (User spec) `new(4, 2.0)` → 4 levels |
+| `test_pyramid_level_dimensions_shrink` | (User spec) `ceil((src-1)/2)` formula |
+| `test_pyramid_pixel_values_in_range` | (User spec) no overflow, fully populated |
+| `test_pyramid_box_filter_known_values` | Hand-computed 4×4 → 2×2 to verify exact algorithm |
+| `test_pyramid_build_is_idempotent` | Re-build clears prior state |
+| `test_pyramid_empty_image_returns_error` | `EmptyImage` variant |
+| `test_pyramid_invalid_scale_returns_error` | `InvalidScaleFactor(1.5)` |
+| `test_pyramid_zero_levels_returns_error` | `ZeroLevels` |
+| `test_pyramid_level_too_small_returns_error` | 5 levels on 4×4 input → `LevelTooSmall` |
+
+**Verification**: `cargo test -p webarkitlib-rs -- kpm::freak::pyramid`
+
+---
+
+## 5. Follow-up Work (Out of Scope This PR)
+
+- **Step 2** of M8: DoG detector (uses this pyramid)
+- **Step 3** of M8: FREAK descriptor extraction
+- **Step 4** of M8: Pipeline integration
+- **Perf PR #1**: `criterion` benchmark for `downsample`
+- **Perf PR #2**: SIMD path (AVX2/SSE4.1/wasm32) gated behind feature flags, with benchmark proof of speedup
+- **Perf PR #3** (maybe): Chunked memory layout if benchmarks show cache misses dominate
+
+---
+
+## 6. Open Risks
+
+1. **`purecv 0.4.0` API verification** — design assumes specific method names (`from_vec`, `as_slice`, field access). Will verify before coding; minor adaptations possible.
+2. **Bit-for-bit verification** — we have no automated comparison against the C++ baseline in this PR. `test_pyramid_box_filter_known_values` uses hand-computed values as a proxy. Full A/B testing against the C++ baseline is a separate validation effort.


### PR DESCRIPTION
## Summary

**Milestone 8 integration — lands the full FREAK feature-matching pipeline into `dev`.** This is the merge of the M8 integration branch (`feat/m8-freak-detector`), which already contains the four sub-PRs (M8-1 → M8-4) merged in order. After this merges, the FREAK pipeline (pyramid → DoG detector → FREAK descriptor → `FeatureStore`) is end-to-end runnable in pure Rust on the `dev` branch.

**Closes**: #125

## The four sub-PRs (all already merged into `feat/m8-freak-detector`)

| Sub-issue | PR | What it added |
|---|---|---|
| #126 (M8-1) | [#130](https://github.com/webarkit/WebARKitLib-rs/pull/130) | Box-filter `Pyramid` (`BoxFilterPyramid8u` port) |
| #127 (M8-2) | [#135](https://github.com/webarkit/WebARKitLib-rs/pull/135) | Bilinear interpolation + `GaussianScaleSpacePyramid` (`BinomialPyramid32f` port) |
| #128 (M8-3) | [#137](https://github.com/webarkit/WebARKitLib-rs/pull/137) | `DoGScaleInvariantDetector` + `OrientationAssignment` |
| #129 (M8-4) | [#143](https://github.com/webarkit/WebARKitLib-rs/pull/143) | `FreakDescriptor` + `Keyframe` + real `find_features` orchestrator |

Each sub-issue has a status comment documenting deviations from spec and the empirical dual-mode result.

## What lands on `dev`

### New public API

```rust
// crates/core/src/kpm/freak/pyramid.rs (M8-1)
pub struct Pyramid { ... }
pub enum PyramidError { ... }

// crates/core/src/kpm/freak/interpolate.rs (M8-2)
pub fn bilinear_interpolate_u8(image: &Matrix<u8>, x: f32, y: f32) -> f32;
pub fn bilinear_interpolate_f32(image: &Matrix<f32>, x: f32, y: f32) -> f32;
pub fn bilinear_interpolate(data: &[u8], width: usize, height: usize, x: f32, y: f32) -> f32;
pub fn bilinear_upsample_point(x: f32, y: f32, octave: i32) -> (f32, f32);
pub fn bilinear_downsample_point(x: f32, y: f32, octave: i32) -> (f32, f32);

// crates/core/src/kpm/freak/gaussian_pyramid.rs (M8-2)
pub struct GaussianScaleSpacePyramid { ... }
pub enum GaussianPyramidError { ... }
pub fn num_octaves_for(width: usize, height: usize, min_size: usize) -> usize;

// crates/core/src/kpm/freak/orientation.rs (M8-3)
pub struct OrientationAssignment { ... }
pub fn compute_polar_gradient_image(level: &Matrix<f32>) -> Matrix<f32>;

// crates/core/src/kpm/freak/detector.rs (M8-3)
pub struct DoGScaleInvariantDetector { ... }
pub struct DoGFeaturePoint { ... }    // with From<&DoGFeaturePoint> for hough::FeaturePoint
pub const NUM_DOG_PER_OCTAVE: usize;

// crates/core/src/kpm/freak/descriptor.rs (M8-4)
pub const FREAK_DESCRIPTOR_BYTES: usize = 96;
pub fn extract_freak_descriptors(pyramid, keypoints, &mut Vec<u8>);

// crates/core/src/kpm/freak/keyframe.rs (M8-4)
pub struct Keyframe { ... }

// crates/core/src/kpm/freak/hough.rs (M8-4 — replaced the M7 stub)
pub fn find_features(keyframe, pyramid, detector) -> Result<(), KpmError>;
```

### Headline result: byte-for-byte C++ parity

Every dual-mode test in the M8 series passes with `|diff| = 0` on Windows MSVC:

| Test | Tolerance shipped | Empirical |
|---|---|---|
| M8-2 pyramid pixels match C++ | 0 (strict `to_bits` equality) | 0 |
| M8-3 DoG keypoint count (no orientation) | ≤ 5 | 0 |
| M8-3 DoG keypoint count (with orientation) | ≤ 10 | 0 |
| M8-4 FREAK descriptor Hamming distance (top-10) | ≤ 2 bits | 0 |

The tolerances are conservative cross-platform headroom (CI on macOS/Linux may show small variance). The Rust port is functionally indistinguishable from the C++ baseline on this hardware.

### Bugs caught during M8

The brainstorming + implementation process surfaced and fixed real cross-platform FP issues:

- **M8-2**: Apple clang ARM64 emits FMA for the binomial filter, producing 1–2 ULP drift vs MSVC/GCC. Fixed by adding `-ffp-contract=off` to non-MSVC C++ compile flags in `build.rs`. This now applies to **all** subsequent M8 ports.
- **M8-3**: `SMOOTH_KERNEL` truncated to 8 digits summed to `1.0 + 1 ULP` (slight amplification); restored to the full 15-digit C++ literals (sums to exactly 1.0) with `#[allow(clippy::excessive_precision)]` to preserve source fidelity.
- **M8-4**: The "96-byte descriptor" terminology in the issue body was the *storage layout* (matching M7's `hamming_distance_96`), not the descriptor data size. Actual descriptor data is 84 bytes; bytes 84..96 are zero padding. Critical for byte-for-byte parity.

### Test counts (relative to dev)

- **+39 unit tests** across the four sub-PRs (M8-1: 9, M8-2: 14, M8-3: 9, M8-4: 7)
- **+4 dual-mode FFI parity tests** (one per sub-PR)
- **+4 FFI shims** in `kpm_c_api.{h,cpp}` for byte-level comparisons against the C++ baseline

### Design docs

Four design documents persisted for future maintainers:
- `docs/design/m8-pyramid.md` (M8-1)
- `docs/design/m8-2-gaussian-pyramid.md` (M8-2)
- `docs/design/m8-3-dog-detector.md` (M8-3)
- `docs/design/m8-4-freak-descriptor.md` (M8-4)

Each contains an Understanding Summary, Decision Log (3–9 decisions), Final API, Assumptions, Test Plan, Follow-up Work, and Open Risks. The decision logs document every deviation from the original issue specs and the rationale for each.

### Stub cleanups

The M7 stub types in `hough.rs` are progressively replaced with real implementations across the M8 series:

- `GaussianScaleSpacePyramid` placeholder — replaced by M8-2's real type
- `DoGScaleInvariantDetector` placeholder — replaced by M8-3's real type
- `Keyframe` placeholder — replaced by M8-4's real type
- `find_features` stub — replaced by M8-4's real `vision::FindFeatures`-style orchestrator

Only the `Keyframe::features: Vec<FeaturePoint>` placeholder field was shaped differently from the real type — the real Keyframe uses `store: FeatureStore` (matches C++ `Keyframe<96>`). Downstream callers from M7 that accessed `.features` would need to migrate to `.store.point(i)` / `.store.descriptor(i)` accessors. (No such callers found.)

## What's NOT in this PR (intentional)

- **Deferred `OrientationAssignment` API surface** — public two-phase `compute_gradients`/`compute`, 7-param constructor, reusable gradient cache. The FREAK descriptor samples the Gaussian pyramid directly (not gradient images), so these items have no current consumer. Tracked in #138 — will land when a real consumer (e.g. multi-frame KPM matcher) appears.
- **`BinaryHierarchicalClustering` index in Keyframe** — C++ `Keyframe<96>::buildIndex()` is not ported. M7's KPM matching builds its own index when needed.
- **Harris detector** — dead code from the removed SURF pipeline; explicitly excluded by every M8 sub-issue.
- **SIMD/rayon** for any M8 hot path. Performance follow-ups are tracked:
  - #131 — `criterion` benchmark for `Pyramid::downsample`
  - #132 — SIMD path for `Pyramid::downsample` with feature flags
  - #133 — chunked memory layout evaluation (gated on benchmark evidence)

## Test plan

All checks ran clean on the integration branch tip before opening this PR:

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build -p webarkitlib-rs` — clean (zero warnings in new files)
- [x] `cargo build -p webarkitlib-rs --features ffi-backend` — clean (C++ shims compile)
- [x] `cargo clippy -p webarkitlib-rs` — clean on new modules
- [x] `cargo test -p webarkitlib-rs --lib` — **all unit tests pass**
- [x] `cargo test -p webarkitlib-rs --lib --features dual-mode` — **391 passed, 0 failed, 2 ignored** (includes all 4 dual-mode FFI parity tests)

## Reviewer checklist

- [x] All four M8 sub-PRs merged into `feat/m8-freak-detector` in order (M8-1 → M8-2 → M8-3 → M8-4)
- [x] No M7 stub types remain in `hough.rs` (`GaussianScaleSpacePyramid`, `DoGScaleInvariantDetector`, `Keyframe` placeholders all removed)
- [x] The four design docs under `docs/design/m8-*.md` accurately describe what landed (decision logs are append-only, no rewrites)
- [x] Dual-mode test tolerances are conservative (`|diff| ≤ small` rather than `== 0`) — CI on macOS/Linux may show small variance that we'd tighten to 0 in a follow-up if consistent
- [x] `CHANGELOG.md` not touched (release-only rule)
- [x] Branch targets `dev` (not `main`)
- [x] `find_features` mirrors C++ `vision::FindFeatures` signature `(keyframe, pyramid, detector)` order matches the data flow
- [x] `-ffp-contract=off` in `build.rs` (added in M8-2, still applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
