### PR TITLE
chore(release): v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,38 @@
-# Changelog - webarkit/webarkitlib-rs
+﻿# Changelog - webarkit/webarkitlib-rs
 
 All notable changes to this project will be documented in this file.
+
+## [0.8.1] - 2026-08-06
+
+## Stabilization & DX — benchmarks, coverage, and full API documentation
+
+### ⚡ Performance
+
+- *(kpm)* Add dedicated kpm_bench.rs Criterion benchmark (#225)
+
+### 🐛 Bug Fixes
+
+- *(ci)* Commit Cargo.lock for reproducible coverage/CI (#224)
+- *(kpm)* Exempt bindgen-generated bindings from the missing_docs gate (#226)
+
+### 📚 Documentation
+
+- *(maintainers)* Document committed Cargo.lock + deliberate dep updates
+- *(benches)* Document kpm_bench + drop stale "no KPM benchmark" claim (#225)
+- *(kpm)* Correct stale backend docs + document KPM public API (#226)
+- *(contributing)* Document the libclang/bindgen ffi-backend build failure (#226)
+- *(wasm)* Add JS/TS integration guide + link from README (#226)
+- *(ar2,icp)* Document the AR2 tracking + ICP public API (#226)
+- *(core)* Document remaining public API + enable crate-wide missing_docs (#226)
+- *(kpm)* Rationale comments for kpm/freak too_many_arguments allows (#83)
+
+### 🚜 Refactor
+
+- *(ar,ar2)* Group params in private helpers + document allows (#83)
+
+### 🧪 Testing
+
+- *(core)* Cover error/validation branches in ar/pattern.rs + kpm/freak/pyramid.rs (#224)
 
 ## [0.8.0] - 2026-06-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "webarkitlib-rs"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bindgen",
  "byteorder",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "webarkitlib-wasm"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 authors = ["kalwalt <github@kalwaltart.it>"]
 edition = "2021"
 description = "A high-performance, memory-safe Rust port of WebARKitLib (ARToolKit) for native and WASM."

--- a/crates/wasm/pkg/README.md
+++ b/crates/wasm/pkg/README.md
@@ -209,7 +209,9 @@ For integration into your own project, install the pre-built package from npm �
 npm install @webarkit/webarkitlib-wasm
 ```
 
-See [@webarkit/webarkitlib-wasm](https://www.npmjs.com/package/@webarkit/webarkitlib-wasm) for API documentation and usage examples.
+📖 **[WebAssembly (JS/TS) integration guide](https://github.com/webarkit/WebARKitLib-rs/blob/main/docs/wasm-js-integration.md)** — a full walkthrough: loading and initializing the module, the standard vs SIMD engines, the three handles (`WasmARHandle` / `WasmKpmHandle` / `WasmNFTHandle`), the NFT detect-then-track loop, the pose-matrix layout, TypeScript usage, and memory management.
+
+See also [@webarkit/webarkitlib-wasm](https://www.npmjs.com/package/@webarkit/webarkitlib-wasm) on npm.
 
 #### Running the bundled demos
 

--- a/crates/wasm/pkg/package.json
+++ b/crates/wasm/pkg/package.json
@@ -5,7 +5,7 @@
                           "kalwalt \u003cgithub@kalwaltart.it\u003e"
                       ],
     "description":  "A high-performance, memory-safe Rust port of WebARKitLib (ARToolKit) for native and WASM.",
-    "version":  "0.8.0",
+    "version":  "0.8.1",
     "license":  "LGPL-3.0-or-later",
     "repository":  {
                        "type":  "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webarkitlib-rs",
-  "version": "0.8.0",
+  "version": "0.8.1",
    "description": "Port of WebARKitLib (ARToolKit) to Rust and WASM",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Release prep for **v0.8.1** — a patch release bundling the post-v0.8.0 Stabilization & DX work.

## Changes
- Bump workspace `Cargo.toml` + `package.json` `0.8.0 → 0.8.1` (+ `Cargo.lock`)
- Regenerate the wasm pkg via `npm run build` (`crates/wasm/pkg/*`)
- Prepend the `[0.8.1]` `CHANGELOG.md` section via git-cliff

## What's in 0.8.1 (since 0.8.0)
- **perf(kpm):** dedicated `kpm_bench.rs` Criterion benchmark (#225)
- **ci/fix:** committed `Cargo.lock` for reproducible coverage/CI; bindgen `missing_docs` exemption (#224, #226)
- **docs:** full public-API rustdoc + crate-wide `#![warn(missing_docs)]` gate, JS/TS WASM integration guide, AR2/ICP/core docs, MAINTAINERS + CONTRIBUTING notes (#226)
- **test:** error/validation-branch coverage (#224)
- **refactor:** `too_many_arguments` cleanup — param structs + rationale (#83)

No new features, no breaking changes — hence the patch bump.

## Remaining release steps (manual, after merge)
1. Merge this → `dev`
2. `git fetch origin main` → `git tag -a v0.8.1 origin/main` won't apply until dev→main; instead: open a `dev → main` PR (like #223) and merge it, then:
   `git fetch origin main && git tag -a v0.8.1 origin/main -m "Release version 0.8.1" && git push origin v0.8.1`
   → triggers `release.yml` (GitHub Release + crates.io + npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)