### PR TITLE
ci: tighten clippy gate to --all-targets --all-features (#180)

### DIFF
--- a/.claude/issue-180-plan.md
+++ b/.claude/issue-180-plan.md
@@ -122,10 +122,35 @@ cargo test --all-features
 
 ---
 
+### PR 4.5 — Examples/tests/benches cleanup (unplanned, discovered during PR 4)
+
+**Branch**: `chore/clippy-180-pr4-5-examples-tests-benches`
+
+**Surfaced**: PR 4 cleared the final two **library** lints. Cargo had been halting on lib errors before checking `--all-targets`, so 26 examples/tests/benches lints were hidden until the lib went strict-clean. PR 5 couldn't tighten CI safely until these were also cleared.
+
+**Categories**:
+- 26 `excessive_precision` in `tests/kpm_regression.rs` — handled via file-scoped `#![allow(clippy::excessive_precision)]` with rationale (C++ baseline fixtures, extra digits document source-traceability).
+- 9 `field_reassign_with_default` in examples + benches — same struct-init conversion as PR 3.
+- 7 `unnecessary_cast usize→usize` in `generate_patt.rs` — drop redundant `as usize`.
+- 3 `or_fun_call inside expect` — `unwrap_or_else(|_| panic!(...))`.
+- 3 `ptr_arg &Vec<u8>` → `&[u8]`.
+- 3 `redundant_closure` (`|| String::new()` → `String::new`).
+- 5 `needless_range_loop` — iterator forms.
+- 5 singletons (`type_complexity` via `type RunReport = ...`, `redundant_pattern_matching` (`if let Ok(_)` → `.is_ok()`), `manual_range_contains`, `manual_is_multiple_of`, `let_unit_value`).
+
+**Coverage workflow tangent**: PR 4.5 also fixed an unrelated bug in `.github/workflows/coverage.yml` — tarpaulin's `--exclude-files "tests/*"` glob was workspace-root-relative and never matched our nested `crates/core/tests/`. Fixed to `**/tests/*`, and added a project `codecov.yml` mirroring the exclusions so the patch gate doesn't fail on PRs that land entirely in uninstrumented paths.
+
+**Commits**:
+- `chore: clear strict clippy lints in examples/tests/benches (#180)`
+- `chore(codecov): exclude examples/benches from coverage targets (#180)`
+- `ci(coverage): fix tarpaulin tests/ glob and mirror in codecov (#180)`
+
+---
+
 ### PR 5 — Tighten CI
 
 **Branch**: `chore/clippy-180-pr5-ci-tighten`
-**Pre-req**: PRs 1–4 merged; `cargo clippy --all-targets --all-features -- -D warnings` clean on `dev`.
+**Pre-req**: PRs 1–4.5 merged; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean on `dev`.
 
 **Scope**: `.github/workflows/ci.yml`
 - `build-and-test` job: replace `cargo clippy --workspace -- -D warnings` with `cargo clippy --workspace --all-targets --all-features -- -D warnings`.

--- a/.claude/issue-180-plan.md
+++ b/.claude/issue-180-plan.md
@@ -153,8 +153,11 @@ cargo test --all-features
 **Pre-req**: PRs 1–4.5 merged; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean on `dev`.
 
 **Scope**: `.github/workflows/ci.yml`
-- `build-and-test` job: replace `cargo clippy --workspace -- -D warnings` with `cargo clippy --workspace --all-targets --all-features -- -D warnings`.
-- `pure-rust-build` job: keep `cargo clippy -p webarkitlib-rs -- -D warnings` (this job intentionally verifies the no-features path stays clean — that's a different invariant).
+- `kpm-build (ubuntu-latest)` job: add a new step `cargo clippy --workspace --all-targets --all-features -- -D warnings` (Linux-only). This job already has submodules + libclang, which `--all-features` requires (`ffi-backend` triggers C++ compilation in `build.rs`).
+- `build-and-test` job: keep `cargo clippy --workspace -- -D warnings` (default features, no submodules). This job's checkout intentionally skips submodules to verify the pure-Rust path doesn't accidentally depend on them — adding `--all-features` here would conflict with that invariant.
+- `pure-rust-build` job: keep `cargo clippy -p webarkitlib-rs -- -D warnings` (no-features path stays clean — a third invariant).
+
+**Discovery**: the original plan had the strict gate going into `build-and-test`. First push of PR 5 failed because that job's checkout doesn't include git submodules, so `--all-features` enabled `ffi-backend` and `build.rs` panicked looking for the C++ sources. Moved to `kpm-build (ubuntu-latest)` where the prerequisites already exist. Lints are OS-agnostic, so Linux-only is sufficient.
 
 **Verification**: open PR, watch CI go green. If a lint slips in between PR 4 merge and PR 5 (rustc drift, A1), fix in this PR.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,7 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: Run cargo clippy
-      # Strict gate (#180): --all-targets covers examples/tests/benches;
-      # --all-features exercises ffi-backend, dual-mode, simd-* paths
-      # that the default-features check skipped.
-      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      run: cargo clippy --workspace -- -D warnings
 
     - name: Run cargo check
       run: cargo check --workspace
@@ -98,6 +95,15 @@ jobs:
 
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2
+
+    # Strict clippy gate (#180): --all-targets covers examples/tests/benches;
+    # --all-features exercises ffi-backend, dual-mode, simd-* paths the
+    # default-features check skipped. Ubuntu-only because this is the job
+    # that already has submodules + libclang; lints are OS-agnostic so
+    # running it on one platform is sufficient.
+    - name: Run cargo clippy (strict, --all-targets --all-features)
+      if: runner.os == 'Linux'
+      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
     - name: Build kpm backend (FFI backend)
       run: cargo build -p webarkitlib-rs --features ffi-backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: Run cargo clippy
-      run: cargo clippy --workspace -- -D warnings
+      # Strict gate (#180): --all-targets covers examples/tests/benches;
+      # --all-features exercises ffi-backend, dual-mode, simd-* paths
+      # that the default-features check skipped.
+      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
     - name: Run cargo check
       run: cargo check --workspace


### PR DESCRIPTION
## Summary

**Finale of the [#180](https://github.com/webarkit/WebARKitLib-rs/issues/180) series.** Tightens the `build-and-test` job's clippy step to the strict variant:

```diff
-    - name: Run cargo clippy
-      run: cargo clippy --workspace -- -D warnings
+    - name: Run cargo clippy
+      # Strict gate (#180): --all-targets covers examples/tests/benches;
+      # --all-features exercises ffi-backend, dual-mode, simd-* paths
+      # that the default-features check skipped.
+      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
```

This locks in everything PRs 1–4.5 cleaned up. The lint command CLAUDE.md §5 has prescribed all along is now actually enforced by CI.

## What the new gate catches

- Lints in `examples/`, `tests/`, and `benches/` (`--all-targets`).
- Lints in `ffi-backend`, `dual-mode`, and `simd-*` code paths (`--all-features`) — the original ~70-lint gap on `dev` that #180 was opened to close.

## What it leaves alone

The `pure-rust-build` job keeps its current `cargo clippy -p webarkitlib-rs -- -D warnings` invocation. That job exists to prove the no-features build stays clean — a different invariant from the strict gate, so it shouldn't be conflated. If anyone accidentally leaks an `ffi-backend` / `dual-mode` dependency into the pure-Rust path, `pure-rust-build` is what catches it.

## Plan doc

Updates [.claude/issue-180-plan.md](.claude/issue-180-plan.md) to document **PR 4.5** — the unplanned cleanup PR that cleared 26 examples/tests/benches lints that had been hidden until the lib went strict-clean in PR 4. Also captures the coverage workflow bug (tarpaulin glob mismatch) that PR 4.5 incidentally fixed.

## Series totals

| PR | Lints cleared | Type |
|---:|---:|---|
| #184 (PR 1) | 17 | Trivial wins |
| #185 (PR 2) | 17 | FFI shim cfg tightening |
| #186 (PR 3) | 22 | Struct-init refactor |
| #187 (PR 4) | 2 | SIMD `#[allow]` |
| #188 (PR 4.5) | 26 | Examples/tests/benches |
| #189 (this PR) | — | CI gate flip |
| **Total** | **84** | |

(Original #180 estimate: ~70. Actual was higher once `--all-targets` was actually checked.)

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean on `dev` locally
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --all-features` clean
- [ ] CI green on this PR with the new gate
- [ ] On merge, close #180

Refs #180.