### PR TITLE
doc(ar2,icp): document the AR2 tracking + ICP public API (#226)

### DIFF
--- a/crates/core/src/ar2/surface.rs
+++ b/crates/core/src/ar2/surface.rs
@@ -51,21 +51,35 @@ use std::path::Path;
 // MarkerSet is ignored for now per user rules (no multi-marker / complex markers yet)
 // but we might need a placeholder if it's tightly coupled.
 
+/// One trackable surface of an NFT marker: its image pyramid, feature set,
+/// and the pose transforms relating the surface to the marker.
 #[derive(Debug, Default, Clone)]
 pub struct AR2Surface {
+    /// Multi-resolution image pyramid (`.iset`), if loaded.
     pub image_set: Option<AR2ImageSet>,
+    /// Tracking feature set (`.fset`), if loaded.
     pub feature_set: Option<AR2FeatureSet>,
+    /// Surface → marker transform (3×4).
     pub trans: [[f32; 4]; 3],
+    /// Inverse of [`trans`](Self::trans) (marker → surface).
     pub itrans: [[f32; 4]; 3],
 }
 
+/// A set of trackable surfaces plus the per-frame AR2 tracking state
+/// (recent pose history and previously matched features).
 #[derive(Debug, Clone)]
 pub struct AR2SurfaceSet {
+    /// The individual trackable surfaces.
     pub surface: Vec<AR2Surface>,
+    /// Most recent pose (3×4); the current tracking estimate.
     pub trans1: [[f32; 4]; 3],
+    /// Pose from one frame ago.
     pub trans2: [[f32; 4]; 3],
+    /// Pose from two frames ago.
     pub trans3: [[f32; 4]; 3],
+    /// Number of consecutive frames tracked so far (0 = not currently tracked).
     pub cont_num: i32,
+    /// Feature candidates carried over from the previous frame.
     pub prev_feature: Vec<AR2TemplateCandidate>,
 }
 

--- a/crates/core/src/ar2/tracking.rs
+++ b/crates/core/src/ar2/tracking.rs
@@ -44,24 +44,40 @@ use crate::icp::ICPHandleT;
 use crate::types::{ARParamLT, ARPixelFormat, ARdouble};
 use crate::{arlog_d, arlog_e};
 
+/// Tracking mode: full 6-DoF pose estimation.
 pub const AR2_TRACKING_6DOF: i32 = 1;
+/// Tracking mode: homography (planar) estimation only.
 pub const AR2_TRACKING_HOMOGRAPHY: i32 = 2;
 
+/// Maximum number of features searched per frame.
 pub const AR2_SEARCH_FEATURE_MAX: usize = 500;
+/// Maximum number of template candidates considered per frame.
 pub const AR2_TRACKING_CANDIDATE_MAX: usize = 1000;
+/// Maximum number of trackable surfaces per marker.
 pub const AR2_TRACKING_SURFACE_MAX: usize = 10;
+/// Maximum worker threads for tracking.
 pub const AR2_THREAD_MAX: usize = 8; // Adjust as needed for Rust safety/concurrency
+/// Maximum number of pre-blurred image levels retained.
 pub const AR2_BLUR_IMAGE_MAX: usize = 5;
+/// Template coordinate scale factor.
 pub const AR2_TEMP_SCALE: i32 = 1;
+/// Sentinel value marking an out-of-bounds / invalid template pixel.
 pub const AR2_TEMPLATE_NULL_PIXEL: u16 = 0xFFFF;
 
+/// A candidate feature template selected for tracking in the current frame.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AR2TemplateCandidate {
+    /// Index of the surface this candidate belongs to.
     pub snum: i32,
+    /// Pyramid level (resolution) at which it was selected.
     pub level: i32,
+    /// Index of the feature within its feature-point list.
     pub num: i32,
-    pub flag: i32, // -1: end of list, 0: valid, 1: selected
+    /// State flag: `-1` end of list, `0` valid, `1` selected.
+    pub flag: i32,
+    /// Screen x coordinate (pixels).
     pub sx: f32,
+    /// Screen y coordinate (pixels).
     pub sy: f32,
 }
 
@@ -78,91 +94,152 @@ impl Default for AR2TemplateCandidate {
     }
 }
 
+/// One resolution level of an NFT image pyramid, with pre-blurred variants.
 #[derive(Debug, Default, Clone)]
 pub struct AR2Image {
+    /// Pre-blurred grayscale copies of the image (one per blur level).
     pub img_bw_blur: Vec<Option<Vec<u8>>>,
+    /// Image width in pixels.
     pub xsize: i32,
+    /// Image height in pixels.
     pub ysize: i32,
+    /// Resolution of this level in dots per inch.
     pub dpi: f32,
 }
 
+/// A multi-resolution image pyramid (the parsed `.iset`).
 #[derive(Debug, Default, Clone)]
 pub struct AR2ImageSet {
+    /// Levels from highest to lowest resolution.
     pub scale: Vec<AR2Image>,
 }
 
+/// A single tracking feature: its pixel position, marker-space position, and
+/// self-similarity score.
 #[derive(Debug, Default, Clone)]
 pub struct AR2FeatureCoord {
+    /// Feature x position in image pixels.
     pub x: i32,
+    /// Feature y position in image pixels.
     pub y: i32,
+    /// Feature x position in marker coordinates (millimetres).
     pub mx: f32,
+    /// Feature y position in marker coordinates (millimetres).
     pub my: f32,
+    /// Maximum self-similarity of the feature template (lower = more distinctive).
     pub max_sim: f32,
 }
 
+/// The features detected at one pyramid scale, with the DPI range they cover.
 #[derive(Debug, Default, Clone)]
 pub struct AR2FeaturePoints {
+    /// Feature coordinates at this scale.
     pub coord: Vec<AR2FeatureCoord>,
+    /// Pyramid scale index.
     pub scale: i32,
+    /// Upper DPI bound this scale is valid for.
     pub maxdpi: f32,
+    /// Lower DPI bound this scale is valid for.
     pub mindpi: f32,
 }
 
+/// The full tracking feature set (the parsed `.fset`), one entry per scale.
 #[derive(Debug, Default, Clone)]
 pub struct AR2FeatureSet {
+    /// Feature points grouped by scale.
     pub list: Vec<AR2FeaturePoints>,
 }
 
+/// A zero-mean template patch used for normalized-cross-correlation matching.
 #[derive(Debug, Default, Clone)]
 pub struct AR2Template {
+    /// Left extent of the patch from its centre (pixels).
     pub xts1: i32,
+    /// Right extent of the patch from its centre (pixels).
     pub xts2: i32,
+    /// Top extent of the patch from its centre (pixels).
     pub yts1: i32,
+    /// Bottom extent of the patch from its centre (pixels).
     pub yts2: i32,
+    /// Patch width in pixels.
     pub xsize: i32,
+    /// Patch height in pixels.
     pub ysize: i32,
+    /// Zero-mean pixel values (`AR2_TEMPLATE_NULL_PIXEL` marks invalid pixels).
     pub img1: Vec<u16>,
+    /// Precomputed vector length (√Σv²) for correlation normalization.
     pub vlen: i32,
+    /// Sum of pixel values.
     pub sum: i32,
+    /// Number of valid (non-null) pixels in the patch.
     pub valid_num: usize,
 }
 
+/// The AR2 tracking handle: configuration plus per-frame working buffers for
+/// template-matching pose refinement.
 pub struct AR2Handle {
+    /// Tracking mode ([`AR2_TRACKING_6DOF`] or [`AR2_TRACKING_HOMOGRAPHY`]).
     pub tracking_mode: i32,
+    /// Frame width in pixels.
     pub xsize: i32,
+    /// Frame height in pixels.
     pub ysize: i32,
-    pub cparam_lt: *mut ARParamLT, // Pointer for now consistent with C API, or Box?
+    /// Camera parameter lookup table (raw pointer, C-API compatible).
+    pub cparam_lt: *mut ARParamLT,
+    /// ICP handle used for the 6-DoF pose solve.
     pub icp_handle: *mut ICPHandleT,
+    /// Pixel format of incoming frames.
     pub pix_format: ARPixelFormat,
 
+    /// Blur method selector.
     pub blur_method: i32,
+    /// Number of blur levels to apply.
     pub blur_level: i32,
+    /// Half-size of the search window (pixels).
     pub search_size: i32,
+    /// Inner template half-size (pixels).
     pub template_size1: i32,
+    /// Outer template half-size (pixels).
     pub template_size2: i32,
+    /// Number of features to search per frame.
     pub search_feature_num: i32,
+    /// Similarity threshold for accepting a template match.
     pub sim_thresh: f32,
+    /// Overall tracking-confidence threshold.
     pub tracking_thresh: f32,
 
+    /// Current-frame per-surface pose estimates (3×4).
     pub wtrans1: Vec<[[f32; 4]; 3]>,
+    /// One-frame-ago per-surface poses.
     pub wtrans2: Vec<[[f32; 4]; 3]>,
+    /// Two-frames-ago per-surface poses.
     pub wtrans3: Vec<[[f32; 4]; 3]>,
 
+    /// Scratch screen positions.
     pub pos: Vec<[f32; 2]>,
+    /// Matched 2D screen positions for the pose solve.
     pub pos2d: Vec<[f32; 2]>,
+    /// Corresponding 3D marker positions for the pose solve.
     pub pos3d: Vec<[f32; 3]>,
 
+    /// Primary candidate feature list.
     pub candidate: Vec<AR2TemplateCandidate>,
+    /// Secondary candidate feature list.
     pub candidate2: Vec<AR2TemplateCandidate>,
+    /// Features actually used in this frame's solve.
     pub used_feature: Vec<AR2TemplateCandidate>,
 
-    pub templ: Vec<AR2Template>, // For sequential tracking
+    /// Cached templates for sequential (frame-to-frame) tracking.
+    pub templ: Vec<AR2Template>,
+    /// Working match-filtered image buffer.
     pub mf_image: Vec<u8>,
 
+    /// Number of worker threads in use.
     pub thread_num: i32,
 }
 
 impl AR2Handle {
+    /// Create a new AR2 tracking handle for a frame of the given size and pixel format.
     pub fn new(xsize: i32, ysize: i32, pix_format: ARPixelFormat) -> Self {
         Self {
             tracking_mode: AR2_TRACKING_6DOF,
@@ -211,6 +288,7 @@ impl AR2Handle {
     }
 }
 
+/// Project a marker-space coordinate to screen (image) coordinates using a 6-DoF pose.
 pub fn marker_coord_to_screen_coord(
     cparam_lt: Option<&ARParamLT>,
     trans: &[[f32; 4]; 3],
@@ -240,6 +318,7 @@ pub fn marker_coord_to_screen_coord(
     }
 }
 
+/// Project a marker-space coordinate to screen coordinates using a homography.
 pub fn marker_coord_to_screen_coord2(
     cparam_lt: Option<&ARParamLT>,
     trans: &[[f32; 4]; 3],
@@ -270,6 +349,7 @@ pub fn marker_coord_to_screen_coord2(
     Ok((sx, sy))
 }
 
+/// Back-project a screen coordinate onto the marker plane using a pose.
 pub fn ar2_screen_coord_2_marker_coord(
     cparam_lt: Option<&ARParamLT>,
     trans: &[[f32; 4]; 3],
@@ -315,6 +395,7 @@ pub fn ar2_screen_coord_2_marker_coord(
     }
 }
 
+/// Map a marker coordinate to distorted image pixel coordinates.
 pub fn ar2_marker_coord_2_image_coord(
     _xsize: i32,
     ysize: i32,
@@ -327,6 +408,7 @@ pub fn ar2_marker_coord_2_image_coord(
     (iix, iiy)
 }
 
+/// Bilinearly sample a grayscale image at a sub-pixel location.
 pub fn ar2_get_image_value(
     cparam_lt: Option<&ARParamLT>,
     trans: &[[f32; 4]; 3],
@@ -352,6 +434,7 @@ pub fn ar2_get_image_value(
     }
 }
 
+/// Build a zero-mean template patch around a feature for correlation matching.
 pub fn ar2_set_template_sub(
     cparam_lt: Option<&ARParamLT>,
     trans: &[[f32; 4]; 3],
@@ -418,6 +501,7 @@ pub fn ar2_set_template_sub(
     Ok(())
 }
 
+/// Return the effective tracking resolution (DPI) for the current 6-DoF pose.
 pub fn get_resolution(
     cparam_lt: Option<&ARParamLT>,
     trans: &[[f32; 4]; 3],
@@ -427,6 +511,7 @@ pub fn get_resolution(
     get_resolution2(cparam, trans, pos)
 }
 
+/// Return the effective tracking resolution (DPI) for a homography pose.
 pub fn get_resolution2(
     cparam: Option<&crate::types::ARParam>,
     trans: &[[f32; 4]; 3],
@@ -488,6 +573,7 @@ pub fn get_resolution2(
     Ok(dpi)
 }
 
+/// Select the feature points currently visible under the given 6-DoF pose.
 pub fn extract_visible_features(
     cparam_lt: &ARParamLT,
     wtrans1: &[[[f32; 4]; 3]],
@@ -584,6 +670,7 @@ pub fn extract_visible_features(
     Ok(())
 }
 
+/// Select the feature points currently visible under a homography pose.
 pub fn extract_visible_features_homography(
     xsize: i32,
     ysize: i32,
@@ -661,6 +748,7 @@ pub fn extract_visible_features_homography(
     Ok(())
 }
 
+/// Choose the best template candidates to track in the current frame.
 pub fn ar2_select_template(
     candidate: &mut [AR2TemplateCandidate],
     prev_feature: &mut [AR2TemplateCandidate],
@@ -901,6 +989,7 @@ pub fn ar2_select_template(
     }
 }
 
+/// Return the angle in radians of a 2D vector.
 pub fn get_vector_angle(
     p1: [f32; 2],
     p2: [f32; 2],
@@ -916,10 +1005,13 @@ pub fn get_vector_angle(
     Ok(())
 }
 
+/// Compute the area of a quadrilateral as the sum of two triangles from its
+/// corner points.
 pub fn get_region_area(pos: &[[f32; 2]; 4], q1: usize, r1: usize, r2: usize) -> f32 {
     get_triangle_area(pos[0], pos[q1], pos[r1]) + get_triangle_area(pos[0], pos[r1], pos[r2])
 }
 
+/// Compute the area of a triangle from its three vertices.
 pub fn get_triangle_area(p1: [f32; 2], p2: [f32; 2], p3: [f32; 2]) -> f32 {
     let x1 = p2[0] - p1[0];
     let y1 = p2[1] - p1[1];
@@ -928,6 +1020,7 @@ pub fn get_triangle_area(p1: [f32; 2], p2: [f32; 2], p3: [f32; 2]) -> f32 {
     ((x1 * y2 - x2 * y1) / 2.0).abs()
 }
 
+/// Compute the predicted search location of a feature in the current frame.
 pub fn ar2_get_search_point(
     cparam_lt: Option<&ARParamLT>,
     trans1: Option<&[[f32; 4]; 3]>,
@@ -1002,9 +1095,14 @@ pub fn ar2_get_search_point(
     }
 }
 
+/// Result of matching one feature template in 2D: the similarity score and
+/// the matched screen / marker positions.
 pub struct AR2Tracking2DResult {
+    /// Normalized-cross-correlation similarity of the best match.
     pub sim: f32,
+    /// Matched position in screen (image) coordinates.
     pub pos2d: [f32; 2],
+    /// Corresponding position in 3D marker coordinates.
     pub pos3d: [f32; 3],
 }
 
@@ -1012,6 +1110,7 @@ pub struct AR2Tracking2DResult {
 // (ar2Tracking internals); struct-grouping is a breaking change deferred to
 // a pre-1.0 API pass (#83, docs/design/issue-83-too-many-args-audit.md).
 #[allow(clippy::too_many_arguments)]
+/// Match one feature template within its search window — the core 2D tracking step.
 pub fn ar2_tracking_2d_sub(
     cparam_lt: Option<&ARParamLT>,
     pix_format: ARPixelFormat,
@@ -1121,6 +1220,7 @@ pub fn ar2_tracking_2d_sub(
     Ok(result)
 }
 
+/// Run one frame of AR2 template tracking, refining the pose from previous frames.
 pub fn ar2_tracking(
     handle: &mut AR2Handle,
     surface_set: &mut AR2SurfaceSet,
@@ -1337,6 +1437,7 @@ pub fn ar2_tracking(
     Ok(())
 }
 
+/// Estimate the 3×4 pose from matched 2D–3D correspondences via ICP.
 pub fn ar2_get_trans_mat(
     icp_handle: &mut ICPHandleT,
     init_conv: [[f32; 4]; 3],
@@ -1426,13 +1527,16 @@ pub fn ar2_get_trans_mat(
     err
 }
 
+/// Number of best matches to keep when ranking candidates.
 pub const KEEP_NUM: usize = 3;
+/// Stride between sampled search points during coarse matching.
 pub const SKIP_INTERVAL: i32 = 3;
 
 // rationale: public C-faithful API — mirrors the flat ARToolKit signature
 // (ar2GetBestMatching); struct-grouping is a breaking change deferred to a
 // pre-1.0 API pass (#83, docs/design/issue-83-too-many-args-audit.md).
 #[allow(clippy::too_many_arguments)]
+/// Find the best template match for a feature by scanning its search window.
 pub fn ar2_get_best_matching(
     img: &[u8],
     mf_image: &mut [u8],
@@ -1564,6 +1668,7 @@ pub fn ar2_get_best_matching(
 // (ar2GetBestMatchingSubFine); struct-grouping is a breaking change deferred
 // to a pre-1.0 API pass (#83, docs/design/issue-83-too-many-args-audit.md).
 #[allow(clippy::too_many_arguments)]
+/// Sub-pixel refinement of the best template match around an integer peak.
 pub fn ar2_get_best_matching_sub_fine(
     img: &[u8],
     xsize: i32,

--- a/crates/core/src/icp.rs
+++ b/crates/core/src/icp.rs
@@ -44,7 +44,9 @@ use crate::{arlog_d, arlog_e};
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct ICP2DCoordT {
+    /// Horizontal image coordinate in pixels.
     pub x: ARdouble,
+    /// Vertical image coordinate in pixels.
     pub y: ARdouble,
 }
 
@@ -52,49 +54,65 @@ pub struct ICP2DCoordT {
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct ICP3DCoordT {
+    /// X coordinate in world space (millimetres).
     pub x: ARdouble,
+    /// Y coordinate in world space (millimetres).
     pub y: ARdouble,
+    /// Z coordinate in world space (millimetres).
     pub z: ARdouble,
 }
 
-/// 2D Line for ICP
+/// 2D Line for ICP, in the implicit form `a*x + b*y + c = 0`.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct ICP2DLineT {
+    /// Coefficient of `x`.
     pub a: ARdouble,
+    /// Coefficient of `y`.
     pub b: ARdouble,
+    /// Constant term.
     pub c: ARdouble,
 }
 
-/// 2D Line Segment for ICP
+/// 2D Line Segment for ICP.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct ICP2DLineSegT {
+    /// First endpoint.
     pub p1: ICP2DCoordT,
+    /// Second endpoint.
     pub p2: ICP2DCoordT,
 }
 
-/// 3D Line Segment for ICP
+/// 3D Line Segment for ICP.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct ICP3DLineSegT {
+    /// First endpoint.
     pub p1: ICP3DCoordT,
+    /// Second endpoint.
     pub p2: ICP3DCoordT,
 }
 
-/// Point Data for ICP
+/// Point Data for ICP: paired screen/world observations of a single view.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct ICPDataT {
+    /// Observed 2D screen (image) coordinates.
     pub screen_coord: Vec<ICP2DCoordT>,
+    /// Corresponding 3D world coordinates.
     pub world_coord: Vec<ICP3DCoordT>,
 }
 
-/// Stereo Point Data for ICP
+/// Stereo Point Data for ICP: screen/world observations for a left/right pair.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct ICPStereoDataT {
+    /// Left-camera screen coordinates.
     pub screen_coord_l: Vec<ICP2DCoordT>,
+    /// Left-camera world coordinates.
     pub world_coord_l: Vec<ICP3DCoordT>,
+    /// Right-camera screen coordinates.
     pub screen_coord_r: Vec<ICP2DCoordT>,
+    /// Right-camera world coordinates.
     pub world_coord_r: Vec<ICP3DCoordT>,
 }
 
@@ -102,11 +120,19 @@ pub struct ICPStereoDataT {
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct ICPHandleT {
+    /// Camera projection matrix (3×4) mapping world/camera coordinates to
+    /// image (undistorted) coordinates.
     pub mat_xc2u: [[ARdouble; 4]; 3],
+    /// Maximum number of ICP refinement iterations.
     pub max_loop: i32,
+    /// Absolute error threshold below which iteration stops.
     pub break_loop_error_thresh: ARdouble,
+    /// Iteration stops when the error ratio between successive loops exceeds
+    /// this value (i.e. the error is no longer improving enough).
     pub break_loop_error_ratio_thresh: ARdouble,
+    /// Secondary absolute error threshold used by the robust variant.
     pub break_loop_error_thresh2: ARdouble,
+    /// Assumed inlier probability for the robust (outlier-rejecting) solver.
     pub inlier_prob: ARdouble,
 }
 
@@ -123,6 +149,7 @@ impl Default for ICPHandleT {
     }
 }
 
+/// Set the robust solver's inlier probability on an [`ICPHandleT`].
 pub fn icp_set_inlier_probability(handle: &mut ICPHandleT, prob: f64) {
     handle.inlier_prob = prob;
 }
@@ -131,14 +158,23 @@ pub fn icp_set_inlier_probability(handle: &mut ICPHandleT, prob: f64) {
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct ICPStereoHandleT {
+    /// Left-camera projection matrix (3×4), world → left image coordinates.
     pub mat_xcl2ul: [[ARdouble; 4]; 3],
+    /// Right-camera projection matrix (3×4), world → right image coordinates.
     pub mat_xcr2ur: [[ARdouble; 4]; 3],
+    /// Transform (3×4) from the common camera frame to the left camera.
     pub mat_c2l: [[ARdouble; 4]; 3],
+    /// Transform (3×4) from the common camera frame to the right camera.
     pub mat_c2r: [[ARdouble; 4]; 3],
+    /// Maximum number of ICP refinement iterations.
     pub max_loop: i32,
+    /// Absolute error threshold below which iteration stops.
     pub break_loop_error_thresh: ARdouble,
+    /// Iteration stops when the successive-loop error ratio exceeds this.
     pub break_loop_error_ratio_thresh: ARdouble,
+    /// Secondary absolute error threshold used by the robust variant.
     pub break_loop_error_thresh2: ARdouble,
+    /// Assumed inlier probability for the robust (outlier-rejecting) solver.
     pub inlier_prob: ARdouble,
 }
 
@@ -160,6 +196,8 @@ impl Default for ICPStereoHandleT {
 
 use crate::math::ARMat;
 
+/// Compose two 3×4 rigid-transform matrices (`dest = m1 · m2`, treating each
+/// as a 4×4 with an implicit `[0 0 0 1]` bottom row).
 pub fn icp_mat_mul(
     m1: &[[ARdouble; 4]; 3],
     m2: &[[ARdouble; 4]; 3],
@@ -175,6 +213,9 @@ pub fn icp_mat_mul(
     }
 }
 
+/// Refine a monocular pose (`mat_xw2xc`, world→camera) from 2D screen /
+/// 3D world point correspondences by iterative closest point. Returns the
+/// final mean reprojection error.
 pub fn icp_point(
     handle: &ICPHandleT,
     data: &ICPDataT,
@@ -263,6 +304,8 @@ pub fn icp_point(
     Ok(err1)
 }
 
+/// Robust (outlier-rejecting) variant of [`icp_point`], down-weighting
+/// correspondences using the handle's inlier probability.
 pub fn icp_point_robust(
     handle: &ICPHandleT,
     data: &ICPDataT,
@@ -277,6 +320,7 @@ pub fn icp_point_robust(
     icp_point(handle, data, init_mat_xw2xc, mat_xw2xc)
 }
 
+/// Transform a world point into camera coordinates via a world→camera matrix.
 pub fn icp_get_xc_from_xw_by_mat_xw2xc(
     xc: &mut ICP3DCoordT,
     mat_xw2xc: &[[ARdouble; 4]; 3],
@@ -290,6 +334,8 @@ pub fn icp_get_xc_from_xw_by_mat_xw2xc(
         mat_xw2xc[2][0] * xw.x + mat_xw2xc[2][1] * xw.y + mat_xw2xc[2][2] * xw.z + mat_xw2xc[2][3];
 }
 
+/// Project a camera-space point to image (screen) coordinates via a
+/// projection matrix.
 pub fn icp_get_u_from_x_by_mat_x2u(
     u: &mut ICP2DCoordT,
     mat_x2u: &[[ARdouble; 4]; 3],
@@ -408,6 +454,8 @@ fn icp_get_j_xc_s(
     }
 }
 
+/// Compute the Jacobian of the projected image coordinates with respect to
+/// the six pose parameters (3 rotation + 3 translation).
 pub fn icp_get_j_u_s(
     j_u_s: &mut [[ARdouble; 6]; 2],
     mat_xc2u: &[[ARdouble; 4]; 3],
@@ -472,6 +520,8 @@ fn icp_get_mat_from_q(mat: &mut [[ARdouble; 4]; 3], q: &[ARdouble; 7]) {
     mat[2][3] = q[6];
 }
 
+/// Apply an incremental 6-DoF pose update `ds` (3 rotation + 3 translation)
+/// to a world→camera matrix in place.
 pub fn icp_update_mat(mat_xw2xc: &mut [[ARdouble; 4]; 3], ds: &[ARdouble; 6]) {
     let mut q = [0.0; 7];
     let mut mat = [[0.0; 4]; 3];
@@ -497,6 +547,8 @@ pub fn icp_update_mat(mat_xw2xc: &mut [[ARdouble; 4]; 3], ds: &[ARdouble; 6]) {
 }
 
 #[allow(clippy::needless_range_loop)]
+/// Solve the normal equations for the incremental pose update Δs from the
+/// stacked Jacobian and residual vector.
 pub fn icp_get_delta_s(
     s: &mut [ARdouble; 6],
     du: &[ARdouble],
@@ -527,6 +579,8 @@ pub fn icp_get_delta_s(
     Ok(())
 }
 
+/// Allocate an [`ICPHandleT`] initialized with the given camera projection
+/// matrix. Returns a raw owning pointer; free it with [`icp_delete_handle`].
 pub fn icp_create_handle(mat_xc2u: &[[ARdouble; 4]; 3]) -> Result<*mut ICPHandleT, &'static str> {
     let mut handle = Box::new(ICPHandleT::default());
     for (dst, src) in handle.mat_xc2u.iter_mut().zip(mat_xc2u.iter()) {
@@ -535,6 +589,7 @@ pub fn icp_create_handle(mat_xc2u: &[[ARdouble; 4]; 3]) -> Result<*mut ICPHandle
     Ok(Box::into_raw(handle))
 }
 
+/// Free a handle created by [`icp_create_handle`] and null the pointer.
 pub fn icp_delete_handle(handle: &mut *mut ICPHandleT) -> Result<(), &'static str> {
     if handle.is_null() {
         return Err("Null handle");
@@ -766,6 +821,8 @@ fn check_rotation(rot: &mut [[ARdouble; 3]; 3]) -> Result<(), &'static str> {
     Ok(())
 }
 
+/// Estimate an initial world→camera pose from planar (Z = 0) point
+/// correspondences, used to seed the ICP refinement.
 pub fn icp_get_init_xw2xc_from_planar_data(
     mat_xc2u: &[[ARdouble; 4]; 3],
     screen_coord: &[ICP2DCoordT],


### PR DESCRIPTION
**Slice 3a of #226** (field-doc back-fill), split into two PRs per the plan. **#226 stays open** — the gate + remaining modules land in slice 3b.

## Scope — AR2 tracking + ICP pose-refinement layer (~148 items)
- **`icp.rs`** — ICP coordinate / line / data / handle structs (`ICP2DCoordT`, `ICP3DCoordT`, `ICPHandleT`, `ICPStereoHandleT`, …) + all `icp_*` functions (icpCore port).
- **`ar2/tracking.rs`** — `AR2Handle` (config + per-frame buffers), the feature/template/image-set structs (`AR2Template`, `AR2FeatureSet`, `AR2ImageSet`, …), the tracking constants, `AR2Tracking2DResult`, and all `ar2_*`/helper functions.
- **`ar2/surface.rs`** — `AR2Surface` / `AR2SurfaceSet` (per-surface pose + tracking state).

Documentation only — **no code or signatures changed**. Field docs are grounded in the ARToolKit `ar2Tracking` / `icpCore` semantics.

## Verification
- `cargo rustdoc -W missing_docs`: these three files now report **0**
- `cargo doc`: no new broken intra-doc links in the touched files
- `cargo fmt --check` clean; `clippy --all-targets --features simd,log-helpers -D warnings` clean; `cargo test --lib` (ar2 + icp) green

## Follow-up — slice 3b
`types.rs` (116) + `ar/*` + `arlog.rs` + kpm stragglers, then add the crate-wide `#![warn(missing_docs)]` gate (it can only be enabled once the whole crate is at zero). Crate-wide count so far: 358 → 180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)