### PR TITLE
ci(miri): skip docs-only changes via paths-ignore + same-name shim

### DIFF
--- a/.github/workflows/miri-skip.yml
+++ b/.github/workflows/miri-skip.yml
@@ -1,0 +1,54 @@
+name: Miri
+
+# Skip-shim for the Miri required gate.
+#
+# The real Miri workflow (.github/workflows/miri.yml) uses `paths-ignore`
+# to skip docs-only changes. But the `protect-main` / `protect-dev`
+# rulesets require a check named `miri (pure-Rust UB validation)` to
+# pass on every PR — including docs-only ones. Without this shim a
+# README-only PR would have a "missing" required check and could not
+# merge.
+#
+# This workflow declares the same `name:` and the same job `name:` as
+# miri.yml, but triggers ONLY on the paths the real workflow ignores.
+# It does no actual work — it just emits a passing check with the
+# expected name so branch protection is satisfied.
+#
+# IMPORTANT: keep the workflow `name:` and job `name:` here in sync
+# with miri.yml. GitHub matches required checks on those names
+# exactly.
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+    paths:
+      - '**/*.md'
+      - 'docs/**'
+      - 'assets/**'
+      - 'LICENSE*'
+      - '.gitignore'
+      - '.gitattributes'
+  push:
+    branches:
+      - dev
+      - main
+    paths:
+      - '**/*.md'
+      - 'docs/**'
+      - 'assets/**'
+      - 'LICENSE*'
+      - '.gitignore'
+      - '.gitattributes'
+
+jobs:
+  miri:
+    name: miri (pure-Rust UB validation)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip — docs-only change, no Rust touched
+        run: |
+          echo "This change touches only docs / assets / LICENSE."
+          echo "The real Miri workflow ran zero seconds because there"
+          echo "is no Rust code change to validate."

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -20,10 +20,24 @@ on:
     branches:
       - dev
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'assets/**'
+      - 'LICENSE*'
+      - '.gitignore'
+      - '.gitattributes'
   push:
     branches:
       - dev
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'assets/**'
+      - 'LICENSE*'
+      - '.gitignore'
+      - '.gitattributes'
 
 env:
   CARGO_TERM_COLOR: always

--- a/docs/miri.md
+++ b/docs/miri.md
@@ -174,6 +174,16 @@ The Miri job is a **required gate** for PRs targeting `dev` and `main`,
 runs in its own workflow at `.github/workflows/miri.yml`, and surfaces
 via a dedicated badge in the project README.
 
+Docs-only changes (`**/*.md`, `docs/**`, `assets/**`, `LICENSE*`,
+`.gitignore`, `.gitattributes`) are skipped via `paths-ignore` in the
+real Miri workflow. A companion shim workflow at
+`.github/workflows/miri-skip.yml` runs on exactly those paths and
+emits a passing check with the same name (`miri (pure-Rust UB
+validation)`), so branch protection's required-check rule is
+satisfied without spinning up the nightly toolchain for a README typo.
+If you change the `paths-ignore` list in `miri.yml`, mirror the change
+to the `paths` list in `miri-skip.yml`.
+
 Each future finding gets its own fix PR — never a mega-PR — mirroring
 the #180 cleanup series pattern (and #192 from this safety net's first
 run, which uncovered a real unaligned-transmute UB).


### PR DESCRIPTION
Follow-up to [#196](https://github.com/webarkit/WebARKitLib-rs/pull/196). Companion to the new `protect-main` / `protect-dev` rulesets.

## Problem

Now that Miri is a required check, a docs-only PR (README typo, `docs/**` change, asset swap) would block at merge — branch protection can't distinguish "skipped because nothing to validate" from "didn't run." A naive `paths-ignore` makes the required check appear *missing*, not *passing*.

## Solution

Two workflow files declaring the **same** `name: Miri` and the **same** job `name: miri (pure-Rust UB validation)`:

| File | Triggers on | Does |
|---|---|---|
| `.github/workflows/miri.yml` | Rust / Cargo / workflow / Cargo.toml changes (everything except docs) | Real Miri run (~55 min) |
| `.github/workflows/miri-skip.yml` | Docs-only changes (`**/*.md`, `docs/**`, `assets/**`, `LICENSE*`, `.gitignore`, `.gitattributes`) | Single `echo` step that emits a passing check |

GitHub branch protection matches required checks by name, so either file satisfies the rule. A docs-only PR no longer spins up the nightly toolchain (saves ~5 min of CI per docs PR) while still passing the gate.

## Files

- `.github/workflows/miri.yml` — adds the `paths-ignore` list to both `pull_request` and `push`.
- `.github/workflows/miri-skip.yml` — new shim. Inverse path list, no real work.
- `docs/miri.md` — documents the pattern and the "keep both path lists in sync" rule.

## Verification

- `cargo fmt --check` clean (no code changes).
- This PR touches a workflow file, so the **real** Miri workflow should run (not the shim). Both rulesets' required checks should turn green.
- Once merged, the next docs-only PR will exercise the shim path — that's the actual proof.

## Test plan after merge

Open a tiny throwaway PR that changes only `README.md`:
- The shim workflow should run and produce a passing `miri (pure-Rust UB validation)` check.
- The real Miri workflow should NOT run.
- The PR should be mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)