### PR TITLE
feat(tools): add annotate_corners HTML tool for absolute corner-error fixtures (#166)

### DIFF
--- a/tools/annotate_corners/README.md
+++ b/tools/annotate_corners/README.md
@@ -27,19 +27,41 @@ works.
 4. After the 4th click, the tool draws a dashed-white quadrilateral
    connecting the four corners — verify it tightly follows the printed
    marker boundary before exporting.
-5. Fill in your GitHub handle (`Annotator`), adjust `Tolerance (px)` if
+5. **Adjust individual corners (optional)**: after all 4 are placed,
+   click any row in the corner list to re-position that single corner.
+   The selected row highlights amber, the corresponding crosshair turns
+   amber and grows, and the next canvas click moves that one corner.
+   Press `Esc` to cancel without changing it.
+6. Fill in your GitHub handle (`Annotator`), adjust `Tolerance (px)` if
    the frame warrants it (default 2.0 px matches the M9 #152 envelope),
    and add any `Notes` (lighting, occlusion, motion blur, etc.).
-6. Click **Download JSON** to save `<image-name>.corners.json` to your
+7. Click **Download JSON** to save `<image-name>.corners.json` to your
    Downloads folder, or **Copy JSON to clipboard** for paste-into-editor
    workflows.
-7. Move both the image and the JSON into
+8. Move both the image and the JSON into
    `crates/core/tests/fixtures/annotated_frames/`.
+
+## Zoom
+
+For sub-pixel accuracy on small marker corners, scroll the mouse wheel
+over the canvas to zoom centered on the cursor. Range is 25%–800%; the
+current zoom level appears as a small overlay in the top-left of the
+canvas area. Use the **Reset zoom (100%)** button in the View panel or
+press `Ctrl/Cmd + 0` to return to 100%.
+
+Panning at high zoom uses the canvas-area scrollbars (the same overflow
+that handles oversized images at 100%); on a trackpad, two-finger drag
+on those scrollbars works as expected.
+
+`image-rendering: pixelated` is set on the canvas, so the underlying
+pixels stay crisp when you zoom in rather than blurring under the
+default bilinear filter — important for picking exact corner pixels.
 
 ## Keyboard shortcuts
 
-- `Ctrl/Cmd + Z` — undo last click
-- `Escape` — clear all clicks (start over for current image)
+- `Ctrl/Cmd + Z` — undo last click (during initial capture)
+- `Ctrl/Cmd + 0` — reset zoom to 100%
+- `Esc` — cancel edit mode if active, otherwise start over (clear all clicks)
 
 ## JSON schema produced
 

--- a/tools/annotate_corners/README.md
+++ b/tools/annotate_corners/README.md
@@ -1,0 +1,93 @@
+# `annotate_corners` — marker-corner annotation tool
+
+Standalone static HTML tool for producing the `.corners.json` ground-truth
+fixtures consumed by the absolute corner-error test gate (issue
+[#166](https://github.com/webarkit/WebARKitLib-rs/issues/166)).
+
+## What it does
+
+Given a query frame (JPEG / PNG) that contains a printed NFT marker, you
+click the **four printed-marker rectangle corners** in
+`top-left → top-right → bottom-right → bottom-left` order, and the tool
+writes a `.corners.json` file with the four pixel coordinates plus
+metadata.
+
+The order matters: it must match the reference image's corner ordering
+(`(0,0), (W,0), (W,H), (0,H)`) so the CI corner-by-corner comparison
+works.
+
+## How to use
+
+1. Open `index.html` directly in any modern browser. No server, no build
+   step, no dependencies — it's a single static file.
+2. Drag a query frame onto the canvas area (or use the file picker).
+3. Click each marker corner in the prompted order. The next-expected
+   corner is highlighted in the status panel. A live hover crosshair
+   helps you line up the click.
+4. After the 4th click, the tool draws a dashed-white quadrilateral
+   connecting the four corners — verify it tightly follows the printed
+   marker boundary before exporting.
+5. Fill in your GitHub handle (`Annotator`), adjust `Tolerance (px)` if
+   the frame warrants it (default 2.0 px matches the M9 #152 envelope),
+   and add any `Notes` (lighting, occlusion, motion blur, etc.).
+6. Click **Download JSON** to save `<image-name>.corners.json` to your
+   Downloads folder, or **Copy JSON to clipboard** for paste-into-editor
+   workflows.
+7. Move both the image and the JSON into
+   `crates/core/tests/fixtures/annotated_frames/`.
+
+## Keyboard shortcuts
+
+- `Ctrl/Cmd + Z` — undo last click
+- `Escape` — clear all clicks (start over for current image)
+
+## JSON schema produced
+
+See issue #166 for the canonical schema. The tool produces:
+
+```json
+{
+  "schema": 1,
+  "image": "pinball-demo.jpg",
+  "image_dims": [2000, 1500],
+  "annotator": "kalwalt",
+  "date": "2026-05-24",
+  "marker_corners_px": [
+    {"role": "top_left",     "x": 145.00, "y": 88.00},
+    {"role": "top_right",    "x": 612.50, "y": 92.30},
+    {"role": "bottom_right", "x": 605.20, "y": 815.40},
+    {"role": "bottom_left",  "x": 152.10, "y": 819.80}
+  ],
+  "tolerance_px": 2.0,
+  "notes": "Corners are the four printed-marker rectangle corners, in the same order as reference-image corners (0,0)/(W,0)/(W,H)/(0,H)."
+}
+```
+
+## Caveats
+
+- **Annotation noise floor** ~1–2 px even with zoom; do not set
+  `tolerance_px` tighter than that.
+- The browser's native page-zoom (`Ctrl+`/`Ctrl-`) works correctly —
+  click coordinates always resolve to native image pixels.
+- For very large images, scroll the canvas area; the page is laid out
+  with vertical and horizontal overflow on the canvas container.
+- The exported JSON's `image` field uses the file name only (no path);
+  the CI test discovers fixtures by scanning the directory, so file
+  names need to be unique.
+
+## When to use which mode
+
+- **Browser tool (this one)**: any frame where you can drag the JPEG
+  onto the page. Recommended.
+- **Manual via GIMP/Photoshop pointer readout**: zero tooling fallback
+  if the browser tool is unavailable for any reason. Tedious; transcribe
+  carefully and double-check ordering.
+
+## References
+
+- Issue [#166](https://github.com/webarkit/WebARKitLib-rs/issues/166) —
+  the absolute corner-error gate this tool feeds.
+- Issue [#160](https://github.com/webarkit/WebARKitLib-rs/issues/160) —
+  the divergence investigation that motivated the new gate.
+- `docs/design/m9-2-rust-backend.md` §10 — the §10 measurement that
+  established the cross-backend gap.

--- a/tools/annotate_corners/index.html
+++ b/tools/annotate_corners/index.html
@@ -1,0 +1,435 @@
+<!DOCTYPE html>
+<!--
+  index.html
+  WebARKitLib-rs
+
+  This file is part of WebARKitLib-rs - WebARKit.
+
+  WebARKitLib-rs is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  WebARKitLib-rs is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+
+  As a special exception, the copyright holders of this library give you
+  permission to link this library with independent modules to produce an
+  executable, regardless of the license terms of these independent modules, and to
+  copy and distribute the resulting executable under terms of your choice,
+  provided that you also meet, for each linked independent module, the terms and
+  conditions of the license of that module. An independent module is a module
+  which is neither derived from nor based on this library. If you modify this
+  library, you may extend this exception to your version of the library, but you
+  are not obligated to do so. If you do not wish to do so, delete this exception
+  statement from your version.
+
+  Copyright 2026 WebARKit.
+
+  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+
+  Marker-corner annotation tool for the WebARKitLib-rs absolute corner-error
+  test gate. See issue #166 for the gate's design and this tool's role in it.
+  Standalone static HTML — open the file directly in any modern browser,
+  no server or build step required.
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>WebARKitLib-rs — Corner annotator</title>
+  <style>
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #1d1f23; color: #e6e8eb; }
+    header { padding: 12px 20px; background: #14161a; border-bottom: 1px solid #2b2e34; }
+    header h1 { margin: 0; font-size: 18px; font-weight: 600; }
+    header p { margin: 4px 0 0; color: #95a0ab; font-size: 13px; }
+    main { display: grid; grid-template-columns: 1fr 380px; gap: 16px; padding: 16px; }
+    #canvasWrap { background: #0e1014; border: 1px dashed #3a3f47; border-radius: 6px; min-height: 480px; max-height: calc(100vh - 120px); overflow: auto; position: relative; }
+    #canvasWrap.dragover { border-color: #4ea1ff; background: #11202e; }
+    #canvas { display: block; cursor: crosshair; }
+    #placeholder { padding: 60px 20px; text-align: center; color: #687078; font-size: 14px; line-height: 1.6; }
+    #placeholder code { background: #0a0c0f; padding: 2px 6px; border-radius: 3px; color: #d8a4ff; }
+    .panel { background: #14161a; border: 1px solid #2b2e34; border-radius: 6px; padding: 14px; margin-bottom: 12px; }
+    .panel h2 { margin: 0 0 10px; font-size: 14px; font-weight: 600; letter-spacing: 0.02em; color: #c5cdd6; text-transform: uppercase; }
+    label { display: block; font-size: 12px; color: #95a0ab; margin: 6px 0 3px; }
+    input[type=text], input[type=number], textarea { width: 100%; padding: 7px 9px; background: #0e1014; border: 1px solid #2b2e34; color: #e6e8eb; border-radius: 4px; font-family: inherit; font-size: 13px; }
+    textarea { resize: vertical; min-height: 60px; }
+    button { width: 100%; padding: 9px 12px; margin-top: 6px; background: #2a4d7c; border: none; color: #fff; border-radius: 4px; font-size: 13px; cursor: pointer; font-weight: 500; }
+    button:hover:not(:disabled) { background: #356099; }
+    button:disabled { background: #2a2d33; color: #5a626c; cursor: not-allowed; }
+    button.secondary { background: #2d3036; }
+    button.secondary:hover:not(:disabled) { background: #3a3f47; }
+    button.primary { background: #2c8b4d; }
+    button.primary:hover:not(:disabled) { background: #34a85b; }
+    .status { padding: 10px 12px; border-radius: 4px; font-size: 14px; line-height: 1.4; }
+    .status.idle { background: #1f2228; color: #95a0ab; }
+    .status.awaiting { background: #2c3a52; color: #c5dbff; border-left: 3px solid #4ea1ff; }
+    .status.done { background: #1f3a2a; color: #b7e8c6; border-left: 3px solid #34a85b; }
+    .status .target { font-weight: 700; font-size: 16px; display: block; margin-top: 4px; }
+    .corners-list { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 12px; line-height: 1.7; }
+    .corners-list .row { display: flex; justify-content: space-between; padding: 3px 6px; border-radius: 3px; }
+    .corners-list .row.has-value { background: #1c2330; color: #d8e3f0; }
+    .corners-list .role { color: #95a0ab; }
+    .corners-list .coords { color: #d8a4ff; }
+    pre.json-output { background: #0a0c0f; border: 1px solid #2b2e34; border-radius: 4px; padding: 10px; font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; max-height: 240px; overflow: auto; color: #c5cdd6; white-space: pre-wrap; word-break: break-all; }
+    .row-split { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+    .hint { font-size: 11px; color: #687078; margin-top: 4px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>WebARKitLib-rs — Corner annotator</h1>
+    <p>Click the four printed-marker corners of a query frame in order: top-left → top-right → bottom-right → bottom-left. Export the resulting JSON for the absolute corner-error test gate (issue #166).</p>
+  </header>
+
+  <main>
+    <div id="canvasWrap">
+      <div id="placeholder">
+        Drop a JPEG / PNG query frame here, or use the file picker on the right.<br>
+        <br>
+        Click each marker corner in <strong>TL → TR → BR → BL</strong> order.<br>
+        The order must match the reference image's corners
+        (<code>(0,0), (W,0), (W,H), (0,H)</code>) so CI corner-by-corner comparison works.
+      </div>
+      <canvas id="canvas" width="0" height="0" style="display:none"></canvas>
+    </div>
+
+    <aside>
+      <div class="panel">
+        <h2>1. Load frame</h2>
+        <input type="file" id="fileInput" accept="image/*">
+        <p class="hint">Tip: you can also drag and drop the image onto the canvas area.</p>
+      </div>
+
+      <div class="panel">
+        <h2>2. Click corners</h2>
+        <div id="status" class="status idle">No image loaded yet.</div>
+        <div class="corners-list" id="cornersList">
+          <div class="row" data-i="0"><span class="role">1. top_left</span><span class="coords">—</span></div>
+          <div class="row" data-i="1"><span class="role">2. top_right</span><span class="coords">—</span></div>
+          <div class="row" data-i="2"><span class="role">3. bottom_right</span><span class="coords">—</span></div>
+          <div class="row" data-i="3"><span class="role">4. bottom_left</span><span class="coords">—</span></div>
+        </div>
+        <div class="row-split">
+          <button id="undoBtn" class="secondary" disabled>Undo last</button>
+          <button id="resetBtn" class="secondary" disabled>Start over</button>
+        </div>
+      </div>
+
+      <div class="panel">
+        <h2>3. Metadata</h2>
+        <label for="annotator">Annotator (GitHub handle)</label>
+        <input type="text" id="annotator" placeholder="kalwalt" />
+        <label for="tolerance">Tolerance (px)</label>
+        <input type="number" id="tolerance" value="2.0" step="0.5" min="0" />
+        <label for="notes">Notes (optional)</label>
+        <textarea id="notes" placeholder="e.g. lighting, marker visibility, occlusions"></textarea>
+      </div>
+
+      <div class="panel">
+        <h2>4. Export</h2>
+        <button id="exportBtn" class="primary" disabled>Download JSON</button>
+        <button id="copyBtn" class="secondary" disabled>Copy JSON to clipboard</button>
+        <pre id="jsonOut" class="json-output" hidden></pre>
+        <p class="hint">Saves alongside the image as <code>&lt;image-name&gt;.corners.json</code>. Drop into <code>crates/core/tests/fixtures/annotated_frames/</code>.</p>
+      </div>
+    </aside>
+  </main>
+
+  <script>
+  'use strict';
+
+  // ─────────────────────────────────────────────────────────────────────
+  // State
+  // ─────────────────────────────────────────────────────────────────────
+  const ROLES = ['top_left', 'top_right', 'bottom_right', 'bottom_left'];
+  const ROLE_LABELS = ['TOP-LEFT', 'TOP-RIGHT', 'BOTTOM-RIGHT', 'BOTTOM-LEFT'];
+  // Distinct visible colors for the 4 corners.
+  const COLORS = ['#ff5252', '#34a85b', '#4ea1ff', '#ffb74d'];
+
+  const state = {
+    image: null,         // HTMLImageElement once loaded
+    imageName: null,     // string, original file name
+    imageDims: [0, 0],   // [w, h]
+    corners: [],         // Array<{x: number, y: number}> in canvas/image px
+    cursor: null,        // {x, y} for the hover crosshair, or null
+  };
+
+  // ─────────────────────────────────────────────────────────────────────
+  // DOM
+  // ─────────────────────────────────────────────────────────────────────
+  const canvas = document.getElementById('canvas');
+  const canvasWrap = document.getElementById('canvasWrap');
+  const placeholder = document.getElementById('placeholder');
+  const fileInput = document.getElementById('fileInput');
+  const statusEl = document.getElementById('status');
+  const cornersList = document.getElementById('cornersList');
+  const undoBtn = document.getElementById('undoBtn');
+  const resetBtn = document.getElementById('resetBtn');
+  const exportBtn = document.getElementById('exportBtn');
+  const copyBtn = document.getElementById('copyBtn');
+  const jsonOut = document.getElementById('jsonOut');
+  const annotatorInput = document.getElementById('annotator');
+  const toleranceInput = document.getElementById('tolerance');
+  const notesInput = document.getElementById('notes');
+
+  const ctx = canvas.getContext('2d');
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Rendering
+  // ─────────────────────────────────────────────────────────────────────
+  function redraw() {
+    if (!state.image) return;
+    ctx.drawImage(state.image, 0, 0);
+
+    // Existing clicked corners with numbered crosshairs.
+    state.corners.forEach((c, i) => drawCrosshair(c.x, c.y, COLORS[i], String(i + 1)));
+
+    // Closed quad once all 4 are in.
+    if (state.corners.length === 4) {
+      ctx.beginPath();
+      ctx.strokeStyle = '#ffffff';
+      ctx.lineWidth = 2;
+      ctx.setLineDash([8, 4]);
+      state.corners.forEach((c, i) => {
+        if (i === 0) ctx.moveTo(c.x, c.y); else ctx.lineTo(c.x, c.y);
+      });
+      ctx.closePath();
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    // Hover crosshair for alignment, only while a target is pending.
+    if (state.cursor && state.corners.length < 4) {
+      drawCrosshair(state.cursor.x, state.cursor.y, COLORS[state.corners.length], null, true);
+    }
+  }
+
+  function drawCrosshair(x, y, color, label, faint = false) {
+    const r = 18;
+    ctx.strokeStyle = color;
+    ctx.lineWidth = faint ? 1 : 2;
+    ctx.globalAlpha = faint ? 0.45 : 1;
+    // Cross.
+    ctx.beginPath();
+    ctx.moveTo(x - r, y); ctx.lineTo(x + r, y);
+    ctx.moveTo(x, y - r); ctx.lineTo(x, y + r);
+    ctx.stroke();
+    // Inner ring.
+    ctx.beginPath();
+    ctx.arc(x, y, 4, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.globalAlpha = 1;
+    // Label
+    if (label) {
+      ctx.fillStyle = color;
+      ctx.font = 'bold 14px sans-serif';
+      ctx.fillText(label, x + r + 4, y - 6);
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────
+  // UI updates
+  // ─────────────────────────────────────────────────────────────────────
+  function refreshUI() {
+    // Status.
+    if (!state.image) {
+      statusEl.className = 'status idle';
+      statusEl.textContent = 'No image loaded yet.';
+    } else if (state.corners.length === 4) {
+      statusEl.className = 'status done';
+      statusEl.innerHTML = 'All 4 corners captured. Verify the dashed-white quad fits the marker, then export.';
+    } else {
+      const i = state.corners.length;
+      statusEl.className = 'status awaiting';
+      statusEl.innerHTML = 'Click the next corner:<span class="target" style="color:' + COLORS[i] + '">' + ROLE_LABELS[i] + '</span>';
+    }
+    // Corner list.
+    cornersList.querySelectorAll('.row').forEach((row, i) => {
+      const coordsEl = row.querySelector('.coords');
+      if (state.corners[i]) {
+        row.classList.add('has-value');
+        coordsEl.textContent = '(' + state.corners[i].x.toFixed(1) + ', ' + state.corners[i].y.toFixed(1) + ')';
+      } else {
+        row.classList.remove('has-value');
+        coordsEl.textContent = '—';
+      }
+    });
+    // Buttons.
+    undoBtn.disabled = state.corners.length === 0;
+    resetBtn.disabled = state.corners.length === 0;
+    const ready = state.image && state.corners.length === 4;
+    exportBtn.disabled = !ready;
+    copyBtn.disabled = !ready;
+    // JSON preview.
+    if (ready) {
+      jsonOut.hidden = false;
+      jsonOut.textContent = buildJson();
+    } else {
+      jsonOut.hidden = true;
+      jsonOut.textContent = '';
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────
+  // JSON output (canonical schema, matches issue #166)
+  // ─────────────────────────────────────────────────────────────────────
+  function buildJson() {
+    const obj = {
+      schema: 1,
+      image: state.imageName || 'unknown.jpg',
+      image_dims: [state.imageDims[0], state.imageDims[1]],
+      annotator: annotatorInput.value.trim() || 'unknown',
+      date: new Date().toISOString().slice(0, 10),
+      marker_corners_px: state.corners.map((c, i) => ({
+        role: ROLES[i],
+        x: Number(c.x.toFixed(2)),
+        y: Number(c.y.toFixed(2)),
+      })),
+      tolerance_px: Number(toleranceInput.value) || 2.0,
+      notes: notesInput.value.trim() || (
+        'Corners are the four printed-marker rectangle corners, ' +
+        'in the same order as reference-image corners ' +
+        '(0,0)/(W,0)/(W,H)/(0,H).'
+      ),
+    };
+    return JSON.stringify(obj, null, 2);
+  }
+
+  function exportJson() {
+    const blob = new Blob([buildJson()], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    const base = (state.imageName || 'corners').replace(/\.[^.]+$/, '');
+    a.download = base + '.corners.json';
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 100);
+  }
+
+  async function copyJson() {
+    try {
+      await navigator.clipboard.writeText(buildJson());
+      const oldText = copyBtn.textContent;
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => copyBtn.textContent = oldText, 1200);
+    } catch (e) {
+      alert('Clipboard write failed: ' + e.message);
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Image loading
+  // ─────────────────────────────────────────────────────────────────────
+  function loadFile(file) {
+    if (!file || !file.type.startsWith('image/')) {
+      alert('Please drop or pick an image file.');
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const img = new Image();
+      img.onload = () => {
+        state.image = img;
+        state.imageName = file.name;
+        state.imageDims = [img.naturalWidth, img.naturalHeight];
+        state.corners = [];
+        canvas.width = img.naturalWidth;
+        canvas.height = img.naturalHeight;
+        canvas.style.display = 'block';
+        placeholder.style.display = 'none';
+        redraw();
+        refreshUI();
+      };
+      img.onerror = () => alert('Failed to decode image.');
+      img.src = e.target.result;
+    };
+    reader.readAsDataURL(file);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Event handlers
+  // ─────────────────────────────────────────────────────────────────────
+  fileInput.addEventListener('change', (e) => loadFile(e.target.files[0]));
+
+  canvasWrap.addEventListener('dragover', (e) => { e.preventDefault(); canvasWrap.classList.add('dragover'); });
+  canvasWrap.addEventListener('dragleave', () => canvasWrap.classList.remove('dragover'));
+  canvasWrap.addEventListener('drop', (e) => {
+    e.preventDefault();
+    canvasWrap.classList.remove('dragover');
+    if (e.dataTransfer.files.length) loadFile(e.dataTransfer.files[0]);
+  });
+
+  // Convert a DOM mouse event into native-image pixel coordinates,
+  // accounting for any CSS scaling (browser-level Ctrl+/- zoom, etc.).
+  function clientToImagePx(ev) {
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    return {
+      x: (ev.clientX - rect.left) * scaleX,
+      y: (ev.clientY - rect.top) * scaleY,
+    };
+  }
+
+  canvas.addEventListener('mousemove', (ev) => {
+    if (!state.image) return;
+    state.cursor = clientToImagePx(ev);
+    redraw();
+  });
+
+  canvas.addEventListener('mouseleave', () => {
+    if (!state.image) return;
+    state.cursor = null;
+    redraw();
+  });
+
+  canvas.addEventListener('click', (ev) => {
+    if (!state.image || state.corners.length >= 4) return;
+    const p = clientToImagePx(ev);
+    // Clamp to image bounds (corners can lie on the edge but shouldn't go off).
+    p.x = Math.max(0, Math.min(canvas.width - 1, p.x));
+    p.y = Math.max(0, Math.min(canvas.height - 1, p.y));
+    state.corners.push(p);
+    redraw();
+    refreshUI();
+  });
+
+  undoBtn.addEventListener('click', () => {
+    if (state.corners.length === 0) return;
+    state.corners.pop();
+    redraw();
+    refreshUI();
+  });
+
+  resetBtn.addEventListener('click', () => {
+    state.corners = [];
+    redraw();
+    refreshUI();
+  });
+
+  exportBtn.addEventListener('click', exportJson);
+  copyBtn.addEventListener('click', copyJson);
+
+  // Live-update JSON preview when metadata changes.
+  [annotatorInput, toleranceInput, notesInput].forEach((el) =>
+    el.addEventListener('input', () => { if (state.corners.length === 4) refreshUI(); })
+  );
+
+  // Keyboard shortcuts.
+  document.addEventListener('keydown', (e) => {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    if (e.key === 'z' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); undoBtn.click(); }
+    if (e.key === 'Escape') resetBtn.click();
+  });
+
+  // Initial UI state.
+  refreshUI();
+  </script>
+</body>
+</html>

--- a/tools/annotate_corners/index.html
+++ b/tools/annotate_corners/index.html
@@ -51,7 +51,9 @@
     main { display: grid; grid-template-columns: 1fr 380px; gap: 16px; padding: 16px; }
     #canvasWrap { background: #0e1014; border: 1px dashed #3a3f47; border-radius: 6px; min-height: 480px; max-height: calc(100vh - 120px); overflow: auto; position: relative; }
     #canvasWrap.dragover { border-color: #4ea1ff; background: #11202e; }
-    #canvas { display: block; cursor: crosshair; }
+    #canvas { display: block; cursor: crosshair; transform-origin: 0 0; image-rendering: pixelated; image-rendering: crisp-edges; }
+    #zoomHud { position: sticky; top: 6px; left: 6px; display: inline-block; background: rgba(20,22,26,0.85); color: #c5cdd6; padding: 4px 8px; border-radius: 4px; font-size: 12px; font-family: ui-monospace, "SF Mono", Menlo, monospace; pointer-events: none; z-index: 10; }
+    #zoomHud.hidden { display: none; }
     #placeholder { padding: 60px 20px; text-align: center; color: #687078; font-size: 14px; line-height: 1.6; }
     #placeholder code { background: #0a0c0f; padding: 2px 6px; border-radius: 3px; color: #d8a4ff; }
     .panel { background: #14161a; border: 1px solid #2b2e34; border-radius: 6px; padding: 14px; margin-bottom: 12px; }
@@ -72,10 +74,17 @@
     .status.done { background: #1f3a2a; color: #b7e8c6; border-left: 3px solid #34a85b; }
     .status .target { font-weight: 700; font-size: 16px; display: block; margin-top: 4px; }
     .corners-list { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 12px; line-height: 1.7; }
-    .corners-list .row { display: flex; justify-content: space-between; padding: 3px 6px; border-radius: 3px; }
+    .corners-list .row { display: flex; justify-content: space-between; padding: 3px 6px; border-radius: 3px; cursor: default; user-select: none; }
     .corners-list .row.has-value { background: #1c2330; color: #d8e3f0; }
+    .corners-list .row.has-value.clickable { cursor: pointer; }
+    .corners-list .row.has-value.clickable:hover { background: #243044; }
+    .corners-list .row.editing { background: #3a2e1c !important; border-left: 3px solid #ffb74d; padding-left: 3px; }
+    .corners-list .row.editing .role { color: #ffb74d; font-weight: 700; }
     .corners-list .role { color: #95a0ab; }
     .corners-list .coords { color: #d8a4ff; }
+    .corners-list .edit-hint { display: none; font-size: 10px; color: #687078; padding: 4px 6px 0; }
+    .corners-list.editable .edit-hint { display: block; }
+    .status.editing { background: #3a2e1c; color: #ffd9a8; border-left: 3px solid #ffb74d; }
     pre.json-output { background: #0a0c0f; border: 1px solid #2b2e34; border-radius: 4px; padding: 10px; font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; max-height: 240px; overflow: auto; color: #c5cdd6; white-space: pre-wrap; word-break: break-all; }
     .row-split { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
     .hint { font-size: 11px; color: #687078; margin-top: 4px; }
@@ -96,6 +105,7 @@
         The order must match the reference image's corners
         (<code>(0,0), (W,0), (W,H), (0,H)</code>) so CI corner-by-corner comparison works.
       </div>
+      <div id="zoomHud" class="hidden">100%</div>
       <canvas id="canvas" width="0" height="0" style="display:none"></canvas>
     </div>
 
@@ -114,11 +124,18 @@
           <div class="row" data-i="1"><span class="role">2. top_right</span><span class="coords">—</span></div>
           <div class="row" data-i="2"><span class="role">3. bottom_right</span><span class="coords">—</span></div>
           <div class="row" data-i="3"><span class="role">4. bottom_left</span><span class="coords">—</span></div>
+          <div class="edit-hint">Click a row above to re-position that single corner. Esc to cancel.</div>
         </div>
         <div class="row-split">
           <button id="undoBtn" class="secondary" disabled>Undo last</button>
           <button id="resetBtn" class="secondary" disabled>Start over</button>
         </div>
+      </div>
+
+      <div class="panel">
+        <h2>View</h2>
+        <p class="hint">Scroll-wheel over the image to zoom (centered on the cursor). Scrollbars on the canvas area handle panning.</p>
+        <button id="zoomResetBtn" class="secondary" disabled>Reset zoom (100%)</button>
       </div>
 
       <div class="panel">
@@ -158,7 +175,13 @@
     imageDims: [0, 0],   // [w, h]
     corners: [],         // Array<{x: number, y: number}> in canvas/image px
     cursor: null,        // {x, y} for the hover crosshair, or null
+    editIndex: null,     // index of corner being re-positioned post-completion, or null
+    zoom: 1.0,           // CSS scale applied to the canvas
   };
+
+  const ZOOM_MIN = 0.25;
+  const ZOOM_MAX = 8.0;
+  const ZOOM_STEP = 1.2;
 
   // ─────────────────────────────────────────────────────────────────────
   // DOM
@@ -177,6 +200,8 @@
   const annotatorInput = document.getElementById('annotator');
   const toleranceInput = document.getElementById('tolerance');
   const notesInput = document.getElementById('notes');
+  const zoomHud = document.getElementById('zoomHud');
+  const zoomResetBtn = document.getElementById('zoomResetBtn');
 
   const ctx = canvas.getContext('2d');
 
@@ -187,10 +212,7 @@
     if (!state.image) return;
     ctx.drawImage(state.image, 0, 0);
 
-    // Existing clicked corners with numbered crosshairs.
-    state.corners.forEach((c, i) => drawCrosshair(c.x, c.y, COLORS[i], String(i + 1)));
-
-    // Closed quad once all 4 are in.
+    // Closed quad once all 4 are in (drawn first so crosshairs sit on top).
     if (state.corners.length === 4) {
       ctx.beginPath();
       ctx.strokeStyle = '#ffffff';
@@ -204,16 +226,35 @@
       ctx.setLineDash([]);
     }
 
-    // Hover crosshair for alignment, only while a target is pending.
-    if (state.cursor && state.corners.length < 4) {
-      drawCrosshair(state.cursor.x, state.cursor.y, COLORS[state.corners.length], null, true);
+    // Existing clicked corners with numbered crosshairs. The corner
+    // being edited gets a thicker, pulsing-amber emphasis.
+    state.corners.forEach((c, i) =>
+      drawCrosshair(c.x, c.y, COLORS[i], String(i + 1), false, i === state.editIndex)
+    );
+
+    // Hover crosshair for alignment — show when capturing the next
+    // sequential corner, or when in edit mode for any corner.
+    if (state.cursor) {
+      const targetIdx = activeTargetIndex();
+      if (targetIdx !== null) {
+        drawCrosshair(state.cursor.x, state.cursor.y, COLORS[targetIdx], null, true);
+      }
     }
   }
 
-  function drawCrosshair(x, y, color, label, faint = false) {
-    const r = 18;
-    ctx.strokeStyle = color;
-    ctx.lineWidth = faint ? 1 : 2;
+  /// Returns the index of the corner the next canvas click will set:
+  /// the next-in-sequence corner during initial capture, the edited
+  /// corner during edit mode, or null if there's nothing to capture.
+  function activeTargetIndex() {
+    if (state.editIndex !== null) return state.editIndex;
+    if (state.corners.length < 4) return state.corners.length;
+    return null;
+  }
+
+  function drawCrosshair(x, y, color, label, faint = false, emphasis = false) {
+    const r = emphasis ? 26 : 18;
+    ctx.strokeStyle = emphasis ? '#ffb74d' : color;
+    ctx.lineWidth = emphasis ? 3 : (faint ? 1 : 2);
     ctx.globalAlpha = faint ? 0.45 : 1;
     // Cross.
     ctx.beginPath();
@@ -222,12 +263,12 @@
     ctx.stroke();
     // Inner ring.
     ctx.beginPath();
-    ctx.arc(x, y, 4, 0, Math.PI * 2);
+    ctx.arc(x, y, emphasis ? 7 : 4, 0, Math.PI * 2);
     ctx.stroke();
     ctx.globalAlpha = 1;
     // Label
     if (label) {
-      ctx.fillStyle = color;
+      ctx.fillStyle = emphasis ? '#ffb74d' : color;
       ctx.font = 'bold 14px sans-serif';
       ctx.fillText(label, x + r + 4, y - 6);
     }
@@ -237,37 +278,47 @@
   // UI updates
   // ─────────────────────────────────────────────────────────────────────
   function refreshUI() {
+    const complete = state.corners.length === 4;
+    const editing = state.editIndex !== null;
+
     // Status.
     if (!state.image) {
       statusEl.className = 'status idle';
       statusEl.textContent = 'No image loaded yet.';
-    } else if (state.corners.length === 4) {
+    } else if (editing) {
+      statusEl.className = 'status editing';
+      statusEl.innerHTML = 'Re-positioning corner:<span class="target" style="color:#ffb74d">' +
+        ROLE_LABELS[state.editIndex] + '</span>Click anywhere on the canvas to place it. Esc to cancel.';
+    } else if (complete) {
       statusEl.className = 'status done';
-      statusEl.innerHTML = 'All 4 corners captured. Verify the dashed-white quad fits the marker, then export.';
+      statusEl.innerHTML = 'All 4 corners captured. Click a row below to re-position one corner, or export.';
     } else {
       const i = state.corners.length;
       statusEl.className = 'status awaiting';
       statusEl.innerHTML = 'Click the next corner:<span class="target" style="color:' + COLORS[i] + '">' + ROLE_LABELS[i] + '</span>';
     }
-    // Corner list.
+    // Corner list rows.
+    cornersList.classList.toggle('editable', complete);
     cornersList.querySelectorAll('.row').forEach((row, i) => {
       const coordsEl = row.querySelector('.coords');
       if (state.corners[i]) {
         row.classList.add('has-value');
+        row.classList.toggle('clickable', complete);
+        row.classList.toggle('editing', i === state.editIndex);
         coordsEl.textContent = '(' + state.corners[i].x.toFixed(1) + ', ' + state.corners[i].y.toFixed(1) + ')';
       } else {
-        row.classList.remove('has-value');
+        row.classList.remove('has-value', 'clickable', 'editing');
         coordsEl.textContent = '—';
       }
     });
     // Buttons.
-    undoBtn.disabled = state.corners.length === 0;
+    undoBtn.disabled = state.corners.length === 0 || editing;
     resetBtn.disabled = state.corners.length === 0;
-    const ready = state.image && state.corners.length === 4;
-    exportBtn.disabled = !ready;
-    copyBtn.disabled = !ready;
+    exportBtn.disabled = !(state.image && complete) || editing;
+    copyBtn.disabled = !(state.image && complete) || editing;
+    zoomResetBtn.disabled = !state.image || Math.abs(state.zoom - 1) < 1e-3;
     // JSON preview.
-    if (ready) {
+    if (state.image && complete) {
       jsonOut.hidden = false;
       jsonOut.textContent = buildJson();
     } else {
@@ -339,10 +390,17 @@
         state.imageName = file.name;
         state.imageDims = [img.naturalWidth, img.naturalHeight];
         state.corners = [];
+        state.editIndex = null;
+        state.zoom = 1.0;
         canvas.width = img.naturalWidth;
         canvas.height = img.naturalHeight;
         canvas.style.display = 'block';
+        canvas.style.transform = 'scale(1)';
         placeholder.style.display = 'none';
+        zoomHud.textContent = '100%';
+        zoomHud.classList.remove('hidden');
+        canvasWrap.scrollLeft = 0;
+        canvasWrap.scrollTop = 0;
         redraw();
         refreshUI();
       };
@@ -390,18 +448,37 @@
   });
 
   canvas.addEventListener('click', (ev) => {
-    if (!state.image || state.corners.length >= 4) return;
+    if (!state.image) return;
+    const targetIdx = activeTargetIndex();
+    if (targetIdx === null) return;
     const p = clientToImagePx(ev);
     // Clamp to image bounds (corners can lie on the edge but shouldn't go off).
     p.x = Math.max(0, Math.min(canvas.width - 1, p.x));
     p.y = Math.max(0, Math.min(canvas.height - 1, p.y));
-    state.corners.push(p);
+    if (state.editIndex !== null) {
+      state.corners[state.editIndex] = p;
+      state.editIndex = null;
+    } else {
+      state.corners.push(p);
+    }
+    redraw();
+    refreshUI();
+  });
+
+  // Click a corner row (post-completion) to enter edit mode for that corner.
+  cornersList.addEventListener('click', (ev) => {
+    const row = ev.target.closest('.row');
+    if (!row) return;
+    const i = Number(row.dataset.i);
+    if (!Number.isInteger(i) || !state.corners[i] || state.corners.length !== 4) return;
+    state.editIndex = (state.editIndex === i) ? null : i;
     redraw();
     refreshUI();
   });
 
   undoBtn.addEventListener('click', () => {
     if (state.corners.length === 0) return;
+    state.editIndex = null;
     state.corners.pop();
     redraw();
     refreshUI();
@@ -409,9 +486,44 @@
 
   resetBtn.addEventListener('click', () => {
     state.corners = [];
+    state.editIndex = null;
     redraw();
     refreshUI();
   });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Zoom (CSS transform on the canvas; container scrollbars handle pan)
+  // ─────────────────────────────────────────────────────────────────────
+  function setZoom(z, anchorClientX, anchorClientY) {
+    if (!state.image) return;
+    const oldZoom = state.zoom;
+    const newZoom = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, z));
+    if (Math.abs(newZoom - oldZoom) < 1e-4) return;
+    state.zoom = newZoom;
+    canvas.style.transform = 'scale(' + newZoom + ')';
+    zoomHud.textContent = Math.round(newZoom * 100) + '%';
+    zoomHud.classList.remove('hidden');
+    // Adjust scroll so the anchor point (mouse cursor by default) stays
+    // visually pinned across the zoom change.
+    if (typeof anchorClientX === 'number' && typeof anchorClientY === 'number') {
+      const rect = canvasWrap.getBoundingClientRect();
+      const factor = newZoom / oldZoom;
+      const ax = anchorClientX - rect.left;
+      const ay = anchorClientY - rect.top;
+      canvasWrap.scrollLeft = (canvasWrap.scrollLeft + ax) * factor - ax;
+      canvasWrap.scrollTop = (canvasWrap.scrollTop + ay) * factor - ay;
+    }
+    refreshUI();
+  }
+
+  canvasWrap.addEventListener('wheel', (ev) => {
+    if (!state.image) return;
+    ev.preventDefault();
+    const factor = ev.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP;
+    setZoom(state.zoom * factor, ev.clientX, ev.clientY);
+  }, { passive: false });
+
+  zoomResetBtn.addEventListener('click', () => setZoom(1.0));
 
   exportBtn.addEventListener('click', exportJson);
   copyBtn.addEventListener('click', copyJson);
@@ -425,7 +537,16 @@
   document.addEventListener('keydown', (e) => {
     if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
     if (e.key === 'z' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); undoBtn.click(); }
-    if (e.key === 'Escape') resetBtn.click();
+    if (e.key === 'Escape') {
+      if (state.editIndex !== null) {
+        state.editIndex = null;
+        redraw();
+        refreshUI();
+      } else {
+        resetBtn.click();
+      }
+    }
+    if (e.key === '0' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); setZoom(1.0); }
   });
 
   // Initial UI state.


### PR DESCRIPTION
Refs #166. **Track A, PR 1 of 3** for the absolute corner-error gate work.

## Summary

Lands `tools/annotate_corners/` — a standalone static HTML annotator for producing the `.corners.json` ground-truth fixtures the new test gate will consume.

- **Single file** (`index.html`, ~430 lines, vanilla JS) — no server, no build step, no dependencies. Open the file directly in any modern browser.
- **Companion README** explaining usage, schema, keyboard shortcuts, caveats, and the relationship to issues #166 / #160.

## How it works

1. Drag a JPEG/PNG query frame onto the canvas (or use the file picker).
2. Click each marker corner in `TL → TR → BR → BL` order. The next-expected target is shown in a colored status panel, and a live hover crosshair (in that corner's color) helps you line up the click.
3. After the 4th click, a dashed-white quadrilateral overlays the four points so you can visually verify the result tightly follows the printed marker boundary before exporting.
4. Fill in `Annotator` (GitHub handle), adjust `Tolerance (px)` if the frame warrants it, optional `Notes`.
5. Click **Download JSON** (saves `<image-name>.corners.json`) or **Copy JSON to clipboard**.

The JSON matches the canonical schema specified in issue #166 §"Storage format".

## Design notes

- Canvas at native image resolution; click coordinates resolved via `getBoundingClientRect`-scaled math so browser-level page zoom (Ctrl+/-) works correctly.
- Color-coded crosshairs (red / green / blue / orange) and numbered labels keep the four ordered corners visually distinct on the canvas.
- Live JSON preview updates as you click and as you edit metadata.
- Keyboard shortcuts: `Ctrl/Cmd+Z` undo last point, `Esc` start over.
- LGPL-3.0 license header in HTML comment form, matching the Rust source-file convention.

## What this PR explicitly does NOT do

- It does not annotate any frames (PR 2 lands fixtures for `pinball-demo.jpg` + 4 new images you'll click yourself).
- It does not introduce a CI gate (PR 3 lands the Rust integration test that consumes the fixtures).
- It does not modify any existing source or test files.

Per CLAUDE.md "one issue per branch" discipline — clean PR1 of the agreed three-PR split.

## Test plan

- [x] HTML file parses; file size 435 lines.
- [x] **Manual verification (over to you)** — open `tools/annotate_corners/index.html` in a browser, drop in `crates/core/examples/Data/pinball-demo.jpg`, click 4 corners, confirm:
  - the quad overlays correctly,
  - the JSON preview updates live,
  - the Download JSON button saves a file named `pinball-demo.corners.json`,
  - the JSON validates against the schema in issue #166.

I can't run a browser from this environment, so the click-through verification is on the human reviewer.

## Refs

- Refs #166 — the gate this tool feeds
- Refs #160 — the divergence investigation
- Refs #165 — visualization that motivated #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)