### PR TITLE
fix(ci): disable cargo-bin cache on kpm-build to stop stale rustup-init shim (#134)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,15 @@ jobs:
       if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install -y libclang-dev
 
+    # cache-bin: false avoids caching ~/.cargo/bin. On macOS this job
+    # intermittently restored a stale `cargo` shim resolving to
+    # `rustup-init`, so `cargo build` was parsed as `rustup-init build`
+    # and failed (#134). This job installs no cargo-managed binaries, so
+    # disabling bin caching costs nothing while removing the flake.
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: false
 
     # Strict clippy gate (#180): --all-targets covers examples/tests/benches;
     # --all-features exercises ffi-backend, dual-mode, simd-* paths the


### PR DESCRIPTION
Disable `~/.cargo/bin` caching on the `kpm-build` job so a stale `cargo`
shim can no longer be restored on the macOS runner.

The `kpm-build (macos-latest)` job flaked intermittently with
`rustup-init: unexpected argument 'build' found`: `Swatinem/rust-cache@v2`
(with the default `cache-bin: true`) restored a cached `~/.cargo/bin`
containing a `cargo` shim that resolved to `rustup-init`, overwriting the
fresh binary just installed by `dtolnay/rust-toolchain@stable`. Subsequent
`cargo build` invocations were then parsed as `rustup-init build` and the
job failed. Linux and Windows were unaffected; the failure was
non-deterministic (depended on which cache the runner restored).

Setting `cache-bin: false` on this job's cache step stops the binaries
(including the rustup proxy shim) from being cached at all. `kpm-build`
installs no cargo-managed tools, so this removes the flake at no cost to
cache effectiveness — only the registry/build caches matter here.

Verification happens in CI itself: the macOS leg of this PR's `kpm-build`
matrix exercises the changed step.

Refs #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)