### PR TITLE
doc(kpm): mark box-filter Pyramid as kept-but-unused reference (#203)

### DIFF
--- a/crates/core/src/kpm/freak/pyramid.rs
+++ b/crates/core/src/kpm/freak/pyramid.rs
@@ -36,6 +36,12 @@
 
 //! Image pyramid built by repeated box-filter downsampling.
 //!
+//! **Not currently wired into any pipeline** (kept as reference — see #203).
+//! This is a faithful, SIMD-accelerated port of the C++ `BoxFilterPyramid8u`,
+//! which is itself unused in the original. The live KPM/FREAK detector builds
+//! its scale space with [`super::gaussian_pyramid::GaussianScaleSpacePyramid`]
+//! instead. Retained as a tested reference implementation.
+//!
 //! Ported from `WebARKitLib/lib/SRC/KPM/FreakMatcher/detectors/pyramid.{h,cpp}`
 //! (`BoxFilterPyramid8u` / `BoxFilterDecimate`).
 //!


### PR DESCRIPTION
## Summary

Resolves the #203 decision: **keep** `BoxFilterPyramid8u` / `Pyramid` as a tested reference implementation (rather than remove or wire it in).

Adds a module-level note to `crates/core/src/kpm/freak/pyramid.rs` making explicit that it is **not wired into any pipeline** — the live KPM/FREAK detector builds its scale space with `GaussianScaleSpacePyramid` — so future readers aren't misled into thinking it's on the hot path.

Doc-only change. Closes #203.

## Context

Discovered during the pyramid perf series (#131/#132): `BoxFilterPyramid8u` has zero callers in both the C++ original and the Rust port. The work landed (benchmark #131, byte-identical SIMD #132; #133 chunked-layout closed `wontfix`) and is kept as a correct, fast reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
