### PR TITLE
refactor(ar): convert Default::default() + field reassign to struct-init (#180)

### DIFF
--- a/crates/core/src/ar/marker.rs
+++ b/crates/core/src/ar/marker.rs
@@ -1475,13 +1475,15 @@ mod tests {
     /// `arGetMarkerInfo.c` lines 92-100.
     #[test]
     fn test_finalize_marker_id_cf_dir_template_color() {
-        let mut m = ARMarkerInfo::default();
-        m.id_patt = 7;
-        m.dir_patt = 2;
-        m.cf_patt = 0.85;
-        m.id_matrix = 99; // should be ignored
-        m.dir_matrix = 3;
-        m.cf_matrix = 0.5;
+        let mut m = ARMarkerInfo {
+            id_patt: 7,
+            dir_patt: 2,
+            cf_patt: 0.85,
+            id_matrix: 99, // should be ignored
+            dir_matrix: 3,
+            cf_matrix: 0.5,
+            ..Default::default()
+        };
 
         finalize_marker_id_cf_dir(&mut m, crate::pattern::AR_TEMPLATE_MATCHING_COLOR);
 
@@ -1492,10 +1494,12 @@ mod tests {
 
     #[test]
     fn test_finalize_marker_id_cf_dir_template_mono() {
-        let mut m = ARMarkerInfo::default();
-        m.id_patt = 4;
-        m.dir_patt = 1;
-        m.cf_patt = 0.7;
+        let mut m = ARMarkerInfo {
+            id_patt: 4,
+            dir_patt: 1,
+            cf_patt: 0.7,
+            ..Default::default()
+        };
 
         finalize_marker_id_cf_dir(&mut m, crate::pattern::AR_TEMPLATE_MATCHING_MONO);
 
@@ -1506,13 +1510,15 @@ mod tests {
 
     #[test]
     fn test_finalize_marker_id_cf_dir_matrix_only() {
-        let mut m = ARMarkerInfo::default();
-        m.id_patt = 99; // should be ignored
-        m.dir_patt = 2;
-        m.cf_patt = 0.5;
-        m.id_matrix = 12;
-        m.dir_matrix = 0;
-        m.cf_matrix = 0.92;
+        let mut m = ARMarkerInfo {
+            id_patt: 99, // should be ignored
+            dir_patt: 2,
+            cf_patt: 0.5,
+            id_matrix: 12,
+            dir_matrix: 0,
+            cf_matrix: 0.92,
+            ..Default::default()
+        };
 
         finalize_marker_id_cf_dir(&mut m, crate::types::AR_MATRIX_CODE_DETECTION);
 
@@ -1523,17 +1529,19 @@ mod tests {
 
     #[test]
     fn test_finalize_marker_id_cf_dir_mixed_color_matrix_leaves_finals_alone() {
-        let mut m = ARMarkerInfo::default();
         // Pre-set finals to sentinel values; verify they're not overwritten.
-        m.id = -42;
-        m.dir = -42;
-        m.cf = -42.0;
-        m.id_patt = 1;
-        m.dir_patt = 1;
-        m.cf_patt = 0.1;
-        m.id_matrix = 2;
-        m.dir_matrix = 2;
-        m.cf_matrix = 0.2;
+        let mut m = ARMarkerInfo {
+            id: -42,
+            dir: -42,
+            cf: -42.0,
+            id_patt: 1,
+            dir_patt: 1,
+            cf_patt: 0.1,
+            id_matrix: 2,
+            dir_matrix: 2,
+            cf_matrix: 0.2,
+            ..Default::default()
+        };
 
         finalize_marker_id_cf_dir(
             &mut m,
@@ -1547,10 +1555,12 @@ mod tests {
 
     #[test]
     fn test_finalize_marker_id_cf_dir_mixed_mono_matrix_leaves_finals_alone() {
-        let mut m = ARMarkerInfo::default();
-        m.id = -42;
-        m.dir = -42;
-        m.cf = -42.0;
+        let mut m = ARMarkerInfo {
+            id: -42,
+            dir: -42,
+            cf: -42.0,
+            ..Default::default()
+        };
 
         finalize_marker_id_cf_dir(
             &mut m,
@@ -1920,16 +1930,18 @@ mod tests {
     /// leaves finals untouched.
     #[test]
     fn test_finalize_marker_id_cf_dir_mono_matrix_leaves_finals_alone() {
-        let mut m = ARMarkerInfo::default();
-        m.id = -42;
-        m.dir = -42;
-        m.cf = -42.0;
-        m.id_patt = 1;
-        m.dir_patt = 1;
-        m.cf_patt = 0.6;
-        m.id_matrix = 2;
-        m.dir_matrix = 2;
-        m.cf_matrix = 0.7;
+        let mut m = ARMarkerInfo {
+            id: -42,
+            dir: -42,
+            cf: -42.0,
+            id_patt: 1,
+            dir_patt: 1,
+            cf_patt: 0.6,
+            id_matrix: 2,
+            dir_matrix: 2,
+            cf_matrix: 0.7,
+            ..Default::default()
+        };
 
         finalize_marker_id_cf_dir(
             &mut m,
@@ -1996,8 +2008,10 @@ mod tests {
     #[test]
     fn test_cutoff_phase_set_on_barcode_edc_fail() {
         use crate::types::{ARMarkerInfoCutoffPhase, MatchError};
-        let mut marker = ARMarkerInfo::default();
-        marker.cutoff_phase = MatchError::BarcodeEdcFail.into();
+        let marker = ARMarkerInfo {
+            cutoff_phase: MatchError::BarcodeEdcFail.into(),
+            ..Default::default()
+        };
         assert_eq!(
             marker.cutoff_phase,
             ARMarkerInfoCutoffPhase::MatchBarcodeEdcFail
@@ -2008,8 +2022,10 @@ mod tests {
     #[test]
     fn test_cutoff_phase_set_on_match_generic() {
         use crate::types::{ARMarkerInfoCutoffPhase, MatchError};
-        let mut marker = ARMarkerInfo::default();
-        marker.cutoff_phase = MatchError::Generic.into();
+        let marker = ARMarkerInfo {
+            cutoff_phase: MatchError::Generic.into(),
+            ..Default::default()
+        };
         assert_eq!(marker.cutoff_phase, ARMarkerInfoCutoffPhase::MatchGeneric);
     }
 
@@ -2025,9 +2041,11 @@ mod tests {
     #[test]
     fn test_history_disabled_skips_merge() {
         use crate::types::ARHandle;
-        let mut handle = ARHandle::default();
-        handle.ar_marker_extraction_mode = crate::types::AR_NOUSE_TRACKING_HISTORY;
-        handle.ar_pattern_detection_mode = crate::pattern::AR_TEMPLATE_MATCHING_MONO;
+        let mut handle = ARHandle {
+            ar_marker_extraction_mode: crate::types::AR_NOUSE_TRACKING_HISTORY,
+            ar_pattern_detection_mode: crate::pattern::AR_TEMPLATE_MATCHING_MONO,
+            ..Default::default()
+        };
 
         // Strong history record.
         handle.history[0].marker.id = 5;
@@ -2065,8 +2083,10 @@ mod tests {
     #[test]
     fn test_history_merge_strengthens_weak_marker_single_mode() {
         use crate::types::ARHandle;
-        let mut handle = ARHandle::default();
-        handle.ar_pattern_detection_mode = crate::pattern::AR_TEMPLATE_MATCHING_MONO;
+        let mut handle = ARHandle {
+            ar_pattern_detection_mode: crate::pattern::AR_TEMPLATE_MATCHING_MONO,
+            ..Default::default()
+        };
 
         // Current marker: weak.
         handle.marker_info[0].area = 10000;
@@ -2109,8 +2129,10 @@ mod tests {
     #[test]
     fn test_history_merge_does_nothing_when_current_cf_higher() {
         use crate::types::ARHandle;
-        let mut handle = ARHandle::default();
-        handle.ar_pattern_detection_mode = crate::pattern::AR_TEMPLATE_MATCHING_MONO;
+        let mut handle = ARHandle {
+            ar_pattern_detection_mode: crate::pattern::AR_TEMPLATE_MATCHING_MONO,
+            ..Default::default()
+        };
 
         handle.marker_info[0].area = 10000;
         handle.marker_info[0].pos = [100.0, 100.0];
@@ -2141,8 +2163,10 @@ mod tests {
     #[test]
     fn test_history_merge_skips_when_area_ratio_out_of_range() {
         use crate::types::ARHandle;
-        let mut handle = ARHandle::default();
-        handle.ar_pattern_detection_mode = crate::pattern::AR_TEMPLATE_MATCHING_MONO;
+        let mut handle = ARHandle {
+            ar_pattern_detection_mode: crate::pattern::AR_TEMPLATE_MATCHING_MONO,
+            ..Default::default()
+        };
 
         handle.marker_info[0].area = 10000;
         handle.marker_info[0].pos = [100.0, 100.0];
@@ -2175,9 +2199,11 @@ mod tests {
     #[test]
     fn test_history_merge_combined_mode_updates_both_cfs() {
         use crate::types::ARHandle;
-        let mut handle = ARHandle::default();
-        handle.ar_pattern_detection_mode =
-            crate::types::AR_TEMPLATE_MATCHING_MONO_AND_MATRIX_CODE_DETECTION;
+        let mut handle = ARHandle {
+            ar_pattern_detection_mode:
+                crate::types::AR_TEMPLATE_MATCHING_MONO_AND_MATRIX_CODE_DETECTION,
+            ..Default::default()
+        };
 
         handle.marker_info[0].area = 10000;
         handle.marker_info[0].pos = [100.0, 100.0];
@@ -2271,9 +2297,10 @@ mod tests {
     #[test]
     fn test_save_creates_new_record_for_new_id() {
         use crate::types::ARHandle;
-        let mut handle = ARHandle::default();
-
-        handle.history_num = 0;
+        let mut handle = ARHandle {
+            history_num: 0,
+            ..Default::default()
+        };
 
         handle.marker_info[0].id = 42;
         handle.marker_info[0].area = 7777;
@@ -2323,8 +2350,10 @@ mod tests {
     #[test]
     fn test_v2_mode_skips_resurrection() {
         use crate::types::ARHandle;
-        let mut handle = ARHandle::default();
-        handle.ar_marker_extraction_mode = crate::types::AR_USE_TRACKING_HISTORY_V2;
+        let mut handle = ARHandle {
+            ar_marker_extraction_mode: crate::types::AR_USE_TRACKING_HISTORY_V2,
+            ..Default::default()
+        };
 
         handle.history[0].marker.id = 9;
         handle.history[0].marker.area = 5000;
@@ -2347,8 +2376,10 @@ mod tests {
     #[test]
     fn test_resurrection_reinserts_missing_history_marker() {
         use crate::types::ARHandle;
-        let mut handle = ARHandle::default();
-        handle.ar_marker_extraction_mode = crate::types::AR_USE_TRACKING_HISTORY;
+        let mut handle = ARHandle {
+            ar_marker_extraction_mode: crate::types::AR_USE_TRACKING_HISTORY,
+            ..Default::default()
+        };
 
         handle.history[0].marker.id = 9;
         handle.history[0].marker.area = 5000;
@@ -2370,8 +2401,10 @@ mod tests {
     #[test]
     fn test_resurrection_does_not_duplicate_existing_marker() {
         use crate::types::ARHandle;
-        let mut handle = ARHandle::default();
-        handle.ar_marker_extraction_mode = crate::types::AR_USE_TRACKING_HISTORY;
+        let mut handle = ARHandle {
+            ar_marker_extraction_mode: crate::types::AR_USE_TRACKING_HISTORY,
+            ..Default::default()
+        };
 
         handle.history[0].marker.area = 5000;
         handle.history[0].marker.pos = [50.0, 50.0];

--- a/crates/core/src/ar/param.rs
+++ b/crates/core/src/ar/param.rs
@@ -246,9 +246,11 @@ mod tests {
 
     #[test]
     fn test_ar_param_change_size_doubles_resolution() {
-        let mut src = ARParam::default();
-        src.xsize = 640;
-        src.ysize = 480;
+        let mut src = ARParam {
+            xsize: 640,
+            ysize: 480,
+            ..Default::default()
+        };
         // fx, skew=0, cx, tx
         src.mat[0] = [700.0, 0.0, 320.0, 0.0];
         // 0, fy, cy, ty
@@ -277,9 +279,11 @@ mod tests {
 
     #[test]
     fn test_ar_param_change_size_halves_resolution() {
-        let mut src = ARParam::default();
-        src.xsize = 1280;
-        src.ysize = 960;
+        let mut src = ARParam {
+            xsize: 1280,
+            ysize: 960,
+            ..Default::default()
+        };
         src.mat[0] = [1400.0, 0.0, 640.0, 0.0];
         src.mat[1] = [0.0, 1400.0, 480.0, 0.0];
         src.mat[2] = [0.0, 0.0, 1.0, 0.0];
@@ -294,9 +298,11 @@ mod tests {
 
     #[test]
     fn test_ar_param_change_size_identity() {
-        let mut src = ARParam::default();
-        src.xsize = 640;
-        src.ysize = 480;
+        let mut src = ARParam {
+            xsize: 640,
+            ysize: 480,
+            ..Default::default()
+        };
         src.mat[0] = [700.0, 0.0, 320.0, 0.0];
         src.mat[1] = [0.0, 700.0, 240.0, 0.0];
         src.mat[2] = [0.0, 0.0, 1.0, 0.0];

--- a/crates/core/src/ar/param_gl.rs
+++ b/crates/core/src/ar/param_gl.rs
@@ -486,9 +486,11 @@ mod tests {
     use crate::types::ARParam;
 
     fn make_param(xsize: i32, ysize: i32, fx: f64, fy: f64, cx: f64, cy: f64) -> ARParam {
-        let mut p = ARParam::default();
-        p.xsize = xsize;
-        p.ysize = ysize;
+        let mut p = ARParam {
+            xsize,
+            ysize,
+            ..Default::default()
+        };
         p.mat[0] = [fx, 0.0, cx, 0.0];
         p.mat[1] = [0.0, fy, cy, 0.0];
         p.mat[2] = [0.0, 0.0, 1.0, 0.0];

--- a/crates/core/src/ar/pattern.rs
+++ b/crates/core/src/ar/pattern.rs
@@ -1235,8 +1235,10 @@ mod tests {
         let param_ltf = ARParamLTf::new_basic(xsize_i32, ysize_i32);
 
         // Build a simple marker_info with the quad we defined
-        let mut marker = ARMarkerInfo::default();
-        marker.vertex = vertex;
+        let marker = ARMarkerInfo {
+            vertex,
+            ..Default::default()
+        };
 
         // Save using the image-first signature of ar_patt_save
         let filename_path = std::path::Path::new(filename);


### PR DESCRIPTION
## Summary

PR 3 of 5 in the [#180](https://github.com/webarkit/WebARKitLib-rs/issues/180) series. Clears all 22 `field_reassign_with_default` lints flagged by `cargo clippy --all-targets --all-features -- -D warnings`.

**Baseline drops from 24 → 2 errors.** The remaining 2 are the SIMD `too_many_arguments` pair (`get_similarity_sse41` / `get_similarity_avx2`) earmarked for PR 4.

## Scope

22 sites across 4 files — slightly wider than #180's original \"all in ar/marker.rs\" estimate. Re-baseline at PR 1 surfaced 5 sites in adjacent files; they're the same lint, mechanical, and need to go before PR 5 can tighten CI.

| File | Sites | Type |
|---|---:|---|
| `ar/marker.rs` | 17 | `ARMarkerInfo` (6) + `ARHandle` (11) — finalize_marker_id_cf_dir tests + history-merge / resurrection pipeline tests |
| `ar/param.rs` | 3 | `ARParam` in `ar_param_change_size` tests |
| `ar/param_gl.rs` | 1 | `ARParam` in `make_param` helper |
| `ar/pattern.rs` | 1 | `ARMarkerInfo` in `ar_patt_save` test |

## Conversion pattern

```rust
// Before
let mut m = ARMarkerInfo::default();
m.id_patt = 7;
m.dir_patt = 2;
m.cf_patt = 0.85;

// After
let mut m = ARMarkerInfo {
    id_patt: 7,
    dir_patt: 2,
    cf_patt: 0.85,
    ..Default::default()
};
```

Where call sites interleave non-field reassigns (e.g. `src.mat[0] = [...]` array indexing) the binding stays `mut` so subsequent index assignments compile.

All sites are test-only code; zero behavior change.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --all-features` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 22 field_reassign lints clear; remaining 2 errors are the PR 4 SIMD sites
- [x] `cargo clippy --workspace -- -D warnings` (existing CI gate) clean
- [x] `cargo clippy -p webarkitlib-rs -- -D warnings` (pure-Rust gate) clean
- [x] `cargo test --all-features` — 471 passed, 8 ignored

Refs #180.