### PR TITLE
doc(core): document remaining public API + enable crate-wide missing_docs (#226)

### DIFF
--- a/crates/core/src/ar/bch.rs
+++ b/crates/core/src/ar/bch.rs
@@ -84,6 +84,7 @@ const BCH_127_INDEX_OF: [i32; 128] = [
 // Public decoders for short codes (parity-65, hamming-63).
 // =====================================================================
 
+/// Decode a 3×3 parity(6,5) matrix code, returning the marker ID.
 pub fn decode_parity65(code_raw: u64) -> Result<u64, &'static str> {
     const PARITY65_DECODER_TABLE: [i8; 64] = [
         0, -1, -1, 3, -1, 5, 6, -1, -1, 9, 10, -1, 12, -1, -1, 15, -1, 17, 18, -1, 20, -1, -1, 23,
@@ -106,6 +107,7 @@ pub fn decode_parity65(code_raw: u64) -> Result<u64, &'static str> {
     }
 }
 
+/// Decode a 3×3 Hamming(6,3) matrix code, returning the ID and corrected-error count.
 pub fn decode_hamming63(code_raw: u64) -> Result<(u64, i32), &'static str> {
     const HAMMING63_DECODER_TABLE: [i8; 64] = [
         0, 0, 0, 1, 0, 1, 1, 1, 0, 2, 4, -1, -1, 5, 3, 1, 0, 2, -1, 6, 7, -1, 3, 1, 2, 2, 3, 2, 3,

--- a/crates/core/src/ar/image_proc.rs
+++ b/crates/core/src/ar/image_proc.rs
@@ -318,6 +318,7 @@ impl ARImageProcInfo {
     }
 }
 
+/// Scalar horizontal box-blur pass over a grayscale image.
 pub fn box_filter_h_scalar(
     data: &[u8],
     image_temp_u16: &mut [u16],
@@ -340,6 +341,7 @@ pub fn box_filter_h_scalar(
     }
 }
 
+/// Scalar vertical box-blur pass over a grayscale image.
 pub fn box_filter_v_scalar(
     image_temp_u16: &[u16],
     image2: &mut [u8],
@@ -403,6 +405,7 @@ pub fn rgba_to_gray(rgba: &[u8]) -> Vec<u8> {
     rgba_to_gray_scalar(rgba)
 }
 
+/// Scalar RGBA → grayscale (luminance) conversion.
 pub fn rgba_to_gray_scalar(rgba: &[u8]) -> Vec<u8> {
     let mut gray = Vec::with_capacity(rgba.len() / 4);
     for chunk in rgba.chunks_exact(4) {

--- a/crates/core/src/ar/labeling.rs
+++ b/crates/core/src/ar/labeling.rs
@@ -41,17 +41,24 @@ use crate::arlog_e;
 use crate::types::{ARLabelInfo, ARdouble};
 use log::trace;
 
+/// Size of the labeling pass scratch work buffer.
 pub const AR_LABELING_WORK_SIZE: usize = 1024 * 32;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
+/// Which luminance polarity to trace during connected-component labeling.
 pub enum LabelingMode {
+    /// Trace dark regions on a lighter background.
     BlackRegion,
+    /// Trace light regions on a darker background.
     WhiteRegion,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
+/// Whether to process the full frame or a half-resolution field.
 pub enum ImageProcMode {
+    /// Process the full-resolution frame.
     FrameImage,
+    /// Process a single interlaced half-resolution field.
     FieldImage, // Handles interlaced half-resolution fields
 }
 

--- a/crates/core/src/ar/marker.rs
+++ b/crates/core/src/ar/marker.rs
@@ -40,16 +40,25 @@
 use crate::types::{ARLabelInfo, ARMarkerInfo2, ARPixelFormat, ARdouble};
 use crate::{arlog_d, arlog_e};
 
+/// Maximum area in pixels for a candidate marker region.
 pub const AR_AREA_MAX: i32 = 100000;
+/// Minimum area in pixels for a candidate marker region.
 pub const AR_AREA_MIN: i32 = 70;
+/// Maximum line-fitting error for accepting a region as a square.
 pub const AR_SQUARE_FIT_THRESH: f64 = 0.05;
+/// Maximum contour chain length traced per region.
 pub const AR_CHAIN_MAX: usize = 10000;
+/// Maximum number of square candidates per frame.
 pub const AR_SQUARE_MAX: usize = 30;
+/// Default confidence threshold for accepting a pattern match.
 pub const AR_CONFIDENCE_CUTOFF_DEFAULT: f64 = 0.5;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
+/// Whether to process the full frame or a half-resolution field.
 pub enum ImageProcMode {
+    /// Process the full-resolution frame.
     FrameImage = 0,
+    /// Process a single interlaced half-resolution field.
     FieldImage = 1,
 }
 

--- a/crates/core/src/ar/math.rs
+++ b/crates/core/src/ar/math.rs
@@ -45,8 +45,11 @@ use std::ops::Mul;
 #[repr(C)]
 #[derive(Default)]
 pub struct ARMat {
+    /// Row-major matrix elements.
     pub m: Vec<ARdouble>,
+    /// Number of rows.
     pub row: i32,
+    /// Number of columns.
     pub clm: i32,
 }
 
@@ -298,6 +301,7 @@ pub fn household(x: &mut [ARdouble]) -> ARdouble {
     -s
 }
 
+/// QR decomposition of `a` in place, accumulating the diagonal into `dv`.
 pub fn qrm(a: &mut ARMat, dv: &mut [ARdouble]) -> Result<(), &'static str> {
     let dim = a.row as usize;
     if dim != a.clm as usize || dim < 2 || dv.len() != dim {
@@ -397,6 +401,7 @@ pub fn qrm(a: &mut ARMat, dv: &mut [ARdouble]) -> Result<(), &'static str> {
 
 impl ARMat {
     #[allow(clippy::needless_range_loop)]
+    /// Compute the per-column mean vector of the matrix.
     pub fn ex(&self, mean: &mut [ARdouble]) -> Result<(), &'static str> {
         let row = self.row as usize;
         let clm = self.clm as usize;
@@ -421,6 +426,7 @@ impl ARMat {
     }
 
     #[allow(clippy::needless_range_loop)]
+    /// Subtract `mean` from every row, centering the data in place.
     pub fn center(&mut self, mean: &[ARdouble]) -> Result<(), &'static str> {
         let row = self.row as usize;
         let clm = self.clm as usize;
@@ -436,6 +442,7 @@ impl ARMat {
         Ok(())
     }
 
+    /// Compute `X · Xᵀ` into `output`.
     pub fn x_by_xt(&self, output: &mut ARMat) -> Result<(), &'static str> {
         let row = self.row as usize;
         let clm = self.clm as usize;
@@ -459,6 +466,7 @@ impl ARMat {
         Ok(())
     }
 
+    /// Compute `Xᵀ · X` into `output`.
     pub fn xt_by_x(&self, output: &mut ARMat) -> Result<(), &'static str> {
         let row = self.row as usize;
         let clm = self.clm as usize;
@@ -482,6 +490,7 @@ impl ARMat {
         Ok(())
     }
 
+    /// Compute the eigenvalues and eigenvectors of the (symmetric) matrix.
     pub fn ev_create(
         &self,
         u: &ARMat,
@@ -527,6 +536,7 @@ impl ARMat {
         Ok(())
     }
 
+    /// Internal principal-component-analysis worker shared by the PCA entry points.
     pub fn pca_internal(
         &self,
         output: &mut ARMat,
@@ -577,6 +587,7 @@ impl ARMat {
         Ok(())
     }
 
+    /// Compute the principal components of the data matrix.
     pub fn pca(
         &self,
         evec: &mut ARMat,
@@ -653,8 +664,11 @@ impl<'b> Mul<&'b ARMat> for &ARMat {
 #[repr(C)]
 #[derive(Default)]
 pub struct ARMatf {
+    /// Row-major matrix elements (single precision).
     pub m: Vec<f32>,
+    /// Number of rows.
     pub row: i32,
+    /// Number of columns.
     pub clm: i32,
 }
 
@@ -706,7 +720,9 @@ impl<'b> Mul<&'b ARMatf> for &ARMatf {
 #[repr(C)]
 #[derive(Default)]
 pub struct ARVec {
+    /// Vector elements.
     pub v: Vec<ARdouble>,
+    /// Number of columns.
     pub clm: i32,
 }
 

--- a/crates/core/src/ar/matrix.rs
+++ b/crates/core/src/ar/matrix.rs
@@ -45,9 +45,13 @@ pub(crate) const AR_GLOBAL_ID_INNER_SIZE: usize = 3;
 /// Results of a matrix code decoding attempt.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MatrixCodeResult {
+    /// Decoded marker ID.
     pub id: i32,
+    /// Orientation (0–3) at which the code matched.
     pub dir: i32,
+    /// Confidence factor of the match (0.0–1.0).
     pub cf: f64,
+    /// Number of bit errors corrected during decoding.
     pub error_corrected: i32,
 }
 

--- a/crates/core/src/ar/pattern.rs
+++ b/crates/core/src/ar/pattern.rs
@@ -43,7 +43,9 @@ use std::fs::File;
 use std::io::{BufWriter, Error, ErrorKind, Result as IoResult, Write};
 use std::path::Path;
 
+/// Maximum number of patterns a handle can hold.
 pub const AR_PATT_NUM_MAX: i32 = 50;
+/// Default pattern edge size in samples.
 pub const AR_PATT_SIZE1: i32 = 16;
 
 // Standard sample factor used in ARToolKit for pattern extraction
@@ -53,8 +55,11 @@ const AR_PATT_SAMPLE_FACTOR1: usize = 4;
 // Ensure these match your actual definitions in WebARKitLib-rs.
 const AR_IMAGE_PROC_FRAME_IMAGE: i32 = 0;
 const AR_IMAGE_PROC_FIELD_IMAGE: i32 = 1;
+/// Template matching mode: colour.
 pub const AR_TEMPLATE_MATCHING_COLOR: i32 = 0;
+/// Template matching mode: mono (luminance).
 pub const AR_TEMPLATE_MATCHING_MONO: i32 = 1;
+/// Minimum contrast required to accept an extracted pattern.
 pub const AR_PATT_CONTRAST_THRESH1: ARdouble = 5.0;
 
 impl ARPattHandle {
@@ -507,6 +512,7 @@ pub fn pattern_match(
 }
 
 #[allow(clippy::needless_range_loop)]
+/// Compute the 3×3 homography mapping the unit square to the marker's screen quad.
 pub fn get_cpara(
     world: &[[ARdouble; 2]; 4],
     vertex: &[[ARdouble; 2]; 4],
@@ -1046,6 +1052,7 @@ pub fn ar_patt_get_image2(
     Ok(())
 }
 
+/// Identify a square marker by matching its extracted pattern against loaded templates.
 pub fn ar_patt_get_id(
     patt_handle: &ARPattHandle,
     patt_detect_mode: i32,
@@ -1077,6 +1084,7 @@ fn dot_product(a: &[i16], b: &[i16]) -> i64 {
     dot_product_scalar(a, b)
 }
 
+/// Scalar dot product of two `i16` slices.
 pub fn dot_product_scalar(a: &[i16], b: &[i16]) -> i64 {
     let mut sum = 0i64;
     for i in 0..a.len() {

--- a/crates/core/src/ar/pose.rs
+++ b/crates/core/src/ar/pose.rs
@@ -41,6 +41,7 @@ use crate::icp::{
 use crate::types::{AR3DHandle, ARMarkerInfo, ARParam, ARdouble};
 // use log::debug; // Removed unused import
 
+/// Allocate an `AR3DHandle` for pose estimation from the given camera parameters.
 pub fn ar_3d_create_handle(ar_param: &ARParam) -> Result<*mut AR3DHandle, &'static str> {
     let icp_handle = icp_create_handle(&ar_param.mat)?;
     let mut handle = Box::new(AR3DHandle::default());
@@ -48,6 +49,7 @@ pub fn ar_3d_create_handle(ar_param: &ARParam) -> Result<*mut AR3DHandle, &'stat
     Ok(Box::into_raw(handle))
 }
 
+/// Free an `AR3DHandle` and null the pointer.
 pub fn ar_3d_delete_handle(handle: &mut *mut AR3DHandle) -> Result<(), &'static str> {
     if handle.is_null() {
         return Err("Null AR3DHandle");
@@ -61,6 +63,7 @@ pub fn ar_3d_delete_handle(handle: &mut *mut AR3DHandle) -> Result<(), &'static 
     Ok(())
 }
 
+/// Estimate the 3×4 pose of a square marker of the given side length.
 pub fn ar_get_trans_mat_square(
     handle: &AR3DHandle,
     marker_info: &ARMarkerInfo,
@@ -129,6 +132,7 @@ pub fn ar_get_trans_mat_square(
     }
 }
 
+/// Estimate a square marker's pose using the previous frame's pose as a seed.
 pub fn ar_get_trans_mat_square_cont(
     handle: &AR3DHandle,
     marker_info: &ARMarkerInfo,
@@ -186,6 +190,7 @@ pub fn ar_get_trans_mat_square_cont(
     }
 }
 
+/// Estimate a 3×4 pose from 2D–3D correspondences via iterative refinement.
 pub fn ar_get_trans_mat(
     handle: &AR3DHandle,
     init_conv: &[[ARdouble; 4]; 3],

--- a/crates/core/src/arlog.rs
+++ b/crates/core/src/arlog.rs
@@ -126,9 +126,13 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(i32)]
 pub enum ArLogLevel {
+    /// Debug level — per-frame rejections and trace detail.
     Debug = 0,
+    /// Info level — one-shot informational events.
     Info = 1,
+    /// Warn level — recoverable anomalies.
     Warn = 2,
+    /// Error level — misconfiguration / wiring errors.
     Error = 3,
     /// Release-info: unconditional informational output with no `[level]` prefix.
     /// Routed through target `"arlog::rel"`.
@@ -178,21 +182,25 @@ pub fn ar_log_level() -> ArLogLevel {
 pub const AR_LOG_REL_TARGET: &str = "arlog::rel";
 
 #[macro_export]
+/// Log a debug-level message (per-frame trace detail).
 macro_rules! arlog_d {
     ($($arg:tt)*) => { ::log::debug!($($arg)*); };
 }
 
 #[macro_export]
+/// Log an info-level message (one-shot events).
 macro_rules! arlog_i {
     ($($arg:tt)*) => { ::log::info!($($arg)*); };
 }
 
 #[macro_export]
+/// Log a warning-level message (recoverable anomalies).
 macro_rules! arlog_w {
     ($($arg:tt)*) => { ::log::warn!($($arg)*); };
 }
 
 #[macro_export]
+/// Log an error-level message (misconfiguration / wiring errors).
 macro_rules! arlog_e {
     ($($arg:tt)*) => { ::log::error!($($arg)*); };
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -109,6 +109,12 @@
 //! use webarkitlib_rs::marker::ar_detect_marker as ar_detect_marker_compat;
 //! ```
 
+// Every `pub` item in the crate is documented (#226). CI's
+// `clippy -D warnings` escalates this lint, so a new undocumented public
+// item fails the build. Bindgen-generated FFI bindings opt out locally with
+// their own `#![allow(missing_docs)]` (see `kpm::kpm_ffi`).
+#![warn(missing_docs)]
+
 pub mod ar;
 pub mod ar2;
 pub mod arlog;

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -37,17 +37,29 @@
 //! Core Data Structures for WebARKitLib
 //! Translated from ARToolKit C headers (ar.h, param.h, etc.)
 
+/// Floating-point type used throughout the AR pipeline.
+///
+/// C equivalent: `ARdouble` (this port always uses 64-bit precision).
 pub type ARdouble = f64;
 
+/// Maximum number of camera lens-distortion factors.
 pub const AR_DIST_FACTOR_NUM_MAX: usize = 9;
+/// Maximum number of contour chain points traced during labeling.
 pub const AR_CHAIN_MAX: usize = 40000;
+/// Maximum number of candidate squares detected per frame.
 pub const AR_SQUARE_MAX: usize = 30;
+/// Size of the scratch work buffer used by the labeling pass.
 pub const AR_LABELING_WORK_SIZE: usize = 1024 * 32;
 
+/// Pattern detection mode: colour template matching.
 pub const AR_TEMPLATE_MATCHING_COLOR: i32 = 0;
+/// Pattern detection mode: mono (luminance) template matching.
 pub const AR_TEMPLATE_MATCHING_MONO: i32 = 1;
+/// Pattern detection mode: matrix (barcode) code detection.
 pub const AR_MATRIX_CODE_DETECTION: i32 = 2;
+/// Pattern detection mode: colour template matching **and** matrix codes.
 pub const AR_TEMPLATE_MATCHING_COLOR_AND_MATRIX_CODE_DETECTION: i32 = 3;
+/// Pattern detection mode: mono template matching **and** matrix codes.
 pub const AR_TEMPLATE_MATCHING_MONO_AND_MATRIX_CODE_DETECTION: i32 = 4;
 
 /// C equivalent: AR_NOUSE_TRACKING_HISTORY
@@ -64,7 +76,9 @@ pub const AR_USE_TRACKING_HISTORY_V2: i32 = 2;
 #[derive(Debug, Clone, PartialEq, Default)]
 #[repr(C)]
 pub struct AR2VideoTimestampT {
+    /// Whole seconds since the (arbitrary) epoch.
     pub sec: u64,
+    /// Microseconds within the current second.
     pub usec: u32,
 }
 
@@ -142,16 +156,26 @@ impl Default for ARMarkerInfo2 {
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ARMarkerInfoCutoffPhase {
+    /// Not cut off — the region was accepted as a valid marker.
     #[default]
     None = 0,
+    /// Rejected while extracting the pattern image from the region.
     PatternExtraction,
+    /// Rejected by a generic matching failure.
     MatchGeneric,
+    /// Rejected for insufficient contrast in the extracted pattern.
     MatchContrast,
+    /// Matrix-code mode: no barcode was found in the region.
     MatchBarcodeNotFound,
+    /// Matrix-code mode: the barcode failed its error-detection check.
     MatchBarcodeEdcFail,
+    /// Rejected because the match confidence was below the cutoff.
     MatchConfidence,
+    /// Rejected because pose estimation failed.
     PoseError,
+    /// Rejected because multi-marker pose estimation failed.
     PoseErrorMulti,
+    /// Rejected by the heuristic that filters troublesome matrix codes.
     HeuristicTroublesomeMatrixCodes,
 }
 
@@ -271,18 +295,26 @@ impl Default for ARMarkerInfo {
     }
 }
 
-// Opaque/dummy types for ARHandle dependencies
+/// Camera lens-distortion lookup tables, mapping between ideal (undistorted)
+/// and observed (distorted) image coordinates.
 #[derive(Debug, Clone, Default)]
 pub struct ARParamLTf {
+    /// Ideal → observed lookup table (interleaved `x, y` pairs).
     pub i2o: Vec<f32>,
+    /// Observed → ideal lookup table (interleaved `x, y` pairs).
     pub o2i: Vec<f32>,
+    /// Table width in pixels.
     pub xsize: i32,
+    /// Table height in pixels.
     pub ysize: i32,
+    /// Horizontal offset applied when indexing the tables.
     pub x_off: i32,
+    /// Vertical offset applied when indexing the tables.
     pub y_off: i32,
 }
 
 impl ARParamLTf {
+    /// Build identity lookup tables of the given size (no distortion applied).
     pub fn new_basic(xsize: i32, ysize: i32) -> Self {
         let i2o = vec![0.0f32; (xsize * ysize * 2) as usize];
         let mut o2i = vec![0.0f32; (xsize * ysize * 2) as usize];
@@ -325,40 +357,60 @@ impl ARParamLTf {
     }
 }
 
+/// Camera parameters bundled with their precomputed distortion lookup tables.
 #[derive(Debug, Clone, Default)]
 pub struct ARParamLT {
+    /// The camera intrinsics and distortion factors.
     pub param: ARParam,
+    /// Precomputed ideal↔observed lookup tables for [`param`](Self::param).
     pub param_ltf: ARParamLTf,
 }
 
 impl ARParamLT {
+    /// Bundle camera parameters with an existing lookup table.
     pub fn new(param: ARParam, param_ltf: ARParamLTf) -> Self {
         Self { param, param_ltf }
     }
 
+    /// Bundle camera parameters with identity lookup tables sized to the
+    /// parameters' image dimensions.
     pub fn new_basic(param: ARParam) -> Self {
         let param_ltf = ARParamLTf::new_basic(param.xsize, param.ysize);
         Self { param, param_ltf }
     }
 }
 
+/// A marker carried across frames by the tracking-history heuristic, with the
+/// number of consecutive frames it has been seen.
 #[repr(C)]
 #[derive(Debug, Clone, Default)]
 pub struct ARTrackingHistory {
+    /// The remembered marker.
     pub marker: ARMarkerInfo,
+    /// Consecutive-frame count for this marker.
     pub count: i32,
 }
 
+/// Integer type used for connected-component labels.
 pub type ARLabelingLabelType = i16;
 
+/// Output of the connected-component labeling pass: the label image plus
+/// per-label statistics.
 #[derive(Debug, Clone)]
 pub struct ARLabelInfo {
+    /// Per-pixel label image (0 = background).
     pub label_image: Vec<ARLabelingLabelType>,
+    /// Number of labels found.
     pub label_num: i32,
+    /// Pixel area of each label.
     pub area: Vec<i32>,
+    /// Clipping box of each label as `[x_min, x_max, y_min, y_max]`.
     pub clip: Vec<[i32; 4]>,
+    /// Centroid position of each label.
     pub pos: Vec<[ARdouble; 2]>,
+    /// Scratch buffer used during labeling.
     pub work: Vec<i32>,
+    /// Secondary scratch buffer used during labeling.
     pub work2: Vec<i32>,
 }
 
@@ -376,58 +428,99 @@ impl Default for ARLabelInfo {
     }
 }
 
+/// Storage for loaded template patterns and their precomputed norms.
+///
+/// Each pattern is stored in four orientations, in both colour and
+/// mono (black-and-white) form.
 #[derive(Debug, Clone, Default)]
 pub struct ARPattHandle {
+    /// Number of patterns currently loaded.
     pub patt_num: i32,
+    /// Maximum number of patterns this handle can hold.
     pub patt_num_max: i32,
+    /// Per-slot occupancy flags (`0` = free, non-zero = loaded).
     pub pattf: Vec<i32>,
+    /// Zero-mean colour pattern data, four orientations per pattern.
     pub patt: Vec<Vec<i16>>,
+    /// Vector norm of each colour pattern, for correlation normalization.
     pub pattpow: Vec<ARdouble>,
+    /// Zero-mean mono pattern data, four orientations per pattern.
     pub patt_bw: Vec<Vec<i16>>,
+    /// Vector norm of each mono pattern.
     pub pattpow_bw: Vec<ARdouble>,
+    /// Pattern edge length in samples (typically 16).
     pub patt_size: i32,
+    /// Per-slot active flags — only active patterns are matched.
     pub active: Vec<bool>,
 }
 
+/// Opaque image-processing state (placeholder for the C `ARImageProcInfo`).
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct ARImageProcInfo {
     _dummy: u8,
 }
 
+/// Pixel layout of an input video frame.
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ARPixelFormat {
+    /// Unset / unrecognised format.
     #[default]
     Invalid = -1,
+    /// 24-bit red, green, blue.
     RGB = 0,
+    /// 24-bit blue, green, red.
     BGR,
+    /// 32-bit red, green, blue, alpha.
     RGBA,
+    /// 32-bit blue, green, red, alpha.
     BGRA,
+    /// 32-bit alpha, blue, green, red.
     ABGR,
+    /// 8-bit luminance only.
     MONO,
+    /// 32-bit alpha, red, green, blue.
     ARGB,
+    /// Packed YUV 4:2:2 (`2vuy` / UYVY).
     TwoVuy,
+    /// Packed YUV 4:2:2 (`yuvs` / YUY2).
     Yuvs,
+    /// 16-bit 5:6:5 RGB.
     Rgb565,
+    /// 16-bit 5:5:5:1 RGBA.
     Rgba5551,
+    /// 16-bit 4:4:4:4 RGBA.
     Rgba4444,
+    /// Planar YUV 4:2:0 (video range).
     FourTwoZeroV,
+    /// Planar YUV 4:2:0 (full range).
     FourTwoZeroF,
+    /// Android NV21 (YUV 4:2:0 semi-planar).
     NV21,
 }
 
+/// Strategy used to pick the binarization threshold during labeling.
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ARLabelingThreshMode {
+    /// Use the threshold supplied by the caller.
     #[default]
     Manual = 0,
+    /// Derive the threshold from the image median.
     AutoMedian,
+    /// Derive the threshold via Otsu's method.
     AutoOtsu,
+    /// Adaptive local thresholding.
     AutoAdaptive,
+    /// Sweep a bracket of thresholds until markers are found.
     AutoBracketing,
 }
 
+/// Matrix (barcode) code family used for marker-ID decoding.
+///
+/// The low byte encodes the grid size; the high bits select the
+/// error-detection/correction scheme.
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ARMatrixCodeType {
@@ -461,36 +554,64 @@ pub enum ARMatrixCodeType {
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub struct ARHandle {
+    /// Debug flag; when non-zero the debug label image is produced.
     pub ar_debug: i32,
+    /// Pixel format of incoming frames.
     pub ar_pixel_format: ARPixelFormat,
+    /// Bytes per pixel implied by [`ar_pixel_format`](Self::ar_pixel_format).
     pub ar_pixel_size: i32,
+    /// Labeling mode (which luminance polarity to trace).
     pub ar_labeling_mode: i32,
+    /// Current binarization threshold (0–255).
     pub ar_labeling_thresh: i32,
+    /// Image-processing mode (full frame vs field/half resolution).
     pub ar_image_proc_mode: i32,
+    /// Pattern detection mode (template, matrix code, or both).
     pub ar_pattern_detection_mode: i32,
+    /// Marker extraction mode.
     pub ar_marker_extraction_mode: i32,
+    /// Camera parameters + distortion lookup tables.
     pub ar_param_lt: *mut ARParamLT,
+    /// Frame width in pixels.
     pub xsize: i32,
+    /// Frame height in pixels.
     pub ysize: i32,
+    /// Number of valid entries in [`marker_info`](Self::marker_info).
     pub marker_num: i32,
+    /// Markers detected in the current frame.
     pub marker_info: Box<[ARMarkerInfo; AR_SQUARE_MAX]>,
+    /// Number of valid entries in [`marker_info2`](Self::marker_info2).
     pub marker2_num: i32,
+    /// Intermediate (pre-filtering) square candidates.
     pub marker_info2: Box<[ARMarkerInfo2; AR_SQUARE_MAX]>,
+    /// Number of valid entries in [`history`](Self::history).
     pub history_num: i32,
+    /// Tracking history used to resurrect briefly-lost markers.
     pub history: Box<[ARTrackingHistory; AR_SQUARE_MAX]>,
+    /// Connected-component labeling results for the current frame.
     pub label_info: ARLabelInfo,
+    /// Loaded template patterns used for matching.
     pub patt_handle: *mut ARPattHandle,
+    /// Strategy used to choose the binarization threshold.
     pub ar_labeling_thresh_mode: ARLabelingThreshMode,
+    /// Frame interval between automatic threshold recalculations.
     pub ar_labeling_thresh_auto_interval: i32,
+    /// Frames remaining until the next automatic recalculation.
     pub ar_labeling_thresh_auto_interval_ttl: i32,
+    /// Bracketing mode: current over-exposed threshold bound.
     pub ar_labeling_thresh_auto_bracket_over: i32,
+    /// Bracketing mode: current under-exposed threshold bound.
     pub ar_labeling_thresh_auto_bracket_under: i32,
+    /// Image-processing scratch state.
     pub ar_image_proc_info: *mut ARImageProcInfo,
+    /// Fraction of the marker square occupied by the pattern (0.5–0.9).
     pub patt_ratio: ARdouble,
+    /// Matrix-code family used when matrix-code detection is enabled.
     pub matrix_code_type: ARMatrixCodeType,
 }
 
 impl ARHandle {
+    /// Create a tracker handle sized to the given camera parameters.
     pub fn new(param: ARParam) -> Self {
         // In the full port, arParamLT would be initialized here too.
         ARHandle {
@@ -500,6 +621,7 @@ impl ARHandle {
         }
     }
 
+    /// Set the input pixel format and update the derived pixel size.
     pub fn set_pixel_format(&mut self, format: ARPixelFormat) {
         self.ar_pixel_format = format;
         // Update pixel size based on format if needed
@@ -514,14 +636,17 @@ impl ARHandle {
         };
     }
 
+    /// Select the matrix-code family used for barcode decoding.
     pub fn set_matrix_code_type(&mut self, code_type: ARMatrixCodeType) {
         self.matrix_code_type = code_type;
     }
 
+    /// Select the pattern detection mode (template, matrix code, or both).
     pub fn set_pattern_detection_mode(&mut self, mode: i32) {
         self.ar_pattern_detection_mode = mode;
     }
 
+    /// Return the currently selected matrix-code family.
     pub fn get_matrix_code_type(&self) -> ARMatrixCodeType {
         self.matrix_code_type
     }
@@ -576,6 +701,7 @@ pub use crate::icp::{ICPHandleT, ICPStereoHandleT};
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub struct AR3DHandle {
+    /// ICP solver state used for monocular pose estimation.
     pub icp_handle: *mut ICPHandleT,
 }
 
@@ -591,6 +717,7 @@ impl Default for AR3DHandle {
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub struct AR3DStereoHandle {
+    /// ICP solver state used for stereo pose estimation.
     pub icp_stereo_handle: *mut ICPStereoHandleT,
 }
 


### PR DESCRIPTION
**Slice 3b — the finisher for #226.** Documents the last of the undocumented public surface and turns on the crate-wide `#![warn(missing_docs)]` gate.

## What's documented
- **`types.rs`** (116) — the ARToolKit core types: `ARHandle`, `ARParamLT`/`ARParamLTf`, `ARLabelInfo`, `ARPattHandle`, the `ARPixelFormat` / `ARMatrixCodeType` / labeling enums, timestamps, the mode/threshold constants, and the `ARMarkerInfoCutoffPhase` variants.
- **`ar/*`** — `math` (`ARMat`/`ARMatf`/`ARVec` + PCA/QR/eigen helpers), and the `marker`/`pattern`/`matrix`/`pose`/`labeling`/`image_proc`/`bch` constants, enums, and functions.
- **`arlog.rs`** — the log-level variants + the `arlog_{d,i,w,e}` macros.

## The gate
Adds `#![warn(missing_docs)]` at the crate root. The crate now reports **zero** missing docs on **both** default features **and** `--all-features`; CI's `clippy -D warnings` escalates the lint, so **any new undocumented `pub` item fails the build** from here on. The bindgen-generated FFI bindings keep their local `#![allow(missing_docs)]` (`kpm::kpm_ffi`, from #231).

## Verification
- `cargo rustdoc -W missing_docs`: **0** (default) and **0** (`--all-features`)
- `cargo clippy --workspace --all-targets --all-features -D warnings`: clean *(run locally with `LIBCLANG_PATH` set to an x64 libclang — the exact CI command)*
- `cargo fmt --check` clean; `cargo test --lib`: 432 passed

Documentation only — no code or signatures changed.

## #226 status
With #231 (KPM rustdoc), #232 (JS/TS guide), #233 (AR2/ICP), and this PR, the **API-reference + integration-guide scope of #226 is complete** → #226 can be closed on merge.

Out of scope (tracked separately if desired): the ~43 pre-existing broken *intra-doc links* (e.g. `arlog_rel`, `_verbose` helpers) — those are `cargo doc` warnings, not part of the `clippy` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)