### PR TITLE
fix(kpm): use BTreeMap for Hough vote tally and VisualDatabase keyframes to remove Rust-side matcher nondeterminism (refs #170)

### DIFF
--- a/crates/core/src/kpm/freak/hough.rs
+++ b/crates/core/src/kpm/freak/hough.rs
@@ -43,7 +43,7 @@
 
 use crate::kpm::backend::KpmError;
 use crate::{arlog_d, arlog_e, arlog_i};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use super::math::{fast_median_f32, safe_division_f32};
 
@@ -313,7 +313,14 @@ pub struct HoughSimilarityVoting {
     pub ref_image_width: i32,
     pub ref_image_height: i32,
     /// Vote map: bin_index → vote count.
-    votes: HashMap<i32, i32>,
+    ///
+    /// `BTreeMap` (not `HashMap`) guarantees deterministic iteration order
+    /// across runs. With `HashMap`, Rust's per-process `RandomState` would
+    /// make `get_maximum_votes`' tie-breaking (`max_by_key` returns the
+    /// last equal element in iteration order) non-deterministic across
+    /// runs — a documented source of intra-Rust matcher variance, see
+    /// issue #170.
+    votes: BTreeMap<i32, i32>,
 }
 
 impl HoughSimilarityVoting {
@@ -342,7 +349,7 @@ impl HoughSimilarityVoting {
             center_y,
             ref_image_width,
             ref_image_height,
-            votes: HashMap::new(),
+            votes: BTreeMap::new(),
         })
     }
 

--- a/crates/core/src/kpm/freak/visual_database.rs
+++ b/crates/core/src/kpm/freak/visual_database.rs
@@ -71,7 +71,7 @@
 //! [`matched_db_id`]: VisualDatabase::matched_db_id
 //! [`matched_geometry`]: VisualDatabase::matched_geometry
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use purecv::core::Matrix;
 
@@ -174,8 +174,18 @@ type MatchOutcome = Option<(Vec<Match>, [f32; 9])>;
 /// `docs/design/m9-1-visual-database.md`).
 pub struct VisualDatabase {
     /// Reference keyframes, keyed by user-supplied id.
-    /// Mirrors C++ `mKeyframeMap` (`std::unordered_map<id_t, keyframe_ptr_t>`).
-    pub keyframes: HashMap<usize, Keyframe>,
+    ///
+    /// Mirrors C++ `mKeyframeMap` (`std::unordered_map<id_t, keyframe_ptr_t>`),
+    /// but we deliberately use `BTreeMap` here for **intra-Rust
+    /// determinism**: [`query`] iterates the keyframes and breaks ties on
+    /// inlier-count with a strict `>` (first match wins). With a hashed
+    /// iteration order, the winning keyframe on borderline ties would
+    /// depend on Rust's per-process `RandomState`, producing run-to-run
+    /// `matched_id` variance — see issue #170. `BTreeMap`'s ascending-key
+    /// order makes the tie-breaking deterministic. Note this doesn't
+    /// achieve cross-language parity with C++ (C++ `unordered_map` still
+    /// has implementation-defined order); see #170 for that broader fix.
+    pub keyframes: BTreeMap<usize, Keyframe>,
 
     // Pipeline components (private state)
     matcher: FeatureMatcher,
@@ -231,7 +241,7 @@ impl VisualDatabase {
             HOMOGRAPHY_DEFAULT_CHUNK_SIZE,
         );
         Ok(Self {
-            keyframes: HashMap::new(),
+            keyframes: BTreeMap::new(),
             matcher: FeatureMatcher::new(),
             homography,
             detector,


### PR DESCRIPTION
Refs #170. **Closes the Rust side** of the matcher non-determinism issue. The C++ side remains open in #170.

## Summary

Two `HashMap` usages in the Rust matching pipeline were producing run-to-run nondeterministic output because their iteration order is randomized by Rust's per-process `RandomState`. Both are mechanically replaced with `BTreeMap` (deterministic ascending-key iteration), following the pattern `freak/clustering.rs` already established (see the comment at line 499).

## The two culprits

**1. `HoughSimilarityVoting::votes`** — the bin→vote tally consumed by `get_maximum_votes`:

```rust
self.votes.iter().max_by_key(|&(_, &count)| count)
```

Per the `Iterator::max_by_key` docs, this returns the **last** equal element in iteration order. With `HashMap`, "last in iteration order" is `RandomState`-dependent. When two Hough bins tie on vote count — common at borderline matches — the winning bin depended on which run the process happened to be. This was the primary cause of pinball-seq2's `matched_id` flipping between consecutive runs (the original #170 repro).

**2. `VisualDatabase::keyframes`** — the keyframe collection iterated by `query`:

```rust
let ids: Vec<usize> = self.keyframes.keys().copied().collect();
for id in ids {
    if let Some((inliers, h)) = self.try_match_one(...) {
        if inliers.len() >= self.min_num_inliers
            && inliers.len() > self.inliers.len()  // strict >: first match wins on ties
        {
            // ...
        }
    }
}
```

Strict-`>` tie-breaking + randomized iteration order = which keyframe wins on inlier-count ties depends on hash seed.

## Verification

- ✅ **5 consecutive normal-mode runs** of the corner-error gate (#169) locally on Windows produce **identical per-cell numbers**. Previously this varied beyond the 0.5 px epsilon on pinball-seq2 between runs.
- ✅ All 264 kpm unit tests pass, including the M9-2 milestone gate `test_dual_mode_no_divergence_on_pinball`.
- ✅ `cargo fmt --all -- --check` clean.
- ✅ `cargo clippy --all-targets --all-features -- --deny warnings` exit 0.
- ✅ The committed Linux-derived `baseline.json` from #169 still passes locally on Windows under the 2.0 px epsilon — the fix doesn't shift per-cell numbers enough to break the cross-platform gate.

## What this does NOT fix

- **C++ cross-platform variance** (`std::unordered_map` iteration order differs between MSVC STL and libstdc++) — that's the still-open part of #170, needs an upstream change in `third_party/WebARKitLib`.
- **Cross-language Rust↔C++ parity** — even with BTreeMap (ascending-key), Rust's tie-breaking will differ from C++'s hashed tie-breaking at borderline matches. §10 of `docs/design/m9-2-rust-backend.md` already documents this as the BHC-variance envelope.

## What this unlocks (in follow-up PRs)

Once the C++ side of #170 also lands and CI re-runs on Linux:

1. `REGRESSION_EPSILON_PX` in `absolute_corner_error.rs` can drop from 2.0 back to ~0.5 px.
2. `pinball-demo`, `pinball-seq2`, `pinball-seq3` can be restored to the fixture set (dropped in #169 because of the C++ flip and the Rust HashMap flip respectively).
3. The gate transitions from "loose-tolerance regression detector" to "tight cross-platform precision check".

## Test plan

- [x] `cargo build --tests --features dual-mode` succeeds
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- --deny warnings` exit 0
- [x] `cargo test --features dual-mode --lib kpm` — 264 passed, 1 ignored
- [x] `cargo test --test absolute_corner_error --features dual-mode` passes
- [x] 5 consecutive normal-mode gate runs all produce identical numbers

## Refs

- Refs #170 — addresses the Rust half; C++ half stays open
- Refs #169 (merged) — the gate that surfaced this
- Refs #160 (closed) — the divergence investigation that started the thread
- Refs #142 (M9-3) — relevant context: pre-flip, fixing this means Rust is fully deterministic per-process when M9-3 makes it the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)