### PR TITLE
perf(kpm): Gaussian scale-space pyramid — benchmark + rayon parallelization

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -153,3 +153,7 @@ required-features = ["simd-x86-sse41"]
 name = "feature_map_bench"
 harness = false
 required-features = ["log-helpers"]
+
+[[bench]]
+name = "gaussian_pyramid_bench"
+harness = false

--- a/crates/core/benches/gaussian_pyramid_bench.rs
+++ b/crates/core/benches/gaussian_pyramid_bench.rs
@@ -1,0 +1,160 @@
+/*
+ *  gaussian_pyramid_bench.rs
+ *  WebARKitLib-rs
+ *
+ *  This file is part of WebARKitLib-rs - WebARKit.
+ *
+ *  WebARKitLib-rs is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  WebARKitLib-rs is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with WebARKitLib-rs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+//! Criterion baseline for the **Gaussian scale-space pyramid** (#200) — the
+//! pyramid the KPM/FREAK detector actually uses (via
+//! `DoGScaleInvariantDetector`).
+//!
+//! Establishes the scalar baseline so the SIMD work can prove its speedup:
+//! the binomial 5-tap filter (#201) and the bilinear downsample (#202).
+//!
+//! Groups, each at 640×480, 1280×720 and 1920×1080:
+//!
+//! - `gaussian_binomial_u8`: `binomial_4th_order_u8_to_f32_scalar` (octave 0).
+//! - `gaussian_binomial_f32`: `binomial_4th_order_f32_to_f32_scalar` (the
+//!   dominant per-octave cost — runs 3× per octave).
+//! - `gaussian_bilinear`: `downsample_bilinear_f32_scalar` (between octaves).
+//! - `gaussian_build`: end-to-end `GaussianScaleSpacePyramid::build` with
+//!   `num_octaves` from `num_octaves_for(w, h, 8)`, matching the real KPM
+//!   backend (`rust_backend.rs`).
+//!
+//! Inputs are filled deterministically with a fixed-seed PRNG so runs are
+//! comparable across machines and across PRs in the series.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use purecv::core::Matrix;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use std::hint::black_box;
+use webarkitlib_rs::kpm::freak::gaussian_pyramid::{
+    binomial_4th_order_f32_to_f32_scalar, binomial_4th_order_u8_to_f32_scalar,
+    downsample_bilinear_f32_scalar,
+};
+use webarkitlib_rs::kpm::freak::{num_octaves_for, GaussianScaleSpacePyramid};
+
+/// Typical AR camera input resolutions as `(width, height)`.
+const SIZES: &[(usize, usize)] = &[(640, 480), (1280, 720), (1920, 1080)];
+
+/// `min_size` for `num_octaves_for`, matching the real KPM backend.
+const MIN_COARSE_SIZE: usize = 8;
+
+/// Deterministic grayscale `Matrix<u8>` (`rows × cols`), fixed-seed PRNG.
+fn random_u8(rows: usize, cols: usize) -> Matrix<u8> {
+    let mut rng = StdRng::seed_from_u64(0x6A05_51A2);
+    let data: Vec<u8> = (0..rows * cols).map(|_| rng.random::<u8>()).collect();
+    Matrix::<u8>::from_vec(rows, cols, 1, data)
+}
+
+/// Deterministic `Matrix<f32>` with values in `[0, 256)`, fixed-seed PRNG.
+fn random_f32(rows: usize, cols: usize) -> Matrix<f32> {
+    let mut rng = StdRng::seed_from_u64(0x6A05_51A3);
+    let data: Vec<f32> = (0..rows * cols)
+        .map(|_| rng.random::<u8>() as f32)
+        .collect();
+    Matrix::<f32>::from_vec(rows, cols, 1, data)
+}
+
+fn bench_binomial_u8(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gaussian_binomial_u8");
+    for &(w, h) in SIZES {
+        let src = random_u8(h, w);
+        group.throughput(Throughput::Elements((w * h) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("scalar", format!("{w}x{h}")),
+            &src,
+            |bencher, src| bencher.iter(|| binomial_4th_order_u8_to_f32_scalar(black_box(src))),
+        );
+    }
+    group.finish();
+}
+
+fn bench_binomial_f32(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gaussian_binomial_f32");
+    for &(w, h) in SIZES {
+        let src = random_f32(h, w);
+        group.throughput(Throughput::Elements((w * h) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("scalar", format!("{w}x{h}")),
+            &src,
+            |bencher, src| bencher.iter(|| binomial_4th_order_f32_to_f32_scalar(black_box(src))),
+        );
+    }
+    group.finish();
+}
+
+fn bench_bilinear(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gaussian_bilinear");
+    for &(w, h) in SIZES {
+        let src = random_f32(h, w);
+        group.throughput(Throughput::Elements((w * h) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("scalar", format!("{w}x{h}")),
+            &src,
+            |bencher, src| bencher.iter(|| downsample_bilinear_f32_scalar(black_box(src))),
+        );
+    }
+    group.finish();
+}
+
+fn bench_build(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gaussian_build");
+    for &(w, h) in SIZES {
+        let src = random_u8(h, w);
+        let n_oct = num_octaves_for(w, h, MIN_COARSE_SIZE);
+        group.throughput(Throughput::Elements((w * h) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("scalar", format!("{w}x{h}")),
+            &src,
+            |bencher, src| {
+                bencher.iter(|| {
+                    let mut p = GaussianScaleSpacePyramid::new(n_oct);
+                    p.build(black_box(src)).expect("build should succeed");
+                    p
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_binomial_u8,
+    bench_binomial_f32,
+    bench_bilinear,
+    bench_build
+);
+criterion_main!(benches);

--- a/crates/core/benches/gaussian_pyramid_bench.rs
+++ b/crates/core/benches/gaussian_pyramid_bench.rs
@@ -65,6 +65,12 @@ use webarkitlib_rs::kpm::freak::gaussian_pyramid::{
 };
 use webarkitlib_rs::kpm::freak::{num_octaves_for, GaussianScaleSpacePyramid};
 
+#[cfg(not(target_arch = "wasm32"))]
+use webarkitlib_rs::kpm::freak::gaussian_pyramid::{
+    binomial_4th_order_f32_to_f32_rayon, binomial_4th_order_u8_to_f32_rayon,
+    downsample_bilinear_f32_rayon,
+};
+
 /// Typical AR camera input resolutions as `(width, height)`.
 const SIZES: &[(usize, usize)] = &[(640, 480), (1280, 720), (1920, 1080)];
 
@@ -97,6 +103,13 @@ fn bench_binomial_u8(c: &mut Criterion) {
             &src,
             |bencher, src| bencher.iter(|| binomial_4th_order_u8_to_f32_scalar(black_box(src))),
         );
+
+        #[cfg(not(target_arch = "wasm32"))]
+        group.bench_with_input(
+            BenchmarkId::new("rayon", format!("{w}x{h}")),
+            &src,
+            |bencher, src| bencher.iter(|| binomial_4th_order_u8_to_f32_rayon(black_box(src))),
+        );
     }
     group.finish();
 }
@@ -111,6 +124,13 @@ fn bench_binomial_f32(c: &mut Criterion) {
             &src,
             |bencher, src| bencher.iter(|| binomial_4th_order_f32_to_f32_scalar(black_box(src))),
         );
+
+        #[cfg(not(target_arch = "wasm32"))]
+        group.bench_with_input(
+            BenchmarkId::new("rayon", format!("{w}x{h}")),
+            &src,
+            |bencher, src| bencher.iter(|| binomial_4th_order_f32_to_f32_rayon(black_box(src))),
+        );
     }
     group.finish();
 }
@@ -124,6 +144,13 @@ fn bench_bilinear(c: &mut Criterion) {
             BenchmarkId::new("scalar", format!("{w}x{h}")),
             &src,
             |bencher, src| bencher.iter(|| downsample_bilinear_f32_scalar(black_box(src))),
+        );
+
+        #[cfg(not(target_arch = "wasm32"))]
+        group.bench_with_input(
+            BenchmarkId::new("rayon", format!("{w}x{h}")),
+            &src,
+            |bencher, src| bencher.iter(|| downsample_bilinear_f32_rayon(black_box(src))),
         );
     }
     group.finish();

--- a/crates/core/src/kpm/freak/gaussian_pyramid.rs
+++ b/crates/core/src/kpm/freak/gaussian_pyramid.rs
@@ -269,32 +269,198 @@ pub fn num_octaves_for(width: usize, height: usize, min_size: usize) -> usize {
 }
 
 // ─────────────────────────────────────────────────────────────────────────
-// Private filter helpers — byte-for-byte port of C++ `binomial_4th_order`
-// and `downsample_bilinear` from `gaussian_scale_space_pyramid.cpp`.
+// Filter helpers — byte-for-byte port of C++ `binomial_4th_order` and
+// `downsample_bilinear` from `gaussian_scale_space_pyramid.cpp`.
+//
+// The per-row helpers below are the single source of truth for the
+// arithmetic; the serial scalar paths and the rayon paths (#207) both call
+// them, so output is bit-for-bit identical regardless of threading
+// (validated by the `dual-mode` C++ parity test). rows are independent, so
+// parallelizing over them changes nothing numerically.
 // ─────────────────────────────────────────────────────────────────────────
+
+/// `1 / 256` normalization applied on the vertical pass. Exact in f32.
+const INV_256: f32 = 1.0 / 256.0;
+
+/// Below this pixel count the rayon path's thread-pool overhead outweighs the
+/// win, so the dispatchers run serially (CLAUDE.md §3: "don't parallelize
+/// small loops"). Benchmarking showed the binomial filter regresses at
+/// 640×480 (~0.3 MPx) but scales ~1.5× at 1280×720 (~0.9 MPx); this
+/// conservative threshold keeps ≤480p serial and is a machine-dependent
+/// heuristic, not a hard tuning point.
+const PARALLEL_MIN_PIXELS: usize = 600_000;
+
+// ── f32 → f32 per-row helpers ────────────────────────────────────────────
+
+/// Horizontal pass of one row, f32 → f32. `s` and `t` are the row slices of
+/// the source and the temp buffer.
+#[inline]
+fn binomial_h_row_f32(s: &[f32], t: &mut [f32], width: usize) {
+    t[0] = 6.0 * s[0] + 4.0 * (s[0] + s[1]) + s[0] + s[2];
+    t[1] = 6.0 * s[1] + 4.0 * (s[0] + s[2]) + s[0] + s[3];
+    for col in 2..width - 2 {
+        t[col] = 6.0 * s[col] + 4.0 * (s[col - 1] + s[col + 1]) + s[col - 2] + s[col + 2];
+    }
+    let c = width - 2;
+    t[c] = 6.0 * s[c] + 4.0 * (s[c - 1] + s[c + 1]) + s[c - 2] + s[c + 1];
+    let c = width - 1;
+    t[c] = 6.0 * s[c] + 4.0 * (s[c - 1] + s[c]) + s[c - 2] + s[c];
+}
+
+/// Vertical pass of one output `row`, f32 → f32. Reads `tmp`, writes
+/// `dst_row` (length `width`). Border rows (0, 1, height-2, height-1)
+/// replicate edges; interior rows use the full 5-tap.
+#[inline]
+fn binomial_v_row_f32(tmp: &[f32], dst_row: &mut [f32], row: usize, width: usize, height: usize) {
+    let h = height;
+    if row == 0 {
+        for (col, d) in dst_row.iter_mut().enumerate() {
+            let p = tmp[col];
+            let pp1 = tmp[width + col];
+            let pp2 = tmp[2 * width + col];
+            *d = (6.0 * p + 4.0 * (p + pp1) + p + pp2) * INV_256;
+        }
+    } else if row == 1 {
+        for (col, d) in dst_row.iter_mut().enumerate() {
+            let pm = tmp[col];
+            let p = tmp[width + col];
+            let pp1 = tmp[2 * width + col];
+            let pp2 = tmp[3 * width + col];
+            *d = (6.0 * p + 4.0 * (pm + pp1) + pm + pp2) * INV_256;
+        }
+    } else if row == h - 2 {
+        for (col, d) in dst_row.iter_mut().enumerate() {
+            let pm2 = tmp[(h - 4) * width + col];
+            let pm1 = tmp[(h - 3) * width + col];
+            let p = tmp[(h - 2) * width + col];
+            let pp = tmp[(h - 1) * width + col];
+            *d = (6.0 * p + 4.0 * (pm1 + pp) + pm2 + pp) * INV_256;
+        }
+    } else if row == h - 1 {
+        for (col, d) in dst_row.iter_mut().enumerate() {
+            let pm2 = tmp[(h - 3) * width + col];
+            let pm1 = tmp[(h - 2) * width + col];
+            let p = tmp[(h - 1) * width + col];
+            *d = (6.0 * p + 4.0 * (pm1 + p) + pm2 + p) * INV_256;
+        }
+    } else {
+        for (col, d) in dst_row.iter_mut().enumerate() {
+            let pm2 = tmp[(row - 2) * width + col];
+            let pm1 = tmp[(row - 1) * width + col];
+            let p = tmp[row * width + col];
+            let pp1 = tmp[(row + 1) * width + col];
+            let pp2 = tmp[(row + 2) * width + col];
+            *d = (6.0 * p + 4.0 * (pm1 + pp1) + pm2 + pp2) * INV_256;
+        }
+    }
+}
+
+// ── u8 → f32 per-row helpers ─────────────────────────────────────────────
+
+/// Horizontal pass of one row, u8 → u16 (exact integer; max 4080).
+#[inline]
+fn binomial_h_row_u8(s: &[u8], t: &mut [u16], width: usize) {
+    t[0] = 6 * s[0] as u16 + 4 * (s[0] as u16 + s[1] as u16) + (s[0] as u16 + s[2] as u16);
+    t[1] = 6 * s[1] as u16 + 4 * (s[0] as u16 + s[2] as u16) + (s[0] as u16 + s[3] as u16);
+    for col in 2..width - 2 {
+        t[col] = 6 * s[col] as u16
+            + 4 * (s[col - 1] as u16 + s[col + 1] as u16)
+            + (s[col - 2] as u16 + s[col + 2] as u16);
+    }
+    let c = width - 2;
+    t[c] = 6 * s[c] as u16
+        + 4 * (s[c - 1] as u16 + s[c + 1] as u16)
+        + (s[c - 2] as u16 + s[c + 1] as u16);
+    let c = width - 1;
+    t[c] = 6 * s[c] as u16 + 4 * (s[c - 1] as u16 + s[c] as u16) + (s[c - 2] as u16 + s[c] as u16);
+}
+
+/// Vertical pass of one output `row`, u16 → f32 (sum in `u32`, then
+/// `* INV_256`).
+#[inline]
+fn binomial_v_row_u8(tmp: &[u16], dst_row: &mut [f32], row: usize, width: usize, height: usize) {
+    let h = height;
+    if row == 0 {
+        for (col, d) in dst_row.iter_mut().enumerate() {
+            let p = tmp[col] as u32;
+            let pp1 = tmp[width + col] as u32;
+            let pp2 = tmp[2 * width + col] as u32;
+            *d = ((6 * p + 4 * (p + pp1) + p + pp2) as f32) * INV_256;
+        }
+    } else if row == 1 {
+        for (col, d) in dst_row.iter_mut().enumerate() {
+            let pm = tmp[col] as u32;
+            let p = tmp[width + col] as u32;
+            let pp1 = tmp[2 * width + col] as u32;
+            let pp2 = tmp[3 * width + col] as u32;
+            *d = ((6 * p + 4 * (pm + pp1) + pm + pp2) as f32) * INV_256;
+        }
+    } else if row == h - 2 {
+        for (col, d) in dst_row.iter_mut().enumerate() {
+            let pm2 = tmp[(h - 4) * width + col] as u32;
+            let pm1 = tmp[(h - 3) * width + col] as u32;
+            let p = tmp[(h - 2) * width + col] as u32;
+            let pp = tmp[(h - 1) * width + col] as u32;
+            *d = ((6 * p + 4 * (pm1 + pp) + pm2 + pp) as f32) * INV_256;
+        }
+    } else if row == h - 1 {
+        for (col, d) in dst_row.iter_mut().enumerate() {
+            let pm2 = tmp[(h - 3) * width + col] as u32;
+            let pm1 = tmp[(h - 2) * width + col] as u32;
+            let p = tmp[(h - 1) * width + col] as u32;
+            *d = ((6 * p + 4 * (pm1 + p) + pm2 + p) as f32) * INV_256;
+        }
+    } else {
+        for (col, d) in dst_row.iter_mut().enumerate() {
+            let pm2 = tmp[(row - 2) * width + col] as u32;
+            let pm1 = tmp[(row - 1) * width + col] as u32;
+            let p = tmp[row * width + col] as u32;
+            let pp1 = tmp[(row + 1) * width + col] as u32;
+            let pp2 = tmp[(row + 2) * width + col] as u32;
+            *d = ((6 * p + 4 * (pm1 + pp1) + pm2 + pp2) as f32) * INV_256;
+        }
+    }
+}
+
+/// 2x2 bilinear downsample of one output row: `(p00+p01+p10+p11) * 0.25`.
+#[inline]
+fn bilinear_row_f32(src_data: &[f32], dst_row: &mut [f32], out_row: usize, src_w: usize) {
+    let r0 = (out_row * 2) * src_w;
+    let r1 = r0 + src_w;
+    for (col, d) in dst_row.iter_mut().enumerate() {
+        let c = col * 2;
+        let sum = src_data[r0 + c] + src_data[r0 + c + 1] + src_data[r1 + c] + src_data[r1 + c + 1];
+        *d = sum * 0.25;
+    }
+}
+
+// ── u8 → f32 ─────────────────────────────────────────────────────────────
 
 /// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, u8 source → f32 dest.
 ///
-/// Dispatches to the fastest available implementation; currently scalar
-/// only (SIMD paths land in #201). See
-/// [`binomial_4th_order_u8_to_f32_scalar`].
+/// Dispatches to the rayon path above [`PARALLEL_MIN_PIXELS`] (non-wasm),
+/// else scalar. Output is identical either way.
 ///
 /// # Note on visibility
 ///
-/// This dispatcher, the `*_scalar` helpers, and
+/// This dispatcher, the `*_scalar` / `*_rayon` variants, and
 /// [`downsample_bilinear_f32`] are `pub` so the criterion benchmark (a
 /// separate crate) can measure them directly. They are not a stability
 /// guarantee — prefer [`GaussianScaleSpacePyramid::build`].
 #[must_use]
 pub fn binomial_4th_order_u8_to_f32(src: &Matrix<u8>) -> Matrix<f32> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        if src.rows.saturating_mul(src.cols) >= PARALLEL_MIN_PIXELS {
+            return binomial_4th_order_u8_to_f32_rayon(src);
+        }
+    }
     binomial_4th_order_u8_to_f32_scalar(src)
 }
 
-/// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, u8 source → f32 dest.
-///
-/// H pass uses `u16` accumulator (max value `16 * 255 = 4080`, fits `u16`).
-/// V pass multiplies by `1 / 256` to yield `f32` output. Border replication:
-/// edge pixels extend the 2-pixel border on each side.
+/// Serial u8 → f32 binomial filter. H pass uses `u16` accumulators (max
+/// `16 * 255 = 4080`); V pass sums in `u32` then `* 1/256`. Border
+/// replication extends edge pixels by 2 on each side.
 ///
 /// C equivalent: `vision::binomial_4th_order(float*, unsigned short*, const unsigned char*, ...)`.
 #[must_use]
@@ -305,98 +471,69 @@ pub fn binomial_4th_order_u8_to_f32_scalar(src: &Matrix<u8>) -> Matrix<f32> {
 
     let src_data = src.as_slice();
     let mut tmp = vec![0u16; width * height];
-
-    // Horizontal pass.
     for row in 0..height {
-        let row_off = row * width;
-        let s = &src_data[row_off..row_off + width];
-        // col 0: xm2 = xm1 = c = s[0], xp1 = s[1], xp2 = s[2].
-        tmp[row_off] =
-            6 * s[0] as u16 + 4 * (s[0] as u16 + s[1] as u16) + (s[0] as u16 + s[2] as u16);
-        // col 1: xm2 = s[0], xm1 = s[0], c = s[1], xp1 = s[2], xp2 = s[3].
-        tmp[row_off + 1] =
-            6 * s[1] as u16 + 4 * (s[0] as u16 + s[2] as u16) + (s[0] as u16 + s[3] as u16);
-        // Non-border cols.
-        for col in 2..width - 2 {
-            tmp[row_off + col] = 6 * s[col] as u16
-                + 4 * (s[col - 1] as u16 + s[col + 1] as u16)
-                + (s[col - 2] as u16 + s[col + 2] as u16);
-        }
-        // col width-2: xp2 clamped to s[width-1].
-        let c = width - 2;
-        tmp[row_off + c] = 6 * s[c] as u16
-            + 4 * (s[c - 1] as u16 + s[c + 1] as u16)
-            + (s[c - 2] as u16 + s[c + 1] as u16);
-        // col width-1: xp1 = xp2 = s[width-1].
-        let c = width - 1;
-        tmp[row_off + c] =
-            6 * s[c] as u16 + 4 * (s[c - 1] as u16 + s[c] as u16) + (s[c - 2] as u16 + s[c] as u16);
+        let off = row * width;
+        binomial_h_row_u8(
+            &src_data[off..off + width],
+            &mut tmp[off..off + width],
+            width,
+        );
     }
 
-    // Vertical pass.
     let mut dst_data = vec![0f32; width * height];
-    const INV_256: f32 = 1.0 / 256.0;
-
-    // Top border: rows 0 and 1.
-    for col in 0..width {
-        // row 0: pm2 = pm1 = p = tmp[col]; pp1 = tmp[width+col]; pp2 = tmp[2w+col].
-        let p = tmp[col] as u32;
-        let pp1 = tmp[width + col] as u32;
-        let pp2 = tmp[2 * width + col] as u32;
-        dst_data[col] = ((6 * p + 4 * (p + pp1) + p + pp2) as f32) * INV_256;
-        // row 1: pm2 = pm1 = tmp[col]; p = tmp[w+col]; pp1 = tmp[2w+col]; pp2 = tmp[3w+col].
-        let pm = tmp[col] as u32;
-        let p = tmp[width + col] as u32;
-        let pp1 = tmp[2 * width + col] as u32;
-        let pp2 = tmp[3 * width + col] as u32;
-        dst_data[width + col] = ((6 * p + 4 * (pm + pp1) + pm + pp2) as f32) * INV_256;
-    }
-
-    // Non-border rows.
-    for row in 2..height - 2 {
-        let row_off = row * width;
-        for col in 0..width {
-            let pm2 = tmp[(row - 2) * width + col] as u32;
-            let pm1 = tmp[(row - 1) * width + col] as u32;
-            let p = tmp[row_off + col] as u32;
-            let pp1 = tmp[(row + 1) * width + col] as u32;
-            let pp2 = tmp[(row + 2) * width + col] as u32;
-            dst_data[row_off + col] = ((6 * p + 4 * (pm1 + pp1) + pm2 + pp2) as f32) * INV_256;
-        }
-    }
-
-    // Bottom border: rows h-2 and h-1.
-    let h = height;
-    for col in 0..width {
-        // row h-2: pp1 = pp2 = tmp[(h-1)*w + col].
-        let pm2 = tmp[(h - 4) * width + col] as u32;
-        let pm1 = tmp[(h - 3) * width + col] as u32;
-        let p = tmp[(h - 2) * width + col] as u32;
-        let pp = tmp[(h - 1) * width + col] as u32;
-        dst_data[(h - 2) * width + col] = ((6 * p + 4 * (pm1 + pp) + pm2 + pp) as f32) * INV_256;
-        // row h-1: p = pp1 = pp2 = tmp[(h-1)*w + col].
-        let pm2 = tmp[(h - 3) * width + col] as u32;
-        let pm1 = tmp[(h - 2) * width + col] as u32;
-        let p = tmp[(h - 1) * width + col] as u32;
-        dst_data[(h - 1) * width + col] = ((6 * p + 4 * (pm1 + p) + pm2 + p) as f32) * INV_256;
+    for row in 0..height {
+        let off = row * width;
+        binomial_v_row_u8(&tmp, &mut dst_data[off..off + width], row, width, height);
     }
 
     Matrix::<f32>::from_vec(height, width, 1, dst_data)
 }
 
+/// Rayon u8 → f32 binomial filter — parallel over rows. Bit-for-bit
+/// identical to [`binomial_4th_order_u8_to_f32_scalar`] (rows independent).
+#[cfg(not(target_arch = "wasm32"))]
+#[must_use]
+pub fn binomial_4th_order_u8_to_f32_rayon(src: &Matrix<u8>) -> Matrix<f32> {
+    use rayon::prelude::*;
+
+    let width = src.cols;
+    let height = src.rows;
+    debug_assert!(width >= 5 && height >= 5);
+
+    let src_data = src.as_slice();
+    let mut tmp = vec![0u16; width * height];
+    tmp.par_chunks_mut(width)
+        .zip(src_data.par_chunks(width))
+        .for_each(|(t_row, s_row)| binomial_h_row_u8(s_row, t_row, width));
+
+    let mut dst_data = vec![0f32; width * height];
+    dst_data
+        .par_chunks_mut(width)
+        .enumerate()
+        .for_each(|(row, dst_row)| binomial_v_row_u8(&tmp, dst_row, row, width, height));
+
+    Matrix::<f32>::from_vec(height, width, 1, dst_data)
+}
+
+// ── f32 → f32 ────────────────────────────────────────────────────────────
+
 /// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, f32 → f32.
 ///
-/// Dispatches to the fastest available implementation; currently scalar
-/// only (SIMD paths land in #201). See
-/// [`binomial_4th_order_f32_to_f32_scalar`].
+/// Dispatches to the rayon path above [`PARALLEL_MIN_PIXELS`] (non-wasm),
+/// else scalar. Output is identical either way.
 #[must_use]
 pub fn binomial_4th_order_f32_to_f32(src: &Matrix<f32>) -> Matrix<f32> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        if src.rows.saturating_mul(src.cols) >= PARALLEL_MIN_PIXELS {
+            return binomial_4th_order_f32_to_f32_rayon(src);
+        }
+    }
     binomial_4th_order_f32_to_f32_scalar(src)
 }
 
-/// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, f32 → f32. Used for
-/// the second and third levels within an octave and for all levels in
-/// non-zero octaves.
+/// Serial f32 → f32 binomial filter. Used for scales 1 and 2 within an
+/// octave and for all scales in non-zero octaves.
 ///
 /// C equivalent: `vision::binomial_4th_order(float*, float*, const float*, ...)`.
 #[must_use]
@@ -407,82 +544,70 @@ pub fn binomial_4th_order_f32_to_f32_scalar(src: &Matrix<f32>) -> Matrix<f32> {
 
     let src_data = src.as_slice();
     let mut tmp = vec![0f32; width * height];
-
-    // Horizontal pass. Addition order matches C++ left-to-right exactly to
-    // preserve f32 bit-for-bit parity (no parenthesizing of the (ll + rr) term).
     for row in 0..height {
-        let row_off = row * width;
-        let s = &src_data[row_off..row_off + width];
-        tmp[row_off] = 6.0 * s[0] + 4.0 * (s[0] + s[1]) + s[0] + s[2];
-        tmp[row_off + 1] = 6.0 * s[1] + 4.0 * (s[0] + s[2]) + s[0] + s[3];
-        for col in 2..width - 2 {
-            tmp[row_off + col] =
-                6.0 * s[col] + 4.0 * (s[col - 1] + s[col + 1]) + s[col - 2] + s[col + 2];
-        }
-        let c = width - 2;
-        tmp[row_off + c] = 6.0 * s[c] + 4.0 * (s[c - 1] + s[c + 1]) + s[c - 2] + s[c + 1];
-        let c = width - 1;
-        tmp[row_off + c] = 6.0 * s[c] + 4.0 * (s[c - 1] + s[c]) + s[c - 2] + s[c];
+        let off = row * width;
+        binomial_h_row_f32(
+            &src_data[off..off + width],
+            &mut tmp[off..off + width],
+            width,
+        );
     }
 
-    // Vertical pass.
     let mut dst_data = vec![0f32; width * height];
-    const INV_256: f32 = 1.0 / 256.0;
-
-    for col in 0..width {
-        // row 0
-        let p = tmp[col];
-        let pp1 = tmp[width + col];
-        let pp2 = tmp[2 * width + col];
-        dst_data[col] = (6.0 * p + 4.0 * (p + pp1) + p + pp2) * INV_256;
-        // row 1
-        let pm = tmp[col];
-        let p = tmp[width + col];
-        let pp1 = tmp[2 * width + col];
-        let pp2 = tmp[3 * width + col];
-        dst_data[width + col] = (6.0 * p + 4.0 * (pm + pp1) + pm + pp2) * INV_256;
-    }
-
-    for row in 2..height - 2 {
-        let row_off = row * width;
-        for col in 0..width {
-            let pm2 = tmp[(row - 2) * width + col];
-            let pm1 = tmp[(row - 1) * width + col];
-            let p = tmp[row_off + col];
-            let pp1 = tmp[(row + 1) * width + col];
-            let pp2 = tmp[(row + 2) * width + col];
-            dst_data[row_off + col] = (6.0 * p + 4.0 * (pm1 + pp1) + pm2 + pp2) * INV_256;
-        }
-    }
-
-    let h = height;
-    for col in 0..width {
-        let pm2 = tmp[(h - 4) * width + col];
-        let pm1 = tmp[(h - 3) * width + col];
-        let p = tmp[(h - 2) * width + col];
-        let pp = tmp[(h - 1) * width + col];
-        dst_data[(h - 2) * width + col] = (6.0 * p + 4.0 * (pm1 + pp) + pm2 + pp) * INV_256;
-        let pm2 = tmp[(h - 3) * width + col];
-        let pm1 = tmp[(h - 2) * width + col];
-        let p = tmp[(h - 1) * width + col];
-        dst_data[(h - 1) * width + col] = (6.0 * p + 4.0 * (pm1 + p) + pm2 + p) * INV_256;
+    for row in 0..height {
+        let off = row * width;
+        binomial_v_row_f32(&tmp, &mut dst_data[off..off + width], row, width, height);
     }
 
     Matrix::<f32>::from_vec(height, width, 1, dst_data)
 }
 
+/// Rayon f32 → f32 binomial filter — parallel over rows. Bit-for-bit
+/// identical to [`binomial_4th_order_f32_to_f32_scalar`] (rows independent).
+#[cfg(not(target_arch = "wasm32"))]
+#[must_use]
+pub fn binomial_4th_order_f32_to_f32_rayon(src: &Matrix<f32>) -> Matrix<f32> {
+    use rayon::prelude::*;
+
+    let width = src.cols;
+    let height = src.rows;
+    debug_assert!(width >= 5 && height >= 5);
+
+    let src_data = src.as_slice();
+    let mut tmp = vec![0f32; width * height];
+    tmp.par_chunks_mut(width)
+        .zip(src_data.par_chunks(width))
+        .for_each(|(t_row, s_row)| binomial_h_row_f32(s_row, t_row, width));
+
+    let mut dst_data = vec![0f32; width * height];
+    dst_data
+        .par_chunks_mut(width)
+        .enumerate()
+        .for_each(|(row, dst_row)| binomial_v_row_f32(&tmp, dst_row, row, width, height));
+
+    Matrix::<f32>::from_vec(height, width, 1, dst_data)
+}
+
+// ── bilinear downsample ──────────────────────────────────────────────────
+
 /// 2x2 bilinear downsample. Output dims: `(src.rows >> 1, src.cols >> 1)`.
 ///
-/// Dispatches to the fastest available implementation; currently scalar
-/// only (SIMD paths land in #202). See [`downsample_bilinear_f32_scalar`].
+/// Dispatches to the rayon path above [`PARALLEL_MIN_PIXELS`] (non-wasm),
+/// else scalar.
 #[must_use]
 pub fn downsample_bilinear_f32(src: &Matrix<f32>) -> Matrix<f32> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        if src.rows.saturating_mul(src.cols) >= PARALLEL_MIN_PIXELS {
+            return downsample_bilinear_f32_rayon(src);
+        }
+    }
     downsample_bilinear_f32_scalar(src)
 }
 
-/// 2x2 bilinear downsample. Output dims: `(src.rows >> 1, src.cols >> 1)`.
-/// Per output pixel: `(p00 + p01 + p10 + p11) * 0.25`. No `ceil` adjustment
-/// (unlike the M8-1 box-filter pyramid).
+/// Serial 2x2 bilinear downsample. Per output pixel:
+/// `(p00 + p01 + p10 + p11) * 0.25`. No `ceil` adjustment (unlike the M8-1
+/// box-filter pyramid).
 ///
 /// C equivalent: `vision::downsample_bilinear`.
 #[must_use]
@@ -492,17 +617,35 @@ pub fn downsample_bilinear_f32_scalar(src: &Matrix<f32>) -> Matrix<f32> {
     let src_data = src.as_slice();
     let src_w = src.cols;
 
-    let mut dst_data = Vec::<f32>::with_capacity(dst_w * dst_h);
+    let mut dst_data = vec![0f32; dst_w * dst_h];
     for row in 0..dst_h {
-        let r0 = (row * 2) * src_w;
-        let r1 = r0 + src_w;
-        for col in 0..dst_w {
-            let c = col * 2;
-            let sum =
-                src_data[r0 + c] + src_data[r0 + c + 1] + src_data[r1 + c] + src_data[r1 + c + 1];
-            dst_data.push(sum * 0.25);
-        }
+        bilinear_row_f32(
+            src_data,
+            &mut dst_data[row * dst_w..(row + 1) * dst_w],
+            row,
+            src_w,
+        );
     }
+    Matrix::<f32>::from_vec(dst_h, dst_w, 1, dst_data)
+}
+
+/// Rayon 2x2 bilinear downsample — parallel over output rows. Bit-for-bit
+/// identical to [`downsample_bilinear_f32_scalar`].
+#[cfg(not(target_arch = "wasm32"))]
+#[must_use]
+pub fn downsample_bilinear_f32_rayon(src: &Matrix<f32>) -> Matrix<f32> {
+    use rayon::prelude::*;
+
+    let dst_w = src.cols >> 1;
+    let dst_h = src.rows >> 1;
+    let src_data = src.as_slice();
+    let src_w = src.cols;
+
+    let mut dst_data = vec![0f32; dst_w * dst_h];
+    dst_data
+        .par_chunks_mut(dst_w)
+        .enumerate()
+        .for_each(|(out_row, dst_row)| bilinear_row_f32(src_data, dst_row, out_row, src_w));
     Matrix::<f32>::from_vec(dst_h, dst_w, 1, dst_data)
 }
 
@@ -513,6 +656,111 @@ mod tests {
     fn gradient_u8(rows: usize, cols: usize) -> Matrix<u8> {
         let data: Vec<u8> = (0..rows * cols).map(|i| (i & 0xFF) as u8).collect();
         Matrix::<u8>::from_vec(rows, cols, 1, data)
+    }
+
+    // ── rayon parity (#207) ──────────────────────────────────────────────
+
+    /// Deterministic random u8 / f32 images, seeded so failures reproduce.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn rng_u8(rows: usize, cols: usize, seed: u64) -> Matrix<u8> {
+        use rand::{Rng, SeedableRng};
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        let data: Vec<u8> = (0..rows * cols).map(|_| rng.random::<u8>()).collect();
+        Matrix::<u8>::from_vec(rows, cols, 1, data)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn rng_f32(rows: usize, cols: usize, seed: u64) -> Matrix<f32> {
+        use rand::{Rng, SeedableRng};
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        let data: Vec<f32> = (0..rows * cols)
+            .map(|_| rng.random::<u8>() as f32)
+            .collect();
+        Matrix::<f32>::from_vec(rows, cols, 1, data)
+    }
+
+    /// Sizes spanning below, at, and above `PARALLEL_MIN_PIXELS`, with odd
+    /// dimensions and small images. All `>= 5x5`.
+    #[cfg(not(target_arch = "wasm32"))]
+    const RAYON_PARITY_SIZES: &[(usize, usize)] = &[
+        (5, 5),
+        (33, 31),
+        (64, 64),
+        (256, 256),
+        (300, 301),
+        (480, 640),
+        (513, 511),
+    ];
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn assert_f32_bits_eq(a: &Matrix<f32>, b: &Matrix<f32>, what: &str) {
+        assert_eq!(a.as_slice().len(), b.as_slice().len(), "{what}: size");
+        for (i, (&x, &y)) in a.as_slice().iter().zip(b.as_slice().iter()).enumerate() {
+            assert_eq!(x.to_bits(), y.to_bits(), "{what}: bit mismatch at {i}");
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_binomial_f32_rayon_matches_scalar() {
+        for (i, &(rows, cols)) in RAYON_PARITY_SIZES.iter().enumerate() {
+            let src = rng_f32(rows, cols, 0x00F3_2A00 + i as u64);
+            let scalar = binomial_4th_order_f32_to_f32_scalar(&src);
+            let rayon = binomial_4th_order_f32_to_f32_rayon(&src);
+            assert_f32_bits_eq(
+                &scalar,
+                &rayon,
+                &format!("binomial_f32 rayon {rows}x{cols}"),
+            );
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_binomial_u8_rayon_matches_scalar() {
+        for (i, &(rows, cols)) in RAYON_PARITY_SIZES.iter().enumerate() {
+            let src = rng_u8(rows, cols, 0x00C8_2A00 + i as u64);
+            let scalar = binomial_4th_order_u8_to_f32_scalar(&src);
+            let rayon = binomial_4th_order_u8_to_f32_rayon(&src);
+            assert_f32_bits_eq(&scalar, &rayon, &format!("binomial_u8 rayon {rows}x{cols}"));
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_bilinear_rayon_matches_scalar() {
+        for (i, &(rows, cols)) in RAYON_PARITY_SIZES.iter().enumerate() {
+            let src = rng_f32(rows, cols, 0x00B1_2A00 + i as u64);
+            let scalar = downsample_bilinear_f32_scalar(&src);
+            let rayon = downsample_bilinear_f32_rayon(&src);
+            assert_f32_bits_eq(&scalar, &rayon, &format!("bilinear rayon {rows}x{cols}"));
+        }
+    }
+
+    /// The dispatchers (which pick rayon above the threshold) must agree with
+    /// the scalar path, including for a large image that triggers rayon.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_dispatchers_match_scalar() {
+        // 800×800 = 640k px > PARALLEL_MIN_PIXELS, so the dispatchers take the
+        // rayon path here.
+        let f = rng_f32(800, 800, 0x0D15_2A00);
+        assert_f32_bits_eq(
+            &binomial_4th_order_f32_to_f32_scalar(&f),
+            &binomial_4th_order_f32_to_f32(&f),
+            "binomial_f32 dispatch",
+        );
+        assert_f32_bits_eq(
+            &downsample_bilinear_f32_scalar(&f),
+            &downsample_bilinear_f32(&f),
+            "bilinear dispatch",
+        );
+        let u = rng_u8(800, 800, 0x0D15_2A01);
+        assert_f32_bits_eq(
+            &binomial_4th_order_u8_to_f32_scalar(&u),
+            &binomial_4th_order_u8_to_f32(&u),
+            "binomial_u8 dispatch",
+        );
     }
 
     // ── Configuration sanity ─────────────────────────────────────────────

--- a/crates/core/src/kpm/freak/gaussian_pyramid.rs
+++ b/crates/core/src/kpm/freak/gaussian_pyramid.rs
@@ -275,12 +275,30 @@ pub fn num_octaves_for(width: usize, height: usize, min_size: usize) -> usize {
 
 /// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, u8 source → f32 dest.
 ///
+/// Dispatches to the fastest available implementation; currently scalar
+/// only (SIMD paths land in #201). See
+/// [`binomial_4th_order_u8_to_f32_scalar`].
+///
+/// # Note on visibility
+///
+/// This dispatcher, the `*_scalar` helpers, and
+/// [`downsample_bilinear_f32`] are `pub` so the criterion benchmark (a
+/// separate crate) can measure them directly. They are not a stability
+/// guarantee — prefer [`GaussianScaleSpacePyramid::build`].
+#[must_use]
+pub fn binomial_4th_order_u8_to_f32(src: &Matrix<u8>) -> Matrix<f32> {
+    binomial_4th_order_u8_to_f32_scalar(src)
+}
+
+/// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, u8 source → f32 dest.
+///
 /// H pass uses `u16` accumulator (max value `16 * 255 = 4080`, fits `u16`).
 /// V pass multiplies by `1 / 256` to yield `f32` output. Border replication:
 /// edge pixels extend the 2-pixel border on each side.
 ///
 /// C equivalent: `vision::binomial_4th_order(float*, unsigned short*, const unsigned char*, ...)`.
-fn binomial_4th_order_u8_to_f32(src: &Matrix<u8>) -> Matrix<f32> {
+#[must_use]
+pub fn binomial_4th_order_u8_to_f32_scalar(src: &Matrix<u8>) -> Matrix<f32> {
     let width = src.cols;
     let height = src.rows;
     debug_assert!(width >= 5 && height >= 5);
@@ -366,12 +384,23 @@ fn binomial_4th_order_u8_to_f32(src: &Matrix<u8>) -> Matrix<f32> {
     Matrix::<f32>::from_vec(height, width, 1, dst_data)
 }
 
+/// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, f32 → f32.
+///
+/// Dispatches to the fastest available implementation; currently scalar
+/// only (SIMD paths land in #201). See
+/// [`binomial_4th_order_f32_to_f32_scalar`].
+#[must_use]
+pub fn binomial_4th_order_f32_to_f32(src: &Matrix<f32>) -> Matrix<f32> {
+    binomial_4th_order_f32_to_f32_scalar(src)
+}
+
 /// 5-tap separable `[1, 4, 6, 4, 1]` binomial filter, f32 → f32. Used for
 /// the second and third levels within an octave and for all levels in
 /// non-zero octaves.
 ///
 /// C equivalent: `vision::binomial_4th_order(float*, float*, const float*, ...)`.
-fn binomial_4th_order_f32_to_f32(src: &Matrix<f32>) -> Matrix<f32> {
+#[must_use]
+pub fn binomial_4th_order_f32_to_f32_scalar(src: &Matrix<f32>) -> Matrix<f32> {
     let width = src.cols;
     let height = src.rows;
     debug_assert!(width >= 5 && height >= 5);
@@ -443,11 +472,21 @@ fn binomial_4th_order_f32_to_f32(src: &Matrix<f32>) -> Matrix<f32> {
 }
 
 /// 2x2 bilinear downsample. Output dims: `(src.rows >> 1, src.cols >> 1)`.
+///
+/// Dispatches to the fastest available implementation; currently scalar
+/// only (SIMD paths land in #202). See [`downsample_bilinear_f32_scalar`].
+#[must_use]
+pub fn downsample_bilinear_f32(src: &Matrix<f32>) -> Matrix<f32> {
+    downsample_bilinear_f32_scalar(src)
+}
+
+/// 2x2 bilinear downsample. Output dims: `(src.rows >> 1, src.cols >> 1)`.
 /// Per output pixel: `(p00 + p01 + p10 + p11) * 0.25`. No `ceil` adjustment
 /// (unlike the M8-1 box-filter pyramid).
 ///
 /// C equivalent: `vision::downsample_bilinear`.
-fn downsample_bilinear_f32(src: &Matrix<f32>) -> Matrix<f32> {
+#[must_use]
+pub fn downsample_bilinear_f32_scalar(src: &Matrix<f32>) -> Matrix<f32> {
     let dst_w = src.cols >> 1;
     let dst_h = src.rows >> 1;
     let src_data = src.as_slice();

--- a/crates/core/src/kpm/freak/gaussian_pyramid.rs
+++ b/crates/core/src/kpm/freak/gaussian_pyramid.rs
@@ -312,7 +312,6 @@ fn binomial_h_row_f32(s: &[f32], t: &mut [f32], width: usize) {
 /// replicate edges; interior rows use the full 5-tap.
 #[inline]
 fn binomial_v_row_f32(tmp: &[f32], dst_row: &mut [f32], row: usize, width: usize, height: usize) {
-    let h = height;
     if row == 0 {
         for (col, d) in dst_row.iter_mut().enumerate() {
             let p = tmp[col];
@@ -328,19 +327,19 @@ fn binomial_v_row_f32(tmp: &[f32], dst_row: &mut [f32], row: usize, width: usize
             let pp2 = tmp[3 * width + col];
             *d = (6.0 * p + 4.0 * (pm + pp1) + pm + pp2) * INV_256;
         }
-    } else if row == h - 2 {
+    } else if row == height - 2 {
         for (col, d) in dst_row.iter_mut().enumerate() {
-            let pm2 = tmp[(h - 4) * width + col];
-            let pm1 = tmp[(h - 3) * width + col];
-            let p = tmp[(h - 2) * width + col];
-            let pp = tmp[(h - 1) * width + col];
+            let pm2 = tmp[(height - 4) * width + col];
+            let pm1 = tmp[(height - 3) * width + col];
+            let p = tmp[(height - 2) * width + col];
+            let pp = tmp[(height - 1) * width + col];
             *d = (6.0 * p + 4.0 * (pm1 + pp) + pm2 + pp) * INV_256;
         }
-    } else if row == h - 1 {
+    } else if row == height - 1 {
         for (col, d) in dst_row.iter_mut().enumerate() {
-            let pm2 = tmp[(h - 3) * width + col];
-            let pm1 = tmp[(h - 2) * width + col];
-            let p = tmp[(h - 1) * width + col];
+            let pm2 = tmp[(height - 3) * width + col];
+            let pm1 = tmp[(height - 2) * width + col];
+            let p = tmp[(height - 1) * width + col];
             *d = (6.0 * p + 4.0 * (pm1 + p) + pm2 + p) * INV_256;
         }
     } else {
@@ -379,7 +378,6 @@ fn binomial_h_row_u8(s: &[u8], t: &mut [u16], width: usize) {
 /// `* INV_256`).
 #[inline]
 fn binomial_v_row_u8(tmp: &[u16], dst_row: &mut [f32], row: usize, width: usize, height: usize) {
-    let h = height;
     if row == 0 {
         for (col, d) in dst_row.iter_mut().enumerate() {
             let p = tmp[col] as u32;
@@ -395,19 +393,19 @@ fn binomial_v_row_u8(tmp: &[u16], dst_row: &mut [f32], row: usize, width: usize,
             let pp2 = tmp[3 * width + col] as u32;
             *d = ((6 * p + 4 * (pm + pp1) + pm + pp2) as f32) * INV_256;
         }
-    } else if row == h - 2 {
+    } else if row == height - 2 {
         for (col, d) in dst_row.iter_mut().enumerate() {
-            let pm2 = tmp[(h - 4) * width + col] as u32;
-            let pm1 = tmp[(h - 3) * width + col] as u32;
-            let p = tmp[(h - 2) * width + col] as u32;
-            let pp = tmp[(h - 1) * width + col] as u32;
+            let pm2 = tmp[(height - 4) * width + col] as u32;
+            let pm1 = tmp[(height - 3) * width + col] as u32;
+            let p = tmp[(height - 2) * width + col] as u32;
+            let pp = tmp[(height - 1) * width + col] as u32;
             *d = ((6 * p + 4 * (pm1 + pp) + pm2 + pp) as f32) * INV_256;
         }
-    } else if row == h - 1 {
+    } else if row == height - 1 {
         for (col, d) in dst_row.iter_mut().enumerate() {
-            let pm2 = tmp[(h - 3) * width + col] as u32;
-            let pm1 = tmp[(h - 2) * width + col] as u32;
-            let p = tmp[(h - 1) * width + col] as u32;
+            let pm2 = tmp[(height - 3) * width + col] as u32;
+            let pm1 = tmp[(height - 2) * width + col] as u32;
+            let p = tmp[(height - 1) * width + col] as u32;
             *d = ((6 * p + 4 * (pm1 + p) + pm2 + p) as f32) * INV_256;
         }
     } else {
@@ -701,6 +699,7 @@ mod tests {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(miri, ignore)] // #207: rayon parity over large images — too slow under Miri
     #[test]
     fn test_binomial_f32_rayon_matches_scalar() {
         for (i, &(rows, cols)) in RAYON_PARITY_SIZES.iter().enumerate() {
@@ -716,6 +715,7 @@ mod tests {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(miri, ignore)] // #207: rayon parity over large images — too slow under Miri
     #[test]
     fn test_binomial_u8_rayon_matches_scalar() {
         for (i, &(rows, cols)) in RAYON_PARITY_SIZES.iter().enumerate() {
@@ -727,6 +727,7 @@ mod tests {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(miri, ignore)] // #207: rayon parity over large images — too slow under Miri
     #[test]
     fn test_bilinear_rayon_matches_scalar() {
         for (i, &(rows, cols)) in RAYON_PARITY_SIZES.iter().enumerate() {
@@ -740,6 +741,7 @@ mod tests {
     /// The dispatchers (which pick rayon above the threshold) must agree with
     /// the scalar path, including for a large image that triggers rayon.
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(miri, ignore)] // #207: rayon parity over large images — too slow under Miri
     #[test]
     fn test_dispatchers_match_scalar() {
         // 800×800 = 640k px > PARALLEL_MIN_PIXELS, so the dispatchers take the


### PR DESCRIPTION
## Summary

Integration PR for the Gaussian-pyramid performance series into `dev`. `GaussianScaleSpacePyramid` is the pyramid the KPM/FREAK detector actually uses (via `DoGScaleInvariantDetector`).

Bundles two merged sub-PRs:

- **#205 (#200)** — criterion benchmark baseline for the binomial filter, bilinear downsample, and end-to-end `build`; promoted the hot helpers to `pub` with dispatchers.
- **#208 (#207)** — **rayon** parallelization of the filter passes (native; wasm stays single-threaded), parallel over rows above a 600k-px threshold.

## Results

- Pyramid kernels: **1.5–2.4×** (binomial f32/u8, bilinear) at 720p/1080p with rayon — where the earlier SIMD attempt (#201/#202, closed) gave ~1.0× because these kernels are memory-bandwidth bound and already auto-vectorized.
- End-to-end pyramid build ~1.3–1.5× at 1080p.
- Validated in the real `simple_nft` pipeline (2000×1500 query): `kpm_matching` ~1.05–1.09× — the pyramid is only ~10–15% of detection, so the win is real but modest (FREAK/matching/Hough dominate). Match output unchanged.

## Correctness

- **Bit-for-bit f32 parity** preserved throughout: per-row helpers are the single source of truth, serial and rayon paths share them, and the strict `dual-mode` C++ parity test passes (so rayon == scalar == C++), plus serial-vs-rayon bit-equality tests.

## Not included

- #201 / #202 (SIMD) — closed `wontfix` (memory-bound; ~1.0×).
- wasm threads — optional future follow-up (high toolchain/deployment friction).

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- --deny warnings`, `cargo test --all-features` all green; CI green on both sub-PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
