### PR TITLE
fix(kpm): replace unaligned transmute in hamming_distance_96 (#192)

### DIFF
--- a/crates/core/src/kpm/freak/clustering.rs
+++ b/crates/core/src/kpm/freak/clustering.rs
@@ -63,16 +63,17 @@ fn hamming_distance_32(a: u32, b: u32) -> u32 {
 /// Computes Hamming distance between two 96-byte (768-bit) FREAK descriptors.
 /// C equivalent: HammingDistance768
 pub fn hamming_distance_96(a: &[u8; 96], b: &[u8; 96]) -> u32 {
-    // SAFETY: Transmuting &[u8; 96] to &[u32; 24] is safe because:
-    // 1. Byte arrays are correctly sized (96 bytes = 24 × 4 bytes)
-    // 2. u32 alignment is guaranteed on all supported targets
-    // 3. The transmute creates a properly-aligned view of the same data
-    let a32 = unsafe { std::mem::transmute::<&[u8; 96], &[u32; 24]>(a) };
-    let b32 = unsafe { std::mem::transmute::<&[u8; 96], &[u32; 24]>(b) };
-
-    a32.iter()
-        .zip(b32.iter())
-        .map(|(x, y)| hamming_distance_32(*x, *y))
+    // Reassemble each 4-byte chunk via `u32::from_ne_bytes` rather than
+    // transmuting `&[u8; 96]` to `&[u32; 24]`. The transmute requires
+    // 4-byte alignment on the input, which `&[u8; 96]` does not
+    // guarantee — Miri flagged it as UB (#192).
+    (0..24)
+        .map(|i| {
+            let off = i * 4;
+            let ax = u32::from_ne_bytes([a[off], a[off + 1], a[off + 2], a[off + 3]]);
+            let bx = u32::from_ne_bytes([b[off], b[off + 1], b[off + 2], b[off + 3]]);
+            hamming_distance_32(ax, bx)
+        })
         .sum()
 }
 


### PR DESCRIPTION
Closes #192. First UB finding from the Miri gate landed in #191 (issue #182).

## Summary

- Replaces the unsound `transmute::<&[u8; 96], &[u32; 24]>` in [`crates/core/src/kpm/freak/clustering.rs:65`](crates/core/src/kpm/freak/clustering.rs:65) with `u32::from_ne_bytes` on 4-byte chunks.
- Removes the `unsafe` block entirely.
- Audit grep confirms this was the only `transmute::<&[u8; ...], &[u32; ...]>` site in the codebase — no further sweeps needed in `kpm/freak/{math,matcher,visual_database}.rs`.

## Why

`&[u8; 96]` has alignment 1; `&[u32; 24]` requires alignment 4. The transmute is UB whenever the input isn't 4-byte aligned at runtime, which the type system doesn't guarantee. Miri proved a real case via `kpm::freak::clustering::tests::test_bhc_max_nodes_to_pop_widens_candidate_set`. The previous `// SAFETY:` comment was wrong on point 3.

## Numerical equivalence

The new code reassembles the same 4 bytes into the same `u32` (native byte order, matching the transmute's behavior) and feeds them into the same `hamming_distance_32` reduction. Bit-identical output is preserved.

## Test plan

- [x] `cargo test -p webarkitlib-rs --lib` — 419 passed, 2 ignored locally.
- [x] `cargo clippy -p webarkitlib-rs --lib --all-features -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] CI: Miri job (now PR-scoped) should pass on this test specifically — the original UB site is gone.
- [ ] CI: dual-mode parity tests still green (C++ baseline equivalence).

## Next step after merge

Once this lands and the Miri job is green on a follow-up PR, ratchet `continue-on-error: true` → `false` in `.github/workflows/ci.yml` and add a Miri status badge to the README (per #182's plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)