### PR TITLE
test(ci): verify ffi-backend tests + example link on macOS (#119)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,28 @@ jobs:
     - name: Build kpm backend (FFI backend)
       run: cargo build -p webarkitlib-rs --features ffi-backend
 
+    # macOS ffi-backend link verification (#119). PR #117 fixed build.rs to
+    # link libc++ (not libstdc++) on Apple targets, but the dual-mode CI step
+    # was scoped to --lib, so the integration tests and the generate_patt
+    # example were never re-built on macOS after the fix. Build them here to
+    # confirm they link against libc++.
+    #
+    # --no-run (not a full run): this verifies the linker fix only. Actually
+    # executing the pose-sensitive integration tests cross-platform is out of
+    # scope — that float-drift question is tracked separately in #118, which
+    # keeps test_full_pipeline_pose gated to Linux.
+    - name: Verify ffi-backend tests + example link (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        cargo test -p webarkitlib-rs \
+          --test kpm_regression \
+          --test nft_pipeline \
+          --test ar2_pinball_io \
+          --test cross_stack_parity \
+          --features ffi-backend --no-run
+        cargo build -p webarkitlib-rs \
+          --example generate_patt --features log-helpers,ffi-backend
+
     # Dual-mode tests run pure-Rust ports against the C++ baseline via the
     # FFI backend (webarkit_cpp_* shims) and assert byte-level parity.
     # Catches regressions that would otherwise only surface in local runs.


### PR DESCRIPTION
Add a macOS-gated step to the `kpm-build` matrix that builds the
ffi-backend integration tests (`--no-run`) and the `generate_patt`
example, confirming they link on Apple targets.

PR #117 fixed `build.rs` to link `libc++` (not `libstdc++`) on Apple
targets after the macOS runner produced `ld: library 'stdc++' not found`
when building `tests/nft_pipeline` and the `generate_patt` example. But
#117's dual-mode CI step was scoped to `--lib`, so the integration tests
and examples were never re-built on macOS after the fix — leaving open
whether the libc++ change was sufficient (#119).

This step closes that gap: if the macOS leg goes green, the libc++ fix is
confirmed and #119 can be closed as resolved by #117. If it fails with a
*different* error, we have a reproducible signal to root-cause.

`--no-run` is deliberate. This verifies linkage only; actually executing
the pose-sensitive assertions cross-platform is out of scope — that
float-drift question is tracked in #118, which keeps `test_full_pipeline_pose`
gated to Linux. (The library itself already builds with `--features
ffi-backend` on macOS via the existing `Build kpm backend` step; the gap
was specifically the test + example targets.)

Verification happens in CI itself: the macOS leg of this PR's `kpm-build`
matrix exercises the new step.

Refs #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)