### PR TITLE
fix(kpm): tighten dual-mode FFI extern cfg to match caller cfg (#180)

### DIFF
--- a/.claude/issue-180-plan.md
+++ b/.claude/issue-180-plan.md
@@ -26,7 +26,7 @@
 | # | Decision | Alternatives considered | Why this choice |
 |---|---|---|---|
 | 1 | Follow #180's 5-PR sequence verbatim | Refine ordering; merge PRs; re-baseline lint counts first | Issue is well-scoped; counts may drift but plan structure is sound |
-| 2 | PR 2 default posture: `#[allow(dead_code)]` + `// rationale:` on extern blocks; delete only the truly orphaned ones | Wire up callers (scope creep); bulk delete (irreversible); case-by-case triage (review burden) | Lowest risk; zero behavior change; honest about why shims exist (dual-mode parity) |
+| 2 | **(Updated during PR 2)** Tighten each extern block's cfg from `#[cfg(feature = "dual-mode")]` to `#[cfg(all(test, feature = "dual-mode"))]` — matches caller cfg, lint disappears because the extern only exists when callers do. Originally planned `#[allow(dead_code)]` + rationale. | Original plan (allow + rationale); wire up callers (scope creep); bulk delete (irreversible) | Evidence at PR 2 time: all 17 "dead" shims have callers, but the callers are gated `cfg(all(test, feature = "dual-mode"))` while the extern blocks were gated only on `cfg(feature = "dual-mode")`. The cfg mismatch was the real root cause; tightening fixes it honestly. Same effort per block (one line), zero behavior change. |
 | 3 | PR 4: inline `#[allow(clippy::too_many_arguments)]` + rationale on `get_similarity_sse41` / `get_similarity_avx2` | `clippy.toml` threshold raise; bundle args into struct | SIMD signatures locked by runtime-dispatch contract; inline is scoped, threshold raise loses signal everywhere |
 | 4 | Defer `clippy.toml` | Add now with `too-many-arguments-threshold = 9` | Only 2 sites today; revisit when SIMD surface grows in M10+ |
 | 5 | Keep CI on `dtolnay/rust-toolchain@stable` after PR 5 | Pin to a specific rustc version; document known-good rustc | Accept the churn; v0.7.0 is shipped, future rustc lint additions fix in follow-up PRs |
@@ -81,9 +81,7 @@ cargo test --all-features
 **Branch**: `chore/clippy-180-pr2-ffi-shims`
 **Scope**: `crates/core/src/kpm/freak/{clustering,homography,math,hough,matcher}.rs` — for each dead `extern "C" { fn webarkit_cpp_*(...) }` block:
 
-1. Run `cargo test --features dual-mode --lib` and `cargo test --features ffi-backend` to find which shims actually have callers.
-2. **If a caller exists** (under any feature combo): add `#[allow(dead_code)]` to the extern block (or to the specific item) with `// rationale: dual-mode parity shim; called from <module>::<test> under --features dual-mode`.
-3. **If no caller exists anywhere**: delete the extern declaration. Note the deletion in the PR body for reviewer scrutiny.
+**Implemented (Decision #2 updated)**: change each block's cfg gate from `#[cfg(feature = "dual-mode")]` to `#[cfg(all(test, feature = "dual-mode"))]` so the extern only exists when its caller (also `cfg(all(test, feature = "dual-mode"))`) does. Add a one-line comment above each block referencing #180 for traceability. Verified all 17 callers still resolve and dual-mode tests still pass.
 
 **Verification**: same triad as PR 1, plus `cargo test --features dual-mode --lib` and `cargo test --features ffi-backend` green.
 

--- a/crates/core/src/kpm/freak/clustering.rs
+++ b/crates/core/src/kpm/freak/clustering.rs
@@ -1047,7 +1047,10 @@ mod tests {
 // from math/rand.h). This is what enables the BHC-indexed match dual-mode
 // test in matcher.rs to assert pair equality with C++ rather than count-only.
 
-#[cfg(feature = "dual-mode")]
+// Only ever called from `#[cfg(all(test, feature = "dual-mode"))]`
+// modules below; gate the extern declaration the same way so the lib
+// target under --all-features doesn't see a phantom dead symbol (#180).
+#[cfg(all(test, feature = "dual-mode"))]
 extern "C" {
     fn webarkit_cpp_fast_random(seed: *mut i32) -> i32;
     fn webarkit_cpp_array_shuffle(v: *mut i32, pop_size: i32, sample_size: i32, seed: *mut i32);

--- a/crates/core/src/kpm/freak/homography.rs
+++ b/crates/core/src/kpm/freak/homography.rs
@@ -2813,7 +2813,10 @@ mod tests {
 // and the final homography agrees element-wise within accumulated float
 // rounding (~1e-5).
 
-#[cfg(feature = "dual-mode")]
+// Only ever called from `#[cfg(all(test, feature = "dual-mode"))]`
+// modules below; gate the extern declaration the same way so the lib
+// target under --all-features doesn't see a phantom dead symbol (#180).
+#[cfg(all(test, feature = "dual-mode"))]
 extern "C" {
     fn webarkit_cpp_mat3_exp_pade_via_eigen(out: *mut f32, input: *const f32);
 

--- a/crates/core/src/kpm/freak/hough.rs
+++ b/crates/core/src/kpm/freak/hough.rs
@@ -1195,7 +1195,10 @@ mod tests {
 // the algorithm level, separately from the end-to-end VisualDatabase
 // parity gate in `visual_database.rs`.
 
-#[cfg(feature = "dual-mode")]
+// Only ever called from `#[cfg(all(test, feature = "dual-mode"))]`
+// modules below; gate the extern declaration the same way so the lib
+// target under --all-features doesn't see a phantom dead symbol (#180).
+#[cfg(all(test, feature = "dual-mode"))]
 extern "C" {
     /// M9 #150: reimplementation of `HoughSimilarityVoting::autoAdjustXYNumBins`
     /// in `kpm_c_api.cpp` (the C++ method is private, so the shim ports the

--- a/crates/core/src/kpm/freak/matcher.rs
+++ b/crates/core/src/kpm/freak/matcher.rs
@@ -805,7 +805,10 @@ mod tests {
 // assert that the match counts agree within a small tolerance (BHC RNG
 // differences and minor floating-point order can cause small variation).
 
-#[cfg(feature = "dual-mode")]
+// Only ever called from `#[cfg(all(test, feature = "dual-mode"))]`
+// modules below; gate the extern declaration the same way so the lib
+// target under --all-features doesn't see a phantom dead symbol (#180).
+#[cfg(all(test, feature = "dual-mode"))]
 extern "C" {
     fn webarkit_cpp_match_features_brute(
         query_descs: *const u8,

--- a/crates/core/src/kpm/freak/math.rs
+++ b/crates/core/src/kpm/freak/math.rs
@@ -2106,7 +2106,10 @@ mod tests {
 // the input domain and assert that the pure-Rust ports produce results within
 // a small tolerance of the C++ baseline.
 
-#[cfg(feature = "dual-mode")]
+// Only ever called from `#[cfg(all(test, feature = "dual-mode"))]`
+// modules below; gate the extern declaration the same way so the lib
+// target under --all-features doesn't see a phantom dead symbol (#180).
+#[cfg(all(test, feature = "dual-mode"))]
 extern "C" {
     // M6-1 (#63) — math_utils.h
     fn webarkit_cpp_fast_atan2(y: f32, x: f32) -> f32;


### PR DESCRIPTION
## Summary

PR 2 of 5 in the [#180](https://github.com/webarkit/WebARKitLib-rs/issues/180) series. Clears all 17 dead `webarkit_cpp_*` extern declarations flagged by `cargo clippy --all-targets --all-features -- -D warnings`.

**Baseline drops from 43 → 24 errors.** Remaining 24 partition cleanly into PR 3 (22 × `field_reassign_with_default` in `ar/marker.rs`) and PR 4 (2 × `too_many_arguments` on SIMD `get_similarity` variants).

## Root cause

Each `extern "C"` block was gated `#[cfg(feature = "dual-mode")]`, but its **only callers** live in modules gated `#[cfg(all(test, feature = "dual-mode"))]` in the same file. When clippy compiles the **library target** with `--all-features`, `dual-mode` is on but `test` is not — so the extern is present, the callers are gone, and the dead-code lint fires legitimately.

## Fix

Tighten each block to `#[cfg(all(test, feature = "dual-mode"))]`, matching its caller exactly. The extern now exists only when its caller does — lint disappears, dual-mode test binaries are byte-identical.

| File | Shims |
|---|---|
| `kpm/freak/clustering.rs` | `fast_random`, `array_shuffle`, `bhc_build_and_query_with_settings` |
| `kpm/freak/homography.rs` | `mat3_exp_pade_via_eigen`, `preemptive_robust_homography`, `robust_homography_find` |
| `kpm/freak/hough.rs` | `auto_adjust_xy_num_bins` |
| `kpm/freak/math.rs` | `fast_atan2`, `fast_sqrt1`, `fast_exp6_f32`, `solve_linear_system_2x2`, `solve_symmetric_linear_system_3x3`, `solve_null_vector_8x9_destructive`, `partial_sort_f32` |
| `kpm/freak/matcher.rs` | `match_features_brute`, `match_features_indexed`, `match_features_guided` |

## Plan deviation

The locked plan (.claude/issue-180-plan.md) Decision #2 originally said "add `#[allow(dead_code)]` + `// rationale:` on each extern block." Once I traced the actual cfg gap I switched to cfg-tightening — same one-line-per-block effort, more honest, removes the symptom by fixing the cause. Plan doc Decision Log updated in this PR.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --all-features` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 17 FFI shim lints clear; remaining 24 errors all in PR 3-4 scope
- [x] `cargo clippy --workspace -- -D warnings` (existing CI gate) clean
- [x] `cargo clippy -p webarkitlib-rs -- -D warnings` (pure-Rust gate) clean
- [x] `cargo test --all-features` — 471 passed, 8 ignored
- [x] `cargo test -p webarkitlib-rs --lib --features dual-mode` — 445 passed, 3 ignored (confirms shims still resolve)

Refs #180.