### PR TITLE
ci(benchmarks): harden against flaky external C-library downloads (#204)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,24 +232,38 @@ jobs:
       working-directory: crates/core
       run: cargo run --example simple --features log-helpers -- ../../benchmarks/data/camera_para.dat ../../benchmarks/data/patt.hiro ../../benchmarks/data/img.jpg
 
-    - name: Run benchmarks
+    - name: Install C benchmark deps (svn for bootstrap)
+      run: sudo apt-get update && sudo apt-get install -y subversion
+
+    - name: Cache C benchmark downloaded sources
+      uses: actions/cache@v4
+      with:
+        path: benchmarks/c_benchmark/archives
+        key: c-bench-archives-${{ runner.os }}-${{ hashFiles('benchmarks/c_benchmark/libraries.json') }}
+
+    # The C baseline pulls external sources (jpeg-9f from ijg.org, WebARKitLib)
+    # whose download occasionally fails with TLS/network errors (#204). It only
+    # produces an optional comparison log, so keep it NON-BLOCKING: a flake must
+    # not fail the benchmarks gate. The required signal is the Rust bench below.
+    - name: Build & run C baseline benchmark (non-blocking)
+      continue-on-error: true
       run: |
-        # Download and Build C benchmark
+        set -e
         cd benchmarks/c_benchmark
-        python ../bootstrap.py --bootstrap-file libraries.json
-        
+        for attempt in 1 2 3; do
+          python ../bootstrap.py --bootstrap-file libraries.json && break
+          echo "bootstrap attempt $attempt failed; retrying in 15s..." >&2
+          sleep 15
+        done
         mkdir -p build && cd build
         cmake .. -DCMAKE_BUILD_TYPE=Release
         make
         cd ..
-        
-        # Run C benchmark for baseline
         mkdir -p ../../target/criterion
         ./build/c_benchmark ../data/camera_para.dat ../data/patt.hiro ../data/hiro.raw 429 317 > ../../target/criterion/c_benchmark.log
-        
-        # Run Rust benchmarks
-        cd ../..
-        cargo bench -p webarkitlib-rs --bench marker_bench
+
+    - name: Run Rust benchmarks
+      run: cargo bench -p webarkitlib-rs --bench marker_bench
     - name: Upload benchmark reports
       uses: actions/upload-artifact@v5
       with:


### PR DESCRIPTION
## Summary

The `benchmarks` CI job built a C baseline by downloading external sources at run time (jpeg-9f from `ijg.org`, WebARKitLib). A TLS/network flake there — plus a missing `svn` — failed the **whole gate** even though the Rust code was fine ([#204](https://github.com/webarkit/WebARKitLib-rs/issues/204); originally hit on PR #199).

Closes #204.

## Changes (`.github/workflows/ci.yml`, `benchmarks` job)

- **Install `subversion`** — the bootstrap logged `command svn not found`.
- **Cache** the downloaded C sources (`benchmarks/c_benchmark/archives`) keyed on `libraries.json` hash — fewer live downloads.
- **Make the C baseline non-blocking** (`continue-on-error: true`) with a **3x retry** on the flaky `bootstrap.py` download. It only produces an optional comparison log.
- **Keep `cargo bench --bench marker_bench` as the required gate** — the actual signal.

Net effect: a transient external-download failure now **degrades gracefully** (skips the C comparison) instead of failing the benchmarks gate. The Rust benchmarks still run and gate as before.

## Note

This workflow change is exercised by this PR's own CI run, which validates the new job end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
