### PR TITLE
ci(miri): promote to required gate, split workflow, add README badge (#182)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,63 +162,9 @@ jobs:
           --test absolute_corner_error \
           --features dual-mode -- --nocapture
 
-  # Miri UB validation (#182): runs the pure-Rust lib under the MIR
-  # interpreter to catch use-after-free, OOB reads, invalid `unsafe`
-  # invariants, uninitialized-memory reads, and reference-aliasing
-  # violations that escape regular tests. Excludes `ffi-backend`
-  # (Miri can't execute C++) and `simd-x86-*` (Miri's x86 SIMD support
-  # is incomplete). Scalar fallbacks ARE validated.
-  #
-  # `continue-on-error: true` initially — will be ratcheted to required
-  # once initial UB findings are resolved via follow-up PRs tracked
-  # under #182. See docs/miri.md for scope, exclusions, local-run
-  # instructions, and the nightly-pin bump procedure.
-  miri:
-    name: miri (pure-Rust UB validation)
-    runs-on: ubuntu-latest
-    # Restrict to PRs against dev/main only — Miri is 5–30x slower than
-    # cargo test and the pre-merge gate is where it earns its keep.
-    if: github.event_name == 'pull_request' && (github.base_ref == 'dev' || github.base_ref == 'main')
-    continue-on-error: true
-    env:
-      # Pinned nightly — bump manually if Miri breaks on this date or
-      # every ~3 months for freshness. See docs/miri.md.
-      MIRI_NIGHTLY: nightly-2026-06-01
-    steps:
-    - uses: actions/checkout@v5
-
-    - name: Install pinned nightly + Miri
-      run: |
-        rustup toolchain install $MIRI_NIGHTLY --component miri --profile minimal
-        rustup default $MIRI_NIGHTLY
-        cargo miri setup
-
-    - name: Rust Cache
-      uses: Swatinem/rust-cache@v2
-      with:
-        key: miri-${{ env.MIRI_NIGHTLY }}
-        shared-key: miri
-
-    # NOTES on MIRIFLAGS:
-    # * -Zmiri-tree-borrows: use the Tree Borrows aliasing model instead
-    #   of the default Stacked Borrows. Stacked Borrows trips inside
-    #   crossbeam-epoch (a transitive dep of rayon, reached from our
-    #   ar2::feature_map par_chunks_mut) on patterns that are sound in
-    #   practice. Tree Borrows accepts them while still catching real
-    #   UB in our own code.
-    # * -Zmiri-strict-provenance is intentionally NOT enabled — it also
-    #   trips inside crossbeam-epoch (integer-to-pointer casts). Re-
-    #   evaluate once the ecosystem migrates. See docs/miri.md.
-    - name: Run Miri (pure-Rust, lib targets only)
-      run: cargo miri test -p webarkitlib-rs --lib
-      env:
-        # -Zmiri-disable-isolation: allow filesystem ops so tests that
-        # use `tempfile` (e.g. ar2::feature_set roundtrip) can run.
-        # -Zmiri-ignore-leaks: rayon's global thread pool spawns workers
-        # that aren't joined at process exit. Miri flags that as a leak
-        # by default; ignoring it is the recommended setting for rayon-
-        # using test suites and does NOT weaken UB detection.
-        MIRIFLAGS: -Zmiri-backtrace=full -Zmiri-tree-borrows -Zmiri-disable-isolation -Zmiri-ignore-leaks
+  # Miri UB validation (#182) lives in its own workflow at
+  # .github/workflows/miri.yml — split out so it can carry a dedicated
+  # status badge and run on its own cadence.
 
   submodule-drift-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,73 @@
+name: Miri
+
+# Miri UB validation (#182): runs the pure-Rust lib under the MIR
+# interpreter to catch use-after-free, OOB reads, invalid `unsafe`
+# invariants, uninitialized-memory reads, and reference-aliasing
+# violations that escape regular tests.
+#
+# Excludes `ffi-backend` (Miri can't execute C++) and `simd-x86-*`
+# (Miri's x86 SIMD support is incomplete). Scalar fallbacks ARE
+# validated.
+#
+# Heavy algorithmic / pipeline tests are skipped via
+# `#[cfg_attr(miri, ignore)]` (#194) — they don't exercise unsafe
+# boundaries and would dominate runtime. See docs/miri.md.
+#
+# Required gate: this workflow MUST pass for PRs targeting dev/main.
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+  push:
+    branches:
+      - dev
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  miri:
+    name: miri (pure-Rust UB validation)
+    runs-on: ubuntu-latest
+    env:
+      # Pinned nightly — bump manually if Miri breaks on this date or
+      # every ~3 months for freshness. See docs/miri.md.
+      MIRI_NIGHTLY: nightly-2026-06-01
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install pinned nightly + Miri
+      run: |
+        rustup toolchain install $MIRI_NIGHTLY --component miri --profile minimal
+        rustup default $MIRI_NIGHTLY
+        cargo miri setup
+
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: miri-${{ env.MIRI_NIGHTLY }}
+        shared-key: miri
+
+    # NOTES on MIRIFLAGS:
+    # * -Zmiri-tree-borrows: use the Tree Borrows aliasing model instead
+    #   of the default Stacked Borrows. Stacked Borrows trips inside
+    #   crossbeam-epoch (a transitive dep of rayon, reached from our
+    #   ar2::feature_map par_chunks_mut) on patterns that are sound in
+    #   practice. Tree Borrows accepts them while still catching real
+    #   UB in our own code.
+    # * -Zmiri-disable-isolation: allow filesystem ops so tests that
+    #   use `tempfile` (e.g. ar2::feature_set roundtrip) can run.
+    # * -Zmiri-ignore-leaks: rayon's global thread pool spawns workers
+    #   that aren't joined at process exit. Miri flags that as a leak
+    #   by default; ignoring it is the recommended setting for rayon-
+    #   using test suites and does NOT weaken UB detection.
+    # * -Zmiri-strict-provenance is intentionally NOT enabled — it also
+    #   trips inside crossbeam-epoch (integer-to-pointer casts). Re-
+    #   evaluate once the ecosystem migrates. See docs/miri.md.
+    - name: Run Miri (pure-Rust, lib targets only)
+      run: cargo miri test -p webarkitlib-rs --lib
+      env:
+        MIRIFLAGS: -Zmiri-backtrace=full -Zmiri-tree-borrows -Zmiri-disable-isolation -Zmiri-ignore-leaks

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![WebARKitLib-rs](./assets/WebARKitLib-Rust-banner.jpg)
 
 [![CI](https://github.com/webarkit/WebARKitLib-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/webarkit/WebARKitLib-rs/actions/workflows/ci.yml)
+[![Miri](https://github.com/webarkit/WebARKitLib-rs/actions/workflows/miri.yml/badge.svg)](https://github.com/webarkit/WebARKitLib-rs/actions/workflows/miri.yml)
 [![codecov](https://codecov.io/gh/webarkit/WebARKitLib-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/webarkit/WebARKitLib-rs)
 [![Crates.io](https://img.shields.io/crates/v/webarkitlib-rs.svg)](https://crates.io/crates/webarkitlib-rs)
 [![npm](https://img.shields.io/npm/v/@webarkit/webarkitlib-wasm.svg)](https://www.npmjs.com/package/@webarkit/webarkitlib-wasm)

--- a/docs/miri.md
+++ b/docs/miri.md
@@ -121,7 +121,7 @@ understanding the report.
 
 ## Bumping the nightly pin
 
-The pin lives in `.github/workflows/ci.yml` as the `MIRI_NIGHTLY` job
+The pin lives in `.github/workflows/miri.yml` as the `MIRI_NIGHTLY` job
 env var. Bump when:
 
 - CI hits a known nightly Miri regression (link the upstream issue in
@@ -133,7 +133,7 @@ Procedure:
 1. Pick a recent known-good nightly from
    <https://rust-lang.github.io/rustup-components-history/> (filter on
    `miri`).
-2. Update `MIRI_NIGHTLY` in `ci.yml` AND the "Running locally" snippet
+2. Update `MIRI_NIGHTLY` in `miri.yml` AND the "Running locally" snippet
    in this file.
 3. Open a PR; CI will validate the new pin.
 
@@ -170,10 +170,10 @@ spot-check their own new `unsafe` code locally with
 
 ## CI gate status
 
-The Miri job currently runs with `continue-on-error: true` (advisory).
-It will be ratcheted to a required gate once initial UB findings
-surfaced by the first runs are resolved via follow-up PRs tracked under
-[#182](https://github.com/webarkit/WebARKitLib-rs/issues/182).
+The Miri job is a **required gate** for PRs targeting `dev` and `main`,
+runs in its own workflow at `.github/workflows/miri.yml`, and surfaces
+via a dedicated badge in the project README.
 
-Each finding gets its own fix PR — never a mega-PR — mirroring the #180
-cleanup series pattern.
+Each future finding gets its own fix PR — never a mega-PR — mirroring
+the #180 cleanup series pattern (and #192 from this safety net's first
+run, which uncovered a real unaligned-transmute UB).


### PR DESCRIPTION
Closes [#182](https://github.com/webarkit/WebARKitLib-rs/issues/182).

Final step in the post-M9 safety net plan. The Miri job has been running clean end-to-end since PR [#195](https://github.com/webarkit/WebARKitLib-rs/pull/195) landed (after PR [#193](https://github.com/webarkit/WebARKitLib-rs/pull/193) fixed the one real UB it caught — [#192](https://github.com/webarkit/WebARKitLib-rs/issues/192) unaligned transmute). Time to flip it from advisory to required.

## Changes

- **Split** the Miri job out of `.github/workflows/ci.yml` into its own workflow at `.github/workflows/miri.yml`. GitHub workflow badges are workflow-scoped, not job-scoped, so a dedicated badge requires its own file.
- **Drop** `continue-on-error: true` — Miri failures now block PR merges.
- **Move** the trigger from a job-level `if:` guard to a workflow-level `on:` block targeting pushes and PRs to `dev`/`main`.
- **Add** a Miri status badge to `README.md`, next to the existing CI badge.
- **Update** `docs/miri.md`: reference the new workflow path and refresh the \"CI gate status\" section.

## Verification

- `cargo fmt --check` clean (no code changes — workflow + docs only).
- Existing CI workflow (`ci.yml`) still passes — it just no longer contains the Miri job.
- New Miri workflow runs on this PR — must be green for the ratchet to land.

## After merge

The #182 plan is complete:

- ✅ Miri CI infrastructure (#191)
- ✅ First real UB finding fixed (#192 → #193)
- ✅ Test scoping for sane runtime (#194 → #195)
- ✅ Required gate + badge (this PR)

Any future Miri findings get their own fix PRs per the #180 / #192 / #193 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)