### PR TITLE
test(kpm): raise M9 coverage — exclude examples + edge tests (#177)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,6 +33,7 @@ jobs:
             --output-dir coverage \
             --timeout 300 \
             --exclude-files "**/tests/*" \
+            --exclude-files "**/examples/*" \
             --ignore-panics
 
       - name: Upload coverage reports to Codecov

--- a/crates/core/src/kpm/freak/clustering.rs
+++ b/crates/core/src/kpm/freak/clustering.rs
@@ -877,6 +877,22 @@ mod tests {
     }
 
     #[test]
+    fn test_bhc_build_all_identical() {
+        // Degenerate input: many identical descriptors. k-medoids distances are
+        // all zero, so the split is degenerate — exercise that path (#177).
+        let feat = [42u8; 96];
+        let owned: Vec<[u8; 96]> = (0..20).map(|_| feat).collect();
+        let features: Vec<&[u8; 96]> = owned.iter().collect();
+        let mut bhc = BinaryHierarchicalClustering::new().unwrap();
+        bhc.build(&features).expect("build over identical features");
+        let res = bhc.query(&feat).expect("query");
+        assert!(
+            !res.is_empty(),
+            "query of an identical feature must return the leaf members"
+        );
+    }
+
+    #[test]
     fn test_bhc_roundtrip() {
         let mut bhc = BinaryHierarchicalClustering::new().unwrap();
         let feat1 = [1u8; 96];

--- a/crates/core/src/kpm/freak/visual_database.rs
+++ b/crates/core/src/kpm/freak/visual_database.rs
@@ -354,10 +354,7 @@ impl VisualDatabase {
     ///
     /// C equivalent: `query(const Image&)` (`visual_database-inline.h:155`).
     pub fn query(&mut self, image: &Matrix<u8>) -> Result<bool, KpmError> {
-        // Reset per-query state (C++ `visual_database-inline.h:194-195`).
-        self.inliers.clear();
-        self.matched_db_id = -1;
-        self.matched_geometry = [0.0; 9];
+        self.reset_query_state();
 
         // Build the pyramid and the query keyframe.
         self.ensure_pyramid(image)?;
@@ -368,12 +365,45 @@ impl VisualDatabase {
             query_kf.store.num_features()
         );
 
-        // Iterate the database; the keyframe with the most inliers wins.
-        // Collect ids upfront because we need a `&mut self` for the matcher
-        // build inside the loop body.
+        let matched = self.match_against_database(&query_kf)?;
+        self.query_keyframe = Some(query_kf);
+        Ok(matched)
+    }
+
+    /// Query with a pre-extracted [`Keyframe`] instead of a raw image.
+    ///
+    /// Skips pyramid construction and feature extraction, running only the
+    /// matching loop against the database. Useful for deterministic testing
+    /// (feed a hand-built keyframe) and for callers that already hold a
+    /// `Keyframe`. The supplied keyframe becomes the stashed `query_keyframe`.
+    ///
+    /// C equivalent: `query(const keyframe_t*)` (`visual_database.h:193`).
+    pub fn query_from_keyframe(&mut self, query_kf: Keyframe) -> Result<bool, KpmError> {
+        self.reset_query_state();
+        let matched = self.match_against_database(&query_kf)?;
+        self.query_keyframe = Some(query_kf);
+        Ok(matched)
+    }
+
+    /// Reset per-query result state (C++ `visual_database-inline.h:194-195`).
+    fn reset_query_state(&mut self) {
+        self.inliers.clear();
+        self.matched_db_id = -1;
+        self.matched_geometry = [0.0; 9];
+    }
+
+    /// Run the matching loop against every stored keyframe; the keyframe with
+    /// the most inliers (above `min_num_inliers`) wins. Assumes per-query state
+    /// was already reset; does not touch `query_keyframe`.
+    ///
+    /// Shared inner loop of [`query`](Self::query) and
+    /// [`query_from_keyframe`](Self::query_from_keyframe)
+    /// (C++ `visual_database-inline.h:200-241`).
+    fn match_against_database(&mut self, query_kf: &Keyframe) -> Result<bool, KpmError> {
+        // Collect ids upfront because we need `&mut self` for try_match_one.
         let ids: Vec<usize> = self.keyframes.keys().copied().collect();
         for id in ids {
-            if let Some((inliers, h)) = self.try_match_one(&query_kf, id)? {
+            if let Some((inliers, h)) = self.try_match_one(query_kf, id)? {
                 if inliers.len() >= self.min_num_inliers && inliers.len() > self.inliers.len() {
                     self.matched_geometry = h;
                     self.inliers = inliers;
@@ -381,8 +411,6 @@ impl VisualDatabase {
                 }
             }
         }
-
-        self.query_keyframe = Some(query_kf);
         Ok(self.matched_db_id >= 0)
     }
 
@@ -1017,6 +1045,40 @@ mod tests {
         let mut db = VisualDatabase::new().expect("new");
         db.add_keyframe(kf, 0).expect("add_keyframe");
         assert!(db.keyframe(0).unwrap().index().is_some());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // real-image pyramid + DoG + BHC pipeline — too slow under Miri
+    fn test_query_from_keyframe_self_matches() {
+        // #147: query_from_keyframe runs the matching loop on a pre-built
+        // keyframe. An identical keyframe must self-match the database entry.
+        let img = load_grayscale("../../benchmarks/data/found.jpg");
+        let build_kf = |img: &Matrix<u8>| -> Keyframe {
+            let mut pyr = crate::kpm::freak::gaussian_pyramid::GaussianScaleSpacePyramid::new(3);
+            pyr.build(img).unwrap();
+            let det =
+                crate::kpm::freak::detector::DoGScaleInvariantDetector::new(3.0, 4.0, 500, true);
+            let mut kf = Keyframe::new(img.cols as i32, img.rows as i32).unwrap();
+            find_features(&mut kf, &pyr, &det).expect("find_features");
+            kf
+        };
+
+        let mut db = VisualDatabase::new().expect("new");
+        db.add_keyframe(build_kf(&img), 0).expect("add_keyframe");
+
+        let matched = db
+            .query_from_keyframe(build_kf(&img))
+            .expect("query_from_keyframe");
+        assert!(matched, "an identical keyframe must self-match");
+        assert_eq!(db.matched_db_id(), 0);
+        assert!(
+            db.inliers().len() >= 8,
+            "self-match should be a strong match"
+        );
+        assert!(
+            db.query_keyframe().is_some(),
+            "query_from_keyframe must stash the query keyframe"
+        );
     }
 
     // -----------------------------------------------------------------

--- a/crates/core/src/kpm/freak/visual_database.rs
+++ b/crates/core/src/kpm/freak/visual_database.rs
@@ -1081,6 +1081,38 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_query_from_keyframe_no_match() {
+        // Deterministic, no image: a db keyframe with all-0x00 descriptors vs a
+        // query keyframe with all-0xFF descriptors — maximally distant, so the
+        // ratio test rejects every candidate and try_match_one short-circuits
+        // (no-match path, #177).
+        let mk = |desc: u8, n: usize| -> Keyframe {
+            let mut kf = Keyframe::new(640, 480).unwrap();
+            for i in 0..n {
+                let p = FeaturePoint {
+                    x: i as f32,
+                    y: i as f32,
+                    angle: 0.0,
+                    scale: 1.0,
+                    maxima: true,
+                };
+                kf.store.add(p, &[desc; 96]).unwrap();
+            }
+            kf
+        };
+
+        let mut db = VisualDatabase::new().expect("new");
+        db.add_keyframe(mk(0x00, 12), 0).expect("add_keyframe");
+
+        let matched = db
+            .query_from_keyframe(mk(0xFF, 12))
+            .expect("query_from_keyframe");
+        assert!(!matched, "maximally-distant descriptors must not match");
+        assert_eq!(db.matched_db_id(), -1);
+        assert!(db.inliers().is_empty());
+    }
+
     // -----------------------------------------------------------------
     // Dual-mode parity test (M9-1 gate per #140, closed by M9 #146)
     // -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Lifts M9-module coverage toward the ≥90% target (PR #176 landed at 84.76%, 91 lines uncovered). v0.8.0 milestone close-out, 3/4.

Refs #177.

> **Stacked on #147** (uses `query_from_keyframe`). Base is the #147 branch; GitHub will auto-retarget this to `dev` once #147 (#217) merges. Review #217 first.

## Changes

- **Exclude `examples/**` from tarpaulin** — the 30-line `simple_nft_dual.rs` diagnostic sat at 0% and was the single biggest gap. Examples are demos, not test code (the issue's preferred option).
- **clustering.rs** — degenerate-input test: BHC `build` over all-identical descriptors (zero-distance k-medoids split) + `query`. Targets the lowest-covered file (74%).
- **visual_database.rs** — no-match test via `query_from_keyframe` (#147): maximally-distant descriptors short-circuit `try_match_one` (the "no-match" branch the issue names).

## Note

Coverage isn't measurable on the local (Windows) dev box — tarpaulin runs in CI only. **Codecov on this PR is the source of truth** for the resulting %. If it still flags residual per-file gaps (e.g. `rust_backend` `DualFreakMatcher` divergence, the `hough` 1-liner), those are quick follow-ups rather than blockers.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --all-features` green (2 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
