### PR TITLE
chore(ar2): allow too_many_arguments on SIMD get_similarity variants (#180)

### DIFF
--- a/crates/core/src/ar2/feature_map.rs
+++ b/crates/core/src/ar2/feature_map.rs
@@ -272,6 +272,11 @@ fn get_similarity_scalar(
 /// after `is_x86_feature_detected!`.
 #[cfg(all(feature = "simd-x86-sse41", target_arch = "x86_64"))]
 #[target_feature(enable = "sse4.1")]
+// rationale: SIMD variant of get_similarity; signature locked to match
+// the scalar fallback and sibling SIMD impl for runtime dispatch via
+// is_x86_feature_detected! — bundling args into a struct would force
+// every caller to materialize it on a hot path with no design win.
+#[allow(clippy::too_many_arguments)]
 unsafe fn get_similarity_sse41(
     image: &[u8],
     xsize: i32,
@@ -384,6 +389,11 @@ unsafe fn get_similarity_sse41(
 /// [`get_similarity`] after `is_x86_feature_detected!`.
 #[cfg(all(feature = "simd-x86-avx2", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2,fma")]
+// rationale: SIMD variant of get_similarity; signature locked to match
+// the scalar fallback and sibling SIMD impl for runtime dispatch via
+// is_x86_feature_detected! — bundling args into a struct would force
+// every caller to materialize it on a hot path with no design win.
+#[allow(clippy::too_many_arguments)]
 unsafe fn get_similarity_avx2(
     image: &[u8],
     xsize: i32,


### PR DESCRIPTION
## Summary

PR 4 of 5 in the [#180](https://github.com/webarkit/WebARKitLib-rs/issues/180) series. Adds `#[allow(clippy::too_many_arguments)]` with rationale on the two SIMD `get_similarity_*` impls in `crates/core/src/ar2/feature_map.rs` (lines 275 and 387), clearing the final two **library** lints flagged by `cargo clippy --all-targets --all-features -- -D warnings`.

**Library is now fully strict-clean.**

## Rationale (in code)

```rust
// rationale: SIMD variant of get_similarity; signature locked to match
// the scalar fallback and sibling SIMD impl for runtime dispatch via
// is_x86_feature_detected! — bundling args into a struct would force
// every caller to materialize it on a hot path with no design win.
#[allow(clippy::too_many_arguments)]
unsafe fn get_similarity_sse41(...) { ... }
```

The two functions are runtime-dispatched SIMD variants. Their 9-arg signatures must match the scalar fallback so the dispatcher can swap between them via `is_x86_feature_detected!`. The plan ([.claude/issue-180-plan.md](.claude/issue-180-plan.md) Decision #3) explicitly chose inline `#[allow]` over a `clippy.toml` threshold raise to keep the exception scoped to these two sites.

## Discovery: PR 4.5 needed before PR 5

Clearing the lib unmasked **24 pre-existing lints in examples/tests/benches** that had been hidden because cargo halts on lib errors before checking those targets. Categories include `excessive_precision` (test fixtures), `field_reassign_with_default` (example code), `unnecessary_cast`, `redundant_closure`, etc.

These are **out of scope for PR 4** and don't block this PR landing. A follow-up cleanup PR (\"PR 4.5\") will clear them before PR 5 tightens CI to `--all-targets --all-features`. The locked plan will be updated to reflect this.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p webarkitlib-rs --lib --all-features -- -D warnings` — library fully strict-clean
- [x] `cargo clippy --workspace -- -D warnings` (existing CI gate) clean
- [x] `cargo clippy -p webarkitlib-rs -- -D warnings` (pure-Rust CI gate) clean
- [x] No occurrences of `too_many_arguments` or `get_similarity_sse41/avx2` lints under `--all-targets --all-features`
- [x] `cargo test --all-features` — 471 passed, 8 ignored

Refs #180.