### PR TITLE
perf(kpm): criterion benchmark for Gaussian scale-space pyramid (#200)

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -153,3 +153,7 @@ required-features = ["simd-x86-sse41"]
 name = "feature_map_bench"
 harness = false
 required-features = ["log-helpers"]
+
+[[bench]]
+name = "gaussian_pyramid_bench"
+harness = false

--- a/crates/core/benches/gaussian_pyramid_bench.rs
+++ b/crates/core/benches/gaussian_pyramid_bench.rs
@@ -1,0 +1,160 @@
+/*
+ *  gaussian_pyramid_bench.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Criterion baseline for the **Gaussian scale-space pyramid** (#200) — the
+//! pyramid the KPM/FREAK detector actually uses (via
+//! `DoGScaleInvariantDetector`).
+//!
+//! Establishes the scalar baseline so the SIMD work can prove its speedup:
+//! the binomial 5-tap filter (#201) and the bilinear downsample (#202).
+//!
+//! Groups, each at 640×480, 1280×720 and 1920×1080:
+//!
+//! - `gaussian_binomial_u8`: `binomial_4th_order_u8_to_f32_scalar` (octave 0).
+//! - `gaussian_binomial_f32`: `binomial_4th_order_f32_to_f32_scalar` (the
+//!   dominant per-octave cost — runs 3× per octave).
+//! - `gaussian_bilinear`: `downsample_bilinear_f32_scalar` (between octaves).
+//! - `gaussian_build`: end-to-end `GaussianScaleSpacePyramid::build` with
+//!   `num_octaves` from `num_octaves_for(w, h, 8)`, matching the real KPM
+//!   backend (`rust_backend.rs`).
+//!
+//! Inputs are filled deterministically with a fixed-seed PRNG so runs are
+//! comparable across machines and across PRs in the series.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use purecv::core::Matrix;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use std::hint::black_box;
+use webarkitlib_rs::kpm::freak::gaussian_pyramid::{
+    binomial_4th_order_f32_to_f32_scalar, binomial_4th_order_u8_to_f32_scalar,
+    downsample_bilinear_f32_scalar,
+};
+use webarkitlib_rs::kpm::freak::{num_octaves_for, GaussianScaleSpacePyramid};
+
+/// Typical AR camera input resolutions as `(width, height)`.
+const SIZES: &[(usize, usize)] = &[(640, 480), (1280, 720), (1920, 1080)];
+
+/// `min_size` for `num_octaves_for`, matching the real KPM backend.
+const MIN_COARSE_SIZE: usize = 8;
+
+/// Deterministic grayscale `Matrix<u8>` (`rows × cols`), fixed-seed PRNG.
+fn random_u8(rows: usize, cols: usize) -> Matrix<u8> {
+    let mut rng = StdRng::seed_from_u64(0x6A05_51A2);
+    let data: Vec<u8> = (0..rows * cols).map(|_| rng.random::<u8>()).collect();
+    Matrix::<u8>::from_vec(rows, cols, 1, data)
+}
+
+/// Deterministic `Matrix<f32>` with values in `[0, 256)`, fixed-seed PRNG.
+fn random_f32(rows: usize, cols: usize) -> Matrix<f32> {
+    let mut rng = StdRng::seed_from_u64(0x6A05_51A3);
+    let data: Vec<f32> = (0..rows * cols)
+        .map(|_| rng.random::<u8>() as f32)
+        .collect();
+    Matrix::<f32>::from_vec(rows, cols, 1, data)
+}
+
+fn bench_binomial_u8(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gaussian_binomial_u8");
+    for &(w, h) in SIZES {
+        let src = random_u8(h, w);
+        group.throughput(Throughput::Elements((w * h) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("scalar", format!("{w}x{h}")),
+            &src,
+            |bencher, src| bencher.iter(|| binomial_4th_order_u8_to_f32_scalar(black_box(src))),
+        );
+    }
+    group.finish();
+}
+
+fn bench_binomial_f32(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gaussian_binomial_f32");
+    for &(w, h) in SIZES {
+        let src = random_f32(h, w);
+        group.throughput(Throughput::Elements((w * h) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("scalar", format!("{w}x{h}")),
+            &src,
+            |bencher, src| bencher.iter(|| binomial_4th_order_f32_to_f32_scalar(black_box(src))),
+        );
+    }
+    group.finish();
+}
+
+fn bench_bilinear(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gaussian_bilinear");
+    for &(w, h) in SIZES {
+        let src = random_f32(h, w);
+        group.throughput(Throughput::Elements((w * h) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("scalar", format!("{w}x{h}")),
+            &src,
+            |bencher, src| bencher.iter(|| downsample_bilinear_f32_scalar(black_box(src))),
+        );
+    }
+    group.finish();
+}
+
+fn bench_build(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gaussian_build");
+    for &(w, h) in SIZES {
+        let src = random_u8(h, w);
+        let n_oct = num_octaves_for(w, h, MIN_COARSE_SIZE);
+        group.throughput(Throughput::Elements((w * h) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("scalar", format!("{w}x{h}")),
+            &src,
+            |bencher, src| {
+                bencher.iter(|| {
+                    let mut p = GaussianScaleSpacePyramid::new(n_oct);
+                    p.build(black_box(src)).expect("build should succeed");
+                    p
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_binomial_u8,
+    bench_binomial_f32,
+    bench_bilinear,
+    bench_build
+);
+criterion_main!(benches);

--- a/crates/core/src/kpm/freak/gaussian_pyramid.rs
+++ b/crates/core/src/kpm/freak/gaussian_pyramid.rs
@@ -275,12 +275,30 @@ pub fn num_octaves_for(width: usize, height: usize, min_size: usize) -> usize {
 
 /// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, u8 source → f32 dest.
 ///
+/// Dispatches to the fastest available implementation; currently scalar
+/// only (SIMD paths land in #201). See
+/// [`binomial_4th_order_u8_to_f32_scalar`].
+///
+/// # Note on visibility
+///
+/// This dispatcher, the `*_scalar` helpers, and
+/// [`downsample_bilinear_f32`] are `pub` so the criterion benchmark (a
+/// separate crate) can measure them directly. They are not a stability
+/// guarantee — prefer [`GaussianScaleSpacePyramid::build`].
+#[must_use]
+pub fn binomial_4th_order_u8_to_f32(src: &Matrix<u8>) -> Matrix<f32> {
+    binomial_4th_order_u8_to_f32_scalar(src)
+}
+
+/// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, u8 source → f32 dest.
+///
 /// H pass uses `u16` accumulator (max value `16 * 255 = 4080`, fits `u16`).
 /// V pass multiplies by `1 / 256` to yield `f32` output. Border replication:
 /// edge pixels extend the 2-pixel border on each side.
 ///
 /// C equivalent: `vision::binomial_4th_order(float*, unsigned short*, const unsigned char*, ...)`.
-fn binomial_4th_order_u8_to_f32(src: &Matrix<u8>) -> Matrix<f32> {
+#[must_use]
+pub fn binomial_4th_order_u8_to_f32_scalar(src: &Matrix<u8>) -> Matrix<f32> {
     let width = src.cols;
     let height = src.rows;
     debug_assert!(width >= 5 && height >= 5);
@@ -366,12 +384,23 @@ fn binomial_4th_order_u8_to_f32(src: &Matrix<u8>) -> Matrix<f32> {
     Matrix::<f32>::from_vec(height, width, 1, dst_data)
 }
 
+/// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, f32 → f32.
+///
+/// Dispatches to the fastest available implementation; currently scalar
+/// only (SIMD paths land in #201). See
+/// [`binomial_4th_order_f32_to_f32_scalar`].
+#[must_use]
+pub fn binomial_4th_order_f32_to_f32(src: &Matrix<f32>) -> Matrix<f32> {
+    binomial_4th_order_f32_to_f32_scalar(src)
+}
+
 /// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, f32 → f32. Used for
 /// the second and third levels within an octave and for all levels in
 /// non-zero octaves.
 ///
 /// C equivalent: `vision::binomial_4th_order(float*, float*, const float*, ...)`.
-fn binomial_4th_order_f32_to_f32(src: &Matrix<f32>) -> Matrix<f32> {
+#[must_use]
+pub fn binomial_4th_order_f32_to_f32_scalar(src: &Matrix<f32>) -> Matrix<f32> {
     let width = src.cols;
     let height = src.rows;
     debug_assert!(width >= 5 && height >= 5);
@@ -443,11 +472,21 @@ fn binomial_4th_order_f32_to_f32(src: &Matrix<f32>) -> Matrix<f32> {
 }
 
 /// 2x2 bilinear downsample. Output dims: `(src.rows >> 1, src.cols >> 1)`.
+///
+/// Dispatches to the fastest available implementation; currently scalar
+/// only (SIMD paths land in #202). See [`downsample_bilinear_f32_scalar`].
+#[must_use]
+pub fn downsample_bilinear_f32(src: &Matrix<f32>) -> Matrix<f32> {
+    downsample_bilinear_f32_scalar(src)
+}
+
+/// 2x2 bilinear downsample. Output dims: `(src.rows >> 1, src.cols >> 1)`.
 /// Per output pixel: `(p00 + p01 + p10 + p11) * 0.25`. No `ceil` adjustment
 /// (unlike the M8-1 box-filter pyramid).
 ///
 /// C equivalent: `vision::downsample_bilinear`.
-fn downsample_bilinear_f32(src: &Matrix<f32>) -> Matrix<f32> {
+#[must_use]
+pub fn downsample_bilinear_f32_scalar(src: &Matrix<f32>) -> Matrix<f32> {
     let dst_w = src.cols >> 1;
     let dst_h = src.rows >> 1;
     let src_data = src.as_slice();


### PR DESCRIPTION
## Summary

Establishes the **scalar baseline** for the Gaussian pyramid SIMD series (#200 → #201 → #202). Unlike the `BoxFilterPyramid8u` trilogy (#131–133, which turned out to optimize dead code — see #203), `GaussianScaleSpacePyramid` is the pyramid the KPM/FREAK detector **actually uses**, via `DoGScaleInvariantDetector`.

Closes #200.

> Stacked PR: targets `feat/gaussian-pyramid-simd` (the series base off `dev`), not `dev` directly.

## Changes

- Promote the three hot helpers to `pub` with **scalar-only dispatchers**, following the `pyramid::downsample` precedent from #131:
  - `binomial_4th_order_u8_to_f32` / `_scalar`
  - `binomial_4th_order_f32_to_f32` / `_scalar`  ← dominant per-octave cost (3× per octave)
  - `downsample_bilinear_f32` / `_scalar`
  - `build` calls the dispatchers, so #201/#202 only need to fill in the SIMD variants and wire dispatch. Behavior is unchanged — the `dual-mode` byte-for-byte C++ parity test stays green.
- Add `crates/core/benches/gaussian_pyramid_bench.rs` benchmarking each scalar helper plus end-to-end `build` (`num_octaves` from `num_octaves_for(w, h, 8)`, matching `rust_backend`), at 640×480 / 1280×720 / 1920×1080 with fixed-seed PRNG input.
- Wire `[[bench]] name = "gaussian_pyramid_bench"` into `Cargo.toml`.

## Baseline numbers (median, contributor machine)

| Group | 640×480 | 1280×720 | 1920×1080 |
|-------|--------:|---------:|----------:|
| `binomial_f32` (dominant) | 710 µs | 2.04 ms | **5.26 ms** |
| `binomial_u8` | 546 µs | 1.60 ms | 3.38 ms |
| `bilinear` | 138 µs | 381 µs | 1.16 ms |
| **`build` (end-to-end)** | 3.11 ms | 9.95 ms | **26.0 ms** |

These dwarf the box-filter downsample (µs-scale) and confirm where the real per-frame cost lives — a full 1080p pyramid build is **~26 ms**, a large slice of a 30 fps frame budget. #201 (binomial filter) is the high-value target; #202 (bilinear) is secondary.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo bench --bench gaussian_pyramid_bench --no-run` compiles
- `cargo clippy --all-targets --all-features -- --deny warnings` — no issues
- `cargo test --all-features gaussian` — 11 passed, **including the `dual-mode` byte-for-byte C++ parity test**

## Next in series

- #201 — SIMD binomial 5-tap filter (**f32 bit-parity: no FMA, matched op order**; dual-mode test is the oracle)
- #202 — SIMD bilinear f32 downsample (same parity constraint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
